### PR TITLE
listener feeds

### DIFF
--- a/app/models/user/statistics.rb
+++ b/app/models/user/statistics.rb
@@ -113,7 +113,7 @@ class User
       :group      =>  'track_owner_id',
       :order      =>  'count_track_owner DESC', 
       :limit      =>  limit, 
-      :conditions => ['track_owner_id != ?', self.id]
+      :conditions => ['track_owner_id != ? AND DATE(`listens`.created_at) > DATE_SUB( CURDATE(), interval 4 month)', self.id]
     ).collect(&:first)
   end  
 


### PR DESCRIPTION
I wasn't able to validate the feeds locally although Safari accepted them (the key question is whether iTunes will).

This introduces a "listener feed" for each user which is a feed of the 15 newest tracks from artists they follow.

It's available as /users/:u/listenfeed.rss
