### PR TITLE
Add support for Cloudfront

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ config/defensio.yml
 config/newrelic.yml
 config/memcached.yml
 config/deploy/*
+config/certs/*
 *.sql
 public/mp3
 public/pics

--- a/Gemfile
+++ b/Gemfile
@@ -57,7 +57,9 @@ gem 'yui-compressor'
 gem 'uglifier'
 gem "coffee-rails"
 gem "soundmanager2-rails"
-gem 'turbolinks', '~> 5.0.0'
+gem 'turbolinks'
+gem 'cloudfront-signer'
+
 
 gem 'newrelic_rpm'
 gem 'scout_apm'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -102,6 +102,7 @@ GEM
     builder (3.2.3)
     chunky_png (1.3.8)
     climate_control (0.1.0)
+    cloudfront-signer (3.0.1)
     cocaine (0.5.8)
       climate_control (>= 0.0.3, < 1.0)
     coderay (1.1.1)
@@ -377,6 +378,7 @@ DEPENDENCIES
   awesome_print
   aws-sdk
   bugsnag
+  cloudfront-signer
   coffee-rails
   compass-rails
   country_select
@@ -431,7 +433,7 @@ DEPENDENCIES
   sqlite3
   thin
   timecop!
-  turbolinks (~> 5.0.0)
+  turbolinks
   uglifier
   will_paginate
   yui-compressor

--- a/app/concerns/listens.rb
+++ b/app/concerns/listens.rb
@@ -15,12 +15,18 @@ module Listens
   end
 
   private
+  
+  def cloudfront_url(url,expires_in=20.minutes)
+    Aws::CF::Signer.sign_url url, :expires => Time.now + expires_in
+  end
 
   def listen(asset, register: true)
     unless prevent_abuse(asset)
       register_listen(asset) if register
       if Alonetone.try(:play_dummy_mp3s)
         play_local_mp3
+      elsif Alonetone.try(:cloudfront_enabled)
+        redirect_to cloudfront_url(asset.mp3.url)
       else
         redirect_to asset.mp3.expiring_url
       end

--- a/config/alonetone.example.yml
+++ b/config/alonetone.example.yml
@@ -7,7 +7,9 @@ development: &defaults
   email: support@yourapp.com
   secret: f041541efd6d104c7051041ec61e7aa5
   storage: filesystem
-  bucket: 
+  bucket: # put your s3 bucket/domain here
+  s3_host_alias: # put your cloudfront domain here
+  cloudfront_enabled: false
   amazon_id: 
   amazon_key:
   rakismet_key: "REPLACEME"
@@ -20,14 +22,7 @@ development: &defaults
   ga: 
   get_clicky: 
   typekit: 
-  smtp_settings:
-    address:
-    port: 25 # ports 587 and 2525 are also supported with STARTTLS
-    enable_starttls_auto: true # detects and uses STARTTLS
-    user_name:
-    password:
-    authentication: 'login'
-    domain: yourapp.com
+  postmark_api_key:
 
 test:
   <<: *defaults

--- a/config/initializers/cloudfront_signer.rb
+++ b/config/initializers/cloudfront_signer.rb
@@ -1,0 +1,5 @@
+Aws::CF::Signer.configure do |config|
+  config.key_path = File.join(Rails.root,'config','certs','cloudfront.pem')
+  config.key_pair_id = Alonetone.cloudfront_key_id
+  config.default_expires = 3600
+end if Alonetone.cloudfront_enabled

--- a/config/initializers/paperclip.rb
+++ b/config/initializers/paperclip.rb
@@ -9,9 +9,9 @@ Paperclip::Attachment.default_options.merge!({
   },
   :s3_region => 'us-east-1',
   :bucket => Alonetone.bucket,
-  :s3_host_alias => Alonetone.bucket,
+  :s3_host_alias => Alonetone.s3_host_alias,
   :url => ':s3_alias_url',
-  :s3_protocol => :http,
+  :s3_protocol => Alonetone.cloudfront_enabled ? :https : :http,
   :s3_url_options => {:virtual_host => true},
   :s3_headers => { 'Expires' => 3.years.from_now.httpdate, 
     'Content-disposition' => 'attachment;'}


### PR DESCRIPTION
Moving to cloudfront so that

1. We can move alonetone to be https while retaining `alonetone.com` urls for mp3s.
2. We can take advantage of http2

Key here for Paperclip was setting `bucket` to be the s3 domain and the `s3_host_alias` to be the cloudfront domain.

Alonetone should still be happy as s3 only.

Benchmarks are from Vienna, hitting the homepage.

## Before this PR, browser cache disabled

DOMContentLoaded 2.19 | Load 2.64

```
DOMContentLoaded 2.04 | Load 2.42
DOMContentLoaded 1.84 | Load 3.09
DOMContentLoaded 2.16 | Load 2.51
DOMContentLoaded 2.36 | Load 2.50
DOMContentLoaded 2.57 | Load 2.73
```

![2017-02-27-b5bcr](https://cloud.githubusercontent.com/assets/472/23344838/bb07593a-fc83-11e6-9c16-7a86bab89d22.jpg)

## Before this PR, browser cache enabled

DOMContentLoaded 0.84 |  Load 0.92

```
DOMContentLoaded 0.94 |  Load 1.17
DOMContentLoaded 0.92 |  Load 1.00
DOMContentLoaded 0.80 |  Load 0.90
DOMContentLoaded 0.77 |  Load 0.84
DOMContentLoaded 0.79 |  Load 0.90
```

![2017-02-27-il8cl](https://cloud.githubusercontent.com/assets/472/23344891/bc84aa3c-fc84-11e6-8e52-9d66f6e18d58.jpg)