### PR TITLE
Implement unsubscribe flow

### DIFF
--- a/app/controllers/following_controller.rb
+++ b/app/controllers/following_controller.rb
@@ -24,7 +24,7 @@ class FollowingController < ApplicationController
     end
 
     current_user.add_or_remove_followee(followee.id)
-    flash[:ok] = "You've unfollowed #{followee.name}! 
+    flash[:ok] = "You've unfollowed #{followee.name}!
                    #{view_context.link_to 'Undo', '/follow/' + followee.login}"
     redirect_to root_path
   end

--- a/app/controllers/following_controller.rb
+++ b/app/controllers/following_controller.rb
@@ -1,0 +1,45 @@
+class FollowingController < ApplicationController
+  before_action :require_login, :redirect_if_current_user_equals_params
+
+  def follow
+    followee = User.find_by!(login: params[:login])
+
+    if already_following?(followee.id)
+      flash[:error] = "You're already following #{followee.name}!"
+      return redirect_to root_path
+    end
+
+    current_user.add_or_remove_followee(followee.id)
+    flash[:ok] = "You've followed #{followee.name}!
+                   #{view_context.link_to 'Undo', '/unfollow/' + followee.login}"
+    redirect_to root_path
+  end
+
+  def unfollow
+    followee = User.find_by!(login: params[:login])
+
+    if not_already_following?(followee.id)
+      flash[:error] = "You're not following #{followee.name}!"
+      return redirect_to root_path
+    end
+
+    current_user.add_or_remove_followee(followee.id)
+    flash[:ok] = "You've unfollowed #{followee.name}! 
+                   #{view_context.link_to 'Undo', '/follow/' + followee.login}"
+    redirect_to root_path
+  end
+
+  private
+
+  def redirect_if_current_user_equals_params
+    redirect_to root_path if current_user.login == params[:login].downcase
+  end
+
+  def already_following?(followee_id)
+    current_user.is_following?(followee_id)
+  end
+
+  def not_already_following?(followee_id)
+    !current_user.is_following?(followee_id)
+  end
+end

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -11,7 +11,7 @@ class NotificationsController < ApplicationController
   def unsubscribe
     current_user.settings[:email_new_tracks] = false
     current_user.save!
-    flash[:ok] = "You've been unsubscribed to email notifications.
+    flash[:ok] = "You've been unsubscribed from email notifications.
                    #{view_context.link_to 'Undo', '/notifications/subscribe'}"
     redirect_to root_path
   end

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -1,0 +1,18 @@
+class NotificationsController < ApplicationController
+  before_action :require_login
+
+  def subscribe
+    current_user.settings[:email_new_tracks] = true
+    current_user.save!
+    flash[:ok] = "Email notifications re-enabled."
+    redirect_to root_path
+  end
+
+  def unsubscribe
+    current_user.settings[:email_new_tracks] = false
+    current_user.save!
+    flash[:ok] = "Email notifications disabled.
+                 #{view_context.link_to "Undo", '/notifications/subscribe'}"
+    redirect_to root_path
+  end
+end

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -12,7 +12,7 @@ class NotificationsController < ApplicationController
     current_user.settings[:email_new_tracks] = false
     current_user.save!
     flash[:ok] = "You've been unsubscribed to email notifications.
-                   #{view_context.link_to "Undo", '/notifications/subscribe'}"
+                   #{view_context.link_to 'Undo', '/notifications/subscribe'}"
     redirect_to root_path
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -131,8 +131,9 @@ class UsersController < ApplicationController
 
   def user_params
     params.require(:user).permit(:login, :name, :email, :password, :password_confirmation,
-      :website, :myspace, :bio, :display_name, :itunes, :settings, :city, :country, :twitter,
-      :settings)
+      :website, :myspace, :bio, :display_name, :itunes, :city, :country, :twitter,
+      settings: %i[display_listen_count block_guest_comments most_popular
+        increase_ego email_comments email_new_tracks])
   end
 
   def ip_is_acceptable?

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -99,11 +99,6 @@ class UsersController < ApplicationController
     head :ok
   end
 
-  def toggle_follow
-    current_user.add_or_remove_followee(params[:followee_id])
-    head :ok
-  end
-
   def destroy
     redirect_to(root_path) && (return false) if params[:user_id] || !params[:login] # bug of doom
     if admin_or_owner_with_delete

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -62,10 +62,10 @@ module UsersHelper
     return unless logged_in? && (user.id != current_user.id)
     already_following = current_user.is_following?(user)
     if already_following
-      link_to('<div class="sprites-heart-broken"></div> un-follow'.html_safe, toggle_follow_user_path(current_user, followee_id: user.id),
+      link_to('<div class="sprites-heart-broken"></div> un-follow'.html_safe, toggle_follow_path(login: user.login),
         class: 'follow following')
     else
-      link_to('<div class="sprites-heart-with-plus"></div> follow'.html_safe, toggle_follow_user_path(current_user, followee_id: user.id),
+      link_to('<div class="sprites-heart-with-plus"></div> follow'.html_safe, toggle_follow_path(login: user.login),
         class: 'follow')
     end
   end

--- a/app/mailers/album_notification.rb
+++ b/app/mailers/album_notification.rb
@@ -8,6 +8,8 @@ class AlbumNotification < ActionMailer::Base
     @num_tracks = playlist.tracks_count
     @play_link = play_link_for(playlist)
     @user_link = user_link
+    @stop_following_link = stop_following_link
+    @unsubscribe_link = unsubscribe_link
     @exclamation = %w[Sweet Yes Oooooh Alright Booya Yum Celebrate OMG].sample
     mail subject: "[alonetone] '#{playlist.user.name}' released a new album!", to: email
   end
@@ -20,5 +22,13 @@ class AlbumNotification < ActionMailer::Base
 
   def play_link_for(playlist)
     user_link + '/playlists/' + playlist.to_param
+  end
+
+  def stop_following_link
+    'https://' + Alonetone.url + '/unfollow/' + @user.login
+  end
+
+  def unsubscribe_link
+    'https://' + Alonetone.url + '/notifications/unsubscribe'
   end
 end

--- a/app/mailers/asset_notification.rb
+++ b/app/mailers/asset_notification.rb
@@ -9,6 +9,8 @@ class AssetNotification < ActionMailer::Base
     @title = asset.title.present? ? asset.title : "new track"
     @play_link = play_link_for(asset)
     @user_link = user_link_for(asset)
+    @stop_following_link = stop_following_link
+    @unsubscribe_link = unsubscribe_link
     @exclamation = %w[Sweet Yes Oooooh Alright Booya Yum Celebrate OMG].sample
     mail subject: "[alonetone] '#{asset.user.name}' uploaded a new track!", to: email
   end
@@ -21,5 +23,13 @@ class AssetNotification < ActionMailer::Base
 
   def play_link_for(asset)
     user_link_for(asset) + '/tracks/' + asset.id.to_s
+  end
+
+  def stop_following_link
+    'https://' + Alonetone.url + '/unfollow/' + @user.login
+  end
+
+  def unsubscribe_link
+    'https://' + Alonetone.url + '/notifications/unsubscribe'
   end
 end

--- a/app/mailers/comment_notification.rb
+++ b/app/mailers/comment_notification.rb
@@ -8,6 +8,8 @@ class CommentNotification < ActionMailer::Base
     @song = asset.name
     @number_of_comments = asset.comments_count
     @login = comment.user.login
+    @unsubscribe_link = unsubscribe_link
+    @settings_link = settings_link(@login)
 
     mail to: comment.user.email, subject: "[alonetone] Comment on '#{asset.name}' from #{person_who_made(comment)}"
   end
@@ -16,5 +18,13 @@ class CommentNotification < ActionMailer::Base
 
   def person_who_made(comment)
     comment.commenter ? comment.commenter.name : 'Guest'
+  end
+
+  def unsubscribe_link
+    'https://' + Alonetone.url + '/notifications/unsubscribe'
+  end
+
+  def settings_link(user)
+    'https://' + Alonetone.url + '/' + user + '/edit'
   end
 end

--- a/app/models/user/profile.rb
+++ b/app/models/user/profile.rb
@@ -1,6 +1,6 @@
 class User
   # has a bunch of prefs
-  serialize :settings
+  store :settings
 
   before_save :normalize_itunes_url
 
@@ -74,7 +74,7 @@ class User
 
   def wants_email?
     # anyone who doesn't have it set to false, aka, opt-out
-    settings.nil? || (settings[:email_new_tracks] != "false")
+    settings.empty? || (settings[:email_new_tracks] != "false")
   end
 
   def has_setting?(setting, value = nil)

--- a/app/views/album_notification/album_release.text.erb
+++ b/app/views/album_notification/album_release.text.erb
@@ -8,9 +8,6 @@ Listen to all <%= @num_tracks %> tracks of "<%= @title %>":
 
 ------------------------------
 
-You are getting this email because you decided to follow <%= @name.capitalize %>. You can change your mind by clicking "un-follow" here:
-<%= @user_link %>
+You are getting this email because you decided to follow <%= @name.capitalize %>. You can change your mind by clicking here: <%= @stop_following_link %>
 
-You can also turn off all emails by editing your profile at alonetone.
-
-
+You can also turn off all emails by unsubscribing here: <%= @unsubscribe_link %>.

--- a/app/views/asset_notification/upload_notification.text.erb
+++ b/app/views/asset_notification/upload_notification.text.erb
@@ -7,9 +7,6 @@ Listen to <%= @title %> on alonetone:
 
 ------------------------------
 
-You are getting this email because you decided to follow <%= @name.capitalize %>. You can change your mind by clicking "un-follow" here:
-<%= @user_link %>
+You are getting this email because you decided to follow <%= @name.capitalize %>. You can change your mind by clicking clicking here: <%= @stop_following_link %>
 
-You can also turn off all emails by editing your profile at alonetone.
-
-
+You can also turn off all emails by unsubscribing here: <%= @unsubscribe_link %>.

--- a/app/views/comment_notification/new_comment.text.erb
+++ b/app/views/comment_notification/new_comment.text.erb
@@ -14,5 +14,6 @@ You got a new comment on your track "<%= @song %>". <%= @number_of_comments > 1 
 Check out all your comments at:
 https://alonetone.com/<%=@login%>/comments
 
-Don't want positive feedback on your tracks via email? Unsubscribe:
-https://alonetone.com/users/<%=@login%>/edit
+Don't want positive feedback on your tracks via email? Adjust your settings here: <%= @settings_link %>
+
+You can also turn off all emails by unsubscribing here: <%= @unsubscribe_link %>.

--- a/app/views/users/show_white.html.erb
+++ b/app/views/users/show_white.html.erb
@@ -6,7 +6,7 @@
         <h1 class="user_name"><%= @user.name %></h1>
       </div>
       <% if logged_in? %>
-        <%= link_to toggle_follow_user_path(current_user, followee_id: @user.id), remote: true, class: 'follow',
+        <%= link_to toggle_follow_path(login: @user.login), remote: true, class: 'follow',
         data: {controller: 'follow', action: 'follow#toggle', :'follow-following' => current_user.is_following?(@user).present? } do %>
           <svg id="faveSVG" class="faveSVG" viewBox="0 0 600 600" xmlns="http://www.w3.org/2000/svg">
             <path class="outline" d="M299.64,180.06C254.2,95.52,123.26,90.77,87.58,197,42.14,332.24,189.85,374.17,299.64,484.42,409.43,374.17,557.14,332.24,511.7,197,476,90.77,345.08,95.52,299.64,180.06Z" fill="none" stroke="#b4b4b4" stroke-miterlimit="10" stroke-width="35" />

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,8 +22,9 @@ Alonetone::Application.routes.draw do
     get '/notifications/subscribe' => 'notifications#subscribe'
     get '/notifications/unsubscribe' => 'notifications#unsubscribe'
 
-    get '/follow/:login' => 'following#follow'
-    get 'unfollow/:login' => 'following#unfollow'
+    get '/follow/:login' => 'following#follow', as: :follow
+    get '/unfollow/:login' => 'following#unfollow', as: :unfollow
+    get '/:login/toggle-follow' => 'following#toggle_follow', as: :toggle_follow
 
     # admin stuff
     get 'secretz' => 'admin#secretz'
@@ -127,7 +128,6 @@ Alonetone::Application.routes.draw do
       member do
         post :attach_pic
         get :sudo
-        get :toggle_follow
       end
       resources 'source_files' #:path_prefix => ':login'
       resources 'tracks', controller: :assets do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,6 +22,9 @@ Alonetone::Application.routes.draw do
     get '/notifications/subscribe' => 'notifications#subscribe'
     get '/notifications/unsubscribe' => 'notifications#unsubscribe'
 
+    get '/follow/:login' => 'following#follow'
+    get 'unfollow/:login' => 'following#unfollow'
+
     # admin stuff
     get 'secretz' => 'admin#secretz'
     get 'toggle_theme' => 'admin#toggle_theme'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,6 +19,9 @@ Alonetone::Application.routes.draw do
     get '/logout', :to => 'user_sessions#destroy', as: 'logout', via: [:get, :post]
     resources :user_sessions
 
+    get '/notifications/subscribe', to: 'notifications#subscribe'
+    get 'notifications/unsubscribe', to: 'notifications#unsubscribe'
+
     # admin stuff
     get 'secretz' => 'admin#secretz'
     get 'toggle_theme' => 'admin#toggle_theme'

--- a/spec/controllers/assets_controller_spec.rb
+++ b/spec/controllers/assets_controller_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe AssetsController, type: :controller do
 
   context "new" do
     it 'should display limit reached flash for new users with >= 25 tracks' do
-      login(:new_user)
+      login(:brand_new_user)
       get :new
       expect(response).to be_successful
       expect(response.body).to include('To prevent abuse, new users are limited to 25 uploads in their first day. Come back tomorrow!')
@@ -20,7 +20,7 @@ RSpec.describe AssetsController, type: :controller do
   end
 
   it 'should disable the form for new users with >= 24 tracks' do
-    login(:new_user)
+    login(:brand_new_user)
     get :new
     expect(assigns(:upload_disabled)).to be_present
   end

--- a/spec/controllers/following_controller_spec.rb
+++ b/spec/controllers/following_controller_spec.rb
@@ -1,0 +1,37 @@
+require "rails_helper"
+
+RSpec.describe FollowingController, type: :controller do
+  fixtures :users
+
+  context 'follow' do
+    it 'should increment following count by one' do
+      login(:brand_new_user)
+      get :follow, params: { login: 'sudara' }
+      expect(users(:brand_new_user).follows.count).to eq(1)
+    end
+
+    it 'should not let you follow someone twice' do
+      login(:brand_new_user)
+      get :follow, params: { login: 'sudara' }
+      get :follow, params: { login: 'sudara' }
+      expect(response).to redirect_to(root_path)
+      expect(flash[:error]).to be_present
+    end
+  end
+
+  context 'unfollow' do
+    it 'should decrement following count by one' do
+      login(:brand_new_user)
+      get :unfollow, params: { login: 'sudara' }
+      expect(users(:brand_new_user).follows.count).to eq(0)
+    end
+
+    it 'should not let you unfollow someone you do not already follow' do
+      login(:brand_new_user)
+      get :unfollow, params: { login: 'sudara' }
+      get :unfollow, params: { login: 'sudara' }
+      expect(response).to redirect_to(root_path)
+      expect(flash[:error]).to be_present
+    end
+  end
+end

--- a/spec/controllers/notifications_controller_spec.rb
+++ b/spec/controllers/notifications_controller_spec.rb
@@ -1,0 +1,21 @@
+require "rails_helper"
+
+RSpec.describe NotificationsController, type: :controller do
+  fixtures :users
+
+  context 'subscribe' do
+    it 'should mark email_new_tracks setting as true' do
+      login(:brand_new_user)
+      get :subscribe
+      expect(users(:brand_new_user).settings[:email_new_tracks]).to eq(true)
+    end
+  end
+
+  context 'unsubscribe' do
+    it 'should mark email_new_tracks setting as false' do
+      login(:brand_new_user)
+      get :unsubscribe
+      expect(users(:brand_new_user).settings[:email_new_tracks]).to eq(false)
+    end
+  end
+end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe UsersController, type: :controller do
       activate_authlogic && create_user
       get :activate, params: { perishable_token: User.last.perishable_token }
       expect(flash[:ok]).to be_present
-      expect(response).to redirect_to(brand_new_user_track_path(User.last.login))
+      expect(response).to redirect_to(new_user_track_path(User.last.login))
     end
 
     it 'should log in user on activation' do
@@ -74,7 +74,7 @@ RSpec.describe UsersController, type: :controller do
       activate_authlogic
       get :activate, params: { perishable_token: "abunchofbullshit" }
       expect(flash[:error]).to be_present
-      expect(response).to redirect_to(brand_new_user_path)
+      expect(response).to redirect_to(new_user_path)
     end
 
     it 'should NOT activate an account if you are already logged in' do

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe UsersController, type: :controller do
       activate_authlogic && create_user
       get :activate, params: { perishable_token: User.last.perishable_token }
       expect(flash[:ok]).to be_present
-      expect(response).to redirect_to(new_user_track_path(User.last.login))
+      expect(response).to redirect_to(brand_new_user_track_path(User.last.login))
     end
 
     it 'should log in user on activation' do
@@ -74,7 +74,7 @@ RSpec.describe UsersController, type: :controller do
       activate_authlogic
       get :activate, params: { perishable_token: "abunchofbullshit" }
       expect(flash[:error]).to be_present
-      expect(response).to redirect_to(new_user_path)
+      expect(response).to redirect_to(brand_new_user_path)
     end
 
     it 'should NOT activate an account if you are already logged in' do

--- a/spec/fixtures/users.yml
+++ b/spec/fixtures/users.yml
@@ -67,10 +67,10 @@ joeblow:
   updated_at: <%= 1.days.ago.to_s :db %>
 
 # Brand new user with 25 tracks
-new_user:
+brand_new_user:
   id: 7
-  login: newuser
-  email: newuser@example.com
+  login: brandnewuser
+  email: brandnewuser@example.com
   salt: <%= salt = Authlogic::Random.hex_token %>
   crypted_password: <%= Authlogic::CryptoProviders::SCrypt.encrypt("test" + salt) %>
   created_at: <%= 5.hours.ago.to_s :db %>

--- a/spec/fixtures/users.yml
+++ b/spec/fixtures/users.yml
@@ -69,7 +69,7 @@ joeblow:
 # Brand new user with 25 tracks
 new_user:
   id: 7
-  login: new_user
+  login: newuser
   email: newuser@example.com
   salt: <%= salt = Authlogic::Random.hex_token %>
   crypted_password: <%= Authlogic::CryptoProviders::SCrypt.encrypt("test" + salt) %>

--- a/spec/mailers/album_notification_spec.rb
+++ b/spec/mailers/album_notification_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+RSpec.describe AlbumNotification, type: :mailer do
+  fixtures :playlists, :users
+
+  describe "album_release" do
+    let(:mail) { AlbumNotification.album_release(playlists(:owp), users(:sudara).email) }
+
+    it "renders the headers" do
+      expect(mail.subject).to eq("[alonetone] '#{users(:sudara).name}' released a new album!")
+      expect(mail.to).to eq(["#{users(:sudara).email}"])
+      expect(mail.from).to eq(["#{Alonetone.email}"])
+    end
+
+    it "includes the unfollow link" do
+      expect(mail.body).to include("https://#{Alonetone.url}/unfollow/#{users(:sudara).login}")
+    end
+
+    it "includes the unsubscribe link" do
+      expect(mail.body).to include("https://#{Alonetone.url}/notifications/unsubscribe")
+    end
+  end
+end

--- a/spec/mailers/asset_notification_spec.rb
+++ b/spec/mailers/asset_notification_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+RSpec.describe AssetNotification, type: :mailer do
+  fixtures :assets, :users
+
+  describe "upload_notification" do
+    let(:mail) { AssetNotification.upload_notification(assets(:valid_mp3), users(:sudara).email) }
+
+    it "renders the headers" do
+      expect(mail.subject).to eq("[alonetone] '#{assets(:valid_mp3).user.name}' uploaded a new track!")
+      expect(mail.to).to eq(["#{users(:sudara).email}"])
+      expect(mail.from).to eq(["#{Alonetone.email}"])
+    end
+
+    it "includes the unfollow link" do
+      expect(mail.body).to include("https://#{Alonetone.url}/unfollow/#{assets(:valid_mp3).user.login}")
+    end
+
+    it "includes the unsubscribe link" do
+      expect(mail.body).to include("https://#{Alonetone.url}/notifications/unsubscribe")
+    end
+  end
+end

--- a/spec/mailers/comment_notification_spec.rb
+++ b/spec/mailers/comment_notification_spec.rb
@@ -1,0 +1,49 @@
+require "rails_helper"
+
+RSpec.describe CommentNotification, type: :mailer do
+  fixtures :comments, :assets
+
+  describe "new_comment by user" do
+    let(:asset) { assets(:valid_mp3) }
+    let(:comment) { comments(:valid_comment_on_asset_by_user) }
+    let(:mail) { CommentNotification.new_comment(comment, asset)}
+
+    it "renders the headers" do
+      expect(mail.to).to eq(["sudara@modernthings.net"])
+      expect(mail.from).to eq(["#{Alonetone.email}"])
+      expect(mail.subject).to eq("[alonetone] Comment on '#{asset.name}' from sudara")
+    end
+
+    it "renders the body" do
+      expect(mail.body).to include("Hey there sudara")
+      expect(mail.body).to include("sudara says:")
+      expect(mail.body).to include("https://#{Alonetone.url}/sudara/edit")
+    end
+
+    it "includes the unsubscribe link" do
+      expect(mail.body).to include("https://#{Alonetone.url}/notifications/unsubscribe")
+    end
+  end
+
+  describe "new_comment by guest" do
+    let(:asset) { assets(:valid_mp3) }
+    let(:comment) { comments(:valid_comment_on_asset_by_guest) }
+    let(:mail) { CommentNotification.new_comment(comment, asset)}
+
+    it "renders the headers" do
+      expect(mail.to).to eq(["sudara@modernthings.net"])
+      expect(mail.from).to eq(["#{Alonetone.email}"])
+      expect(mail.subject).to eq("[alonetone] Comment on '#{asset.name}' from Guest")
+    end
+
+    it "renders the body" do
+      expect(mail.body).to include("Hey there sudara")
+      expect(mail.body).to include("Guest says:")
+      expect(mail.body).to include("https://#{Alonetone.url}/sudara/edit")
+    end
+
+    it "includes the unsubscribe link" do
+      expect(mail.body).to include("https://#{Alonetone.url}/notifications/unsubscribe")
+    end
+  end
+end

--- a/spec/request/assets_controller_spec.rb
+++ b/spec/request/assets_controller_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe AssetsController, type: :request do
 
   context '#new' do
     before do
-      create_user_session(users(:new_user))
+      create_user_session(users(:brand_new_user))
     end
 
     it 'should not allow new users w/ >= 25 tracks to upload' do
@@ -167,11 +167,11 @@ RSpec.describe AssetsController, type: :request do
 
   context '#create' do
     before do
-      create_user_session(users(:new_user))
+      create_user_session(users(:brand_new_user))
     end
 
     it 'should prevent uploads from new users with >= 25 tracks' do
-      post '/new_user/tracks', params: { asset_data: [fixture_file_upload('assets/muppets.mp3', 'audio/mpeg')] }
+      post '/brandnewuser/tracks', params: { asset_data: [fixture_file_upload('assets/muppets.mp3', 'audio/mpeg')] }
       follow_redirect!
       expect(response.body).to include('To prevent abuse, new users are limited to 25 uploads in their first day. Come back tomorrow!')
     end

--- a/spec/request/following_controller_spec.rb
+++ b/spec/request/following_controller_spec.rb
@@ -1,0 +1,39 @@
+require "rails_helper"
+
+RSpec.describe FollowingController, type: :request do
+  fixtures :users
+
+  before :each do
+    create_user_session(users(:brand_new_user))
+  end
+
+  it "should successfully follow someone" do
+    get "/follow/sudara"
+    follow_redirect!
+    expect(response).to be_successful
+  end
+
+  it "should successfully unfollow someone", following: true do
+    get "/follow/sudara"
+    follow_redirect!
+
+    get "/unfollow/sudara"
+    follow_redirect!
+    expect(response).to be_successful
+  end
+
+  it "should not follow someone twice" do
+    get "/follow/sudara"
+    follow_redirect!
+
+    get "/follow/sudara"
+    follow_redirect!
+    expect(response).to be_successful
+  end
+
+  it "should not unfollow someone you are not already following" do
+    get "/follow/arthur"
+    follow_redirect!
+    expect(response).to be_successful
+  end
+end


### PR DESCRIPTION
This PR implements #190 and fixes some over-eager find and replace mistakes in the test suite. It uses the new settings store to handle email notification preferences.

It also includes the commits for `convert-settings-to-store` due to a branch snafu but these can be ignored. Additionally, the existing `new_user` entry in the `Users.yml` fixture conflicted with the `new_user` method in the User model spec so it has been renamed.