### PR TITLE
Tighten annotate rules to skip nested model files

### DIFF
--- a/lib/tasks/auto_annotate_models.rake
+++ b/lib/tasks/auto_annotate_models.rake
@@ -30,7 +30,7 @@ if Rails.env.development?
       'exclude_controllers'       => 'true',
       'exclude_helpers'           => 'true',
       'exclude_sti_subclasses'    => 'false',
-      'ignore_model_sub_dir'      => 'false',
+      'ignore_model_sub_dir'      => 'true',
       'ignore_columns'            => nil,
       'ignore_routes'             => nil,
       'ignore_unknown_models'     => 'false',


### PR DESCRIPTION
Before:
```
$ rake db:migrate
W, [2018-11-08T09:56:46.033691 #20867]  WARN -- Skylight: [SKYLIGHT] [3.1.1] Running Skylight in development mode. No data will be reported until you deploy your app.
(To disable this message for all local apps, run `skylight disable_dev_warning`.)
== 20181108145335 Bar: migrating ==============================================
-- add_index(:comments, :user_agent)
   -> 1.7397s
== 20181108145335 Bar: migrated (1.7398s) =====================================

Unable to annotate app/models/asset/statistics.rb: file doesn't contain a valid model class
Unable to annotate app/models/asset/radio.rb: file doesn't contain a valid model class
Unable to annotate app/models/asset/uploading.rb: file doesn't contain a valid model class
Unable to annotate app/models/user/validation.rb: file doesn't contain a valid model class
Unable to annotate app/models/user/statistics.rb: file doesn't contain a valid model class
Unable to annotate app/models/user/posting.rb: file doesn't contain a valid model class
Unable to annotate app/models/user/profile.rb: file doesn't contain a valid model class
Unable to annotate app/models/user/findability.rb: file doesn't contain a valid model class
Annotated (1): app/models/comment.rb
```
After:
```
[09:36:27] (silence-annotate) alonetone
$ rake db:migrate
W, [2018-11-08T09:37:34.130983 #15060]  WARN -- Skylight: [SKYLIGHT] [3.1.1] Running Skylight in development mode. No data will be reported until you deploy your app.
(To disable this message for all local apps, run `skylight disable_dev_warning`.)
== 20181108143626 Foo: migrating ==============================================
-- add_index(:comments, :remote_ip)
   -> 1.0407s
== 20181108143626 Foo: migrated (1.0412s) =====================================

Annotated (1): app/models/comment.rb
```

Takes care of https://github.com/sudara/alonetone/issues/256