### PR TITLE
I302 spam comments

### DIFF
--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -76,6 +76,8 @@ class Comment < ActiveRecord::Base
   end
 
   def increment_counters
+    return if is_spam?
+
     if commentable.is_a? Asset
       User.increment_counter(:comments_count, commentable.user, touch: true)
       Asset.increment_counter(:comments_count, commentable, touch: true)

--- a/bin/one-shot/2018/11/I302-recount-comments-count.rb
+++ b/bin/one-shot/2018/11/I302-recount-comments-count.rb
@@ -1,0 +1,17 @@
+# was seeing this issue locally when running without rescue
+# can't dump `waveform`: was supposed to be a Array, but was a String. -- "[]"
+failed_assets = []
+
+Asset.find_each do |asset|
+  next if asset.is_spam?
+
+  current_count = asset.comments_count
+  non_spam_count = asset.comments.include_private.count
+  next if current_count == non_spam_count
+
+  begin
+    asset.update_attributes(comments_count: non_spam_count)
+  rescue
+    failed_assets << asset.id
+  end
+end

--- a/spec/controllers/comments_controller_spec.rb
+++ b/spec/controllers/comments_controller_spec.rb
@@ -48,6 +48,18 @@ RSpec.describe CommentsController, type: :controller do
          Comment.last.update_attribute(:is_spam, true)
       end.to change { ActionMailer::Base.deliveries.size }.by(0)
     end
+
+    it "should increment comment_count if comment was not a spam" do
+      params = { :comment => { "body" => "Comment", "private" => "0", "commentable_type" => "Asset", "commentable_id" => 1 }, "user_id" => users(:sudara).login, "track_id" => assets(:valid_mp3).permalink }
+      expect { post :create, params: params, xhr: true }.to change { Asset.first.comments_count }.by(1)
+    end
+
+    it "should not increment comment_count if comment is spam" do
+      # the "viagra-test-123" guarantees a spam response
+      params = { :comment => { "body" => "viagra-test-123", "private" => 1, "commentable_type" => "Asset", "commentable_id" => 4 }, "user_id" => users(:sudara).login, "track_id" => assets(:valid_mp3).permalink }
+      post :create, params: params, xhr: true
+      expect(Asset.find(1).comments_count).to eq(0)
+    end
   end
 
   context "private comments made by user" do


### PR DESCRIPTION
https://github.com/sudara/alonetone/issues/302

- [x] Make sure spam comments don't increment comments_count
- [x] Add a migration to generate comments_count for all assets, counting only non-spam comments.