### PR TITLE
Use transactional fixtures instead of Database Cleaner and minor spec suite cleanups.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -94,7 +94,6 @@ group :test do
   gem 'rspec-rails', :require => false
   gem 'rspec-mocks', :require => false
   gem 'guard-rspec', :require => false
-  gem 'database_cleaner', :require => false
   gem 'rb-fsevent', :require => false
   gem 'guard', :require => false
   gem 'listen', :require => false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -146,7 +146,6 @@ GEM
     crass (1.0.4)
     daemons (1.3.1)
     dalli (2.7.9)
-    database_cleaner (1.7.0)
     db_text_search (0.3.0)
       activerecord (>= 4.1.15, < 6.0)
     diff-lcs (1.3)
@@ -519,7 +518,6 @@ DEPENDENCIES
   compass-rails
   country_select
   dalli
-  database_cleaner
   dynamic_form
   factory_bot_rails
   font-awesome-sass

--- a/greenfield/test/integration/navigation_test.rb
+++ b/greenfield/test/integration/navigation_test.rb
@@ -1,9 +1,4 @@
 require 'test_helper'
 
 class NavigationTest < ActionDispatch::IntegrationTest
-  fixtures :all
-
-  # test "the truth" do
-  #   assert true
-  # end
 end

--- a/spec/controllers/assets_controller_spec.rb
+++ b/spec/controllers/assets_controller_spec.rb
@@ -3,7 +3,6 @@ include ActiveJob::TestHelper
 
 RSpec.describe AssetsController, type: :controller do
   render_views
-  fixtures :assets, :users, :audio_features
 
   before :each do
     clear_enqueued_jobs

--- a/spec/controllers/comments_controller_spec.rb
+++ b/spec/controllers/comments_controller_spec.rb
@@ -1,7 +1,6 @@
 require "rails_helper"
 
 RSpec.describe CommentsController, type: :controller do
-  fixtures :users, :comments, :assets
   include ActiveJob::TestHelper
 
   context "basics" do

--- a/spec/controllers/following_controller_spec.rb
+++ b/spec/controllers/following_controller_spec.rb
@@ -1,8 +1,6 @@
 require "rails_helper"
 
 RSpec.describe FollowingController, type: :controller do
-  fixtures :users
-
   context 'follow' do
     it 'should increment following count by one' do
       login(:brand_new_user)

--- a/spec/controllers/notifications_controller_spec.rb
+++ b/spec/controllers/notifications_controller_spec.rb
@@ -1,8 +1,6 @@
 require "rails_helper"
 
 RSpec.describe NotificationsController, type: :controller do
-  fixtures :users
-
   context 'subscribe' do
     it 'should mark email_new_tracks setting as true' do
       login(:brand_new_user)

--- a/spec/controllers/password_resets_controller_spec.rb
+++ b/spec/controllers/password_resets_controller_spec.rb
@@ -1,8 +1,6 @@
 require "rails_helper"
 
 RSpec.describe PasswordResetsController, type: :controller do
-  fixtures :users
-
   context 'resetting' do
     it "should error if the email provided doesn't exist" do
       post :create, params: { email: "blah" }

--- a/spec/controllers/playlists_controller_spec.rb
+++ b/spec/controllers/playlists_controller_spec.rb
@@ -1,8 +1,6 @@
 require "rails_helper"
 
 RSpec.describe PlaylistsController, 'permissions', type: :controller do
-  fixtures :playlists, :users
-
   it "should show a playlist" do
     get :show, params: { id: 1, permalink: 'owp', user_id: 'sudara' }
     expect(response).to be_successful
@@ -109,8 +107,6 @@ RSpec.describe PlaylistsController, 'permissions', type: :controller do
 end
 
 RSpec.describe PlaylistsController, "sharing and exporting", type: :controller do
-  fixtures :playlists, :users
-
   it "should deliver us tasty xml for single playlist" do
     request.env["HTTP_ACCEPT"] = "application/xml"
     get :show, params: { id: '1', user_id: 'sudara', permalink: 'owp' }

--- a/spec/controllers/search_controller_spec.rb
+++ b/spec/controllers/search_controller_spec.rb
@@ -1,8 +1,6 @@
 require "rails_helper"
 
 RSpec.describe SearchController, type: :controller do
-  fixtures :users, :assets
-
   context "basics" do
     it 'should search assets by name / filename and return results' do
       get :index, params: { query: 'Song1' }

--- a/spec/controllers/user_sessions_controller_spec.rb
+++ b/spec/controllers/user_sessions_controller_spec.rb
@@ -1,8 +1,6 @@
 require "rails_helper"
 
 RSpec.describe UserSessionsController, type: :controller do
-  fixtures :users
-
   it "should successfully login with alonetone login" do
     post :create, params: { user_session: { login: 'arthur', password: 'test' } }
     expect(controller.session["user_credentials"]).to eq(users(:arthur).persistence_token)

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -256,8 +256,8 @@ RSpec.describe UsersController, type: :controller do
       login(:sudara)
       get :sudo, params: { id: 'arthur' }
       expect(controller.session["user_credentials"]).to eq(users(:arthur).persistence_token)
-      expect(users(:arthur).current_login_ip).not_to eq('10.1.1.1')
-      expect(users(:arthur).last_request_at.utc).to be_within(1.minute).of 1.day.ago # shouldn't have changed from yml
+      expect(users(:arthur).current_login_ip).to eq('9.9.9.9')
+      expect(users(:arthur).last_request_at.utc).to be < 1.hour.ago
     end
   end
 

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -2,7 +2,6 @@ require "rails_helper"
 
 RSpec.describe UsersController, type: :controller do
   render_views
-  fixtures :users, :profiles, :assets
 
   context 'show' do
     it "should show delete user button for admins" do
@@ -133,8 +132,8 @@ RSpec.describe UsersController, type: :controller do
       expect(response).to redirect_to("http://test.host/arthur/tracks/new")
     end
   end
+
   context "profile" do
-    fixtures :users, :assets
     %i[sudara arthur].each do |user|
       it "should let a user or admin edit" do
         login(user)

--- a/spec/jobs/create_audio_feature_job_spec.rb
+++ b/spec/jobs/create_audio_feature_job_spec.rb
@@ -3,8 +3,6 @@ require 'rails_helper'
 RSpec.describe CreateAudioFeatureJob, type: :job do
   include ActiveJob::TestHelper
 
-  fixtures :assets
-
   after do
     clear_enqueued_jobs
     clear_performed_jobs

--- a/spec/mailers/album_notification_spec.rb
+++ b/spec/mailers/album_notification_spec.rb
@@ -1,8 +1,6 @@
 require "rails_helper"
 
 RSpec.describe AlbumNotification, type: :mailer do
-  fixtures :playlists, :users
-
   describe "album_release" do
     let(:mail) { AlbumNotification.album_release(playlists(:owp), users(:sudara).email) }
 

--- a/spec/mailers/asset_notification_spec.rb
+++ b/spec/mailers/asset_notification_spec.rb
@@ -1,8 +1,6 @@
 require "rails_helper"
 
 RSpec.describe AssetNotification, type: :mailer do
-  fixtures :assets, :users
-
   describe "upload_notification" do
     let(:mail) { AssetNotification.upload_notification(assets(:valid_mp3), users(:sudara).email) }
 

--- a/spec/mailers/comment_notification_spec.rb
+++ b/spec/mailers/comment_notification_spec.rb
@@ -1,8 +1,6 @@
 require "rails_helper"
 
 RSpec.describe CommentNotification, type: :mailer do
-  fixtures :comments, :assets
-
   describe "new_comment by user" do
     let(:asset) { assets(:valid_mp3) }
     let(:comment) { comments(:valid_comment_on_asset_by_user) }

--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -7,7 +7,6 @@ def new_track(file)
 end
 
 RSpec.describe Asset, type: :model do
-  fixtures :users, :assets
   context "validation" do
     it 'can be an mp3 file' do
       expect(assets(:valid_mp3)).to be_valid
@@ -168,8 +167,6 @@ RSpec.describe Asset, type: :model do
 end
 
 RSpec.describe Asset, 'on update', type: :model do
-  fixtures :users, :assets
-
   it 'should regenerate a permalink after the title is changed' do
     asset = new_track('muppets.mp3')
     asset.save

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -1,8 +1,6 @@
 require "rails_helper"
 
 RSpec.describe Comment, type: :model do
-  fixtures :users, :comments, :assets
-
   let(:new_comment) { assets(:valid_mp3).comments.new(body: 'test', commentable_type: 'Asset', commentable_id: '1') }
 
   context "validation" do

--- a/spec/models/playlist_spec.rb
+++ b/spec/models/playlist_spec.rb
@@ -1,8 +1,6 @@
 require "rails_helper"
 
 RSpec.describe Playlist, type: :model do
-  fixtures :playlists, :tracks, :assets, :users
-
   it 'should be valid with title, description, user' do
     expect(playlists(:owp)).to be_valid
   end

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -1,8 +1,6 @@
 require "rails_helper"
 
 RSpec.describe Post, type: :model do
-  fixtures :forums, :topics, :posts, :users
-
   context "validation" do
     it "should be valid" do
       expect(posts(:post1)).to be_valid

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -1,8 +1,6 @@
 require "rails_helper"
 
 RSpec.describe Topic, type: :model do
-  fixtures :forums, :topics, :posts
-
   context "validation" do
     it "should be valid" do
       expect(topics(:topic1)).to be_valid

--- a/spec/models/track_spec.rb
+++ b/spec/models/track_spec.rb
@@ -1,8 +1,6 @@
 require "rails_helper"
 
 RSpec.describe Track, type: :model do
-  fixtures :playlists, :tracks, :assets, :users
-
   it "should be valid with a asset_id and a playlist_id" do
     expect(tracks(:owp1)).to be_valid
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,8 +1,6 @@
 require "rails_helper"
 
 RSpec.describe User, type: :model do
-  fixtures :users, :assets, :playlists, :tracks
-
   context "validation" do
     it "should be valid with email, login and password" do
       expect(new_user).to be_valid

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -76,15 +76,6 @@ RSpec.configure do |config|
   config.before(:example, type: :controller) do
     activate_authlogic
   end
-
-  # Setting this config option `false` removes rspec-core's monkey patching of the
-  # top level methods like `describe`, `shared_examples_for` and `shared_context`
-  # on `main` and `Module`. The methods are always available through the `RSpec`
-  # module like `RSpec.describe` regardless of this setting.
-  # For backwards compatibility this defaults to `true`.
-  #
-  # https://relishapp.com/rspec/rspec-core/v/3-0/docs/configuration/global-namespace-dsl
-  config.expose_dsl_globally = false
 end
 
 FactoryBot.reload

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -6,7 +6,6 @@ ENV['RAILS_ENV'] ||= 'test'
 require File.expand_path('../config/environment', __dir__)
 
 require 'rspec/rails'
-require 'database_cleaner'
 require 'authlogic/test_case'
 require 'factory_bot_rails'
 require "selenium/webdriver"
@@ -54,16 +53,7 @@ RSpec.configure do |config|
   config.include ActiveSupport::Testing::TimeHelpers
 
   config.before(:suite) do
-    DatabaseCleaner.strategy = :transaction
-    DatabaseCleaner.clean_with(:truncation)
     InvisibleCaptcha.timestamp_enabled = false
-  end
-  config.before(:each) do
-    DatabaseCleaner.start
-  end
-
-  config.append_after(:each) do
-    DatabaseCleaner.clean
   end
 
   config.include Authlogic::TestCase, type: :request

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -77,10 +77,6 @@ RSpec.configure do |config|
     activate_authlogic
   end
 
-  def pay!(subscription_type_id, item=nil)
-    post "paypal/post_payment", tx: "68E56277NB6235547", st: "Completed", amt: "29.00", cc: "USD", cm: subscription_type_id, item_number: item
-  end
-
   # Setting this config option `false` removes rspec-core's monkey patching of the
   # top level methods like `describe`, `shared_examples_for` and `shared_context`
   # on `main` and `Module`. The methods are always available through the `RSpec`

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -50,6 +50,7 @@ RSpec.configure do |config|
   config.include Authlogic::TestCase
   config.include RSpec::Support::Logging
   config.include RSpec::Support::LittleHelpers
+  config.include RSpec::Support::LoginHelpers
   config.include ActiveSupport::Testing::TimeHelpers
 
   config.before(:suite) do
@@ -75,27 +76,6 @@ RSpec.configure do |config|
   config.before(:example, type: :controller) do
     activate_authlogic
   end
-
-  module LoginHelper
-    include Authlogic::TestCase
-
-    def login(user)
-      login_as = user.is_a?(User) ? user : users(user) # grab the fixture
-
-      expect(session = UserSession.create(login_as)).to be_truthy # make sure we logged in
-      allow(controller).to receive(:current_user_session).and_return(session)
-      allow(controller).to receive(:current_user).and_return(login_as) # make authlogic happy
-    end
-
-    def create_user_session(user)
-      post '/user_sessions', params: { user_session: { login: user.login, password: 'test' } }
-    end
-
-    def logout
-      UserSession.find.destroy if UserSession.find
-    end
-  end
-  config.include LoginHelper
 
   def pay!(subscription_type_id, item=nil)
     post "paypal/post_payment", tx: "68E56277NB6235547", st: "Completed", amt: "29.00", cc: "USD", cm: subscription_type_id, item_number: item

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,7 +1,10 @@
-# This file is copied to spec/ when you run 'rails generate rspec:install'
-ENV['RAILS_ENV'] ||= 'test'
+# frozen_string_literal: true
+
 require 'spec_helper'
-require File.expand_path('../../config/environment', __FILE__)
+
+ENV['RAILS_ENV'] ||= 'test'
+require File.expand_path('../config/environment', __dir__)
+
 require 'rspec/rails'
 require 'database_cleaner'
 require 'authlogic/test_case'

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -29,19 +29,19 @@ Percy.config.default_widths = [375, 1280]
 ActiveRecord::Migration.maintain_test_schema!
 
 RSpec.configure do |config|
+  # Use Active Record fixture path relative to spec/ directory.
+  config.fixture_path = Rails.root.join('spec', 'fixtures').to_s
+
+  # All of the fixtures all of the time.
+  config.global_fixtures = :all
+
+  # Use transactional fixtures.
+  config.use_transactional_fixtures = true
 
   config.before(:suite) { Percy::Capybara.initialize_build }
   config.after(:suite) { Percy::Capybara.finalize_build }
 
-  # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
-  config.fixture_path = "#{::Rails.root}/spec/fixtures"
-
   config.render_views
-
-  # If you're not using ActiveRecord, or you'd prefer not to run each of your
-  # examples within a transaction, remove the following line or assign false
-  # instead of true.
-  config.use_transactional_fixtures = false
 
   config.infer_base_class_for_anonymous_controllers = false
   config.infer_spec_type_from_file_location!

--- a/spec/request/admin/assets_controller_spec.rb
+++ b/spec/request/admin/assets_controller_spec.rb
@@ -1,8 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe Admin::AssetsController, type: :request do
-  fixtures :assets, :users
-
   before do
     create_user_session(users(:sudara))
   end

--- a/spec/request/admin/comments_controller_spec.rb
+++ b/spec/request/admin/comments_controller_spec.rb
@@ -35,8 +35,6 @@ RSpec.describe Admin::CommentsController, type: :request do
     end
 
     it "should send notification" do
-      allow(comment).to receive(:is_deliverable?).and_return(true)
-
       expect do
         put unspam_admin_comment_path(comment.id)
       end.to change { ActionMailer::Base.deliveries.size }.by(1)

--- a/spec/request/admin/comments_controller_spec.rb
+++ b/spec/request/admin/comments_controller_spec.rb
@@ -1,8 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe Admin::CommentsController, type: :request do
-  fixtures :comments, :users
-
   before do
     create_user_session(users(:sudara))
   end

--- a/spec/request/assets_controller_spec.rb
+++ b/spec/request/assets_controller_spec.rb
@@ -1,7 +1,6 @@
 require "rails_helper"
 
 RSpec.describe AssetsController, type: :request do
-  fixtures :assets, :users
   include ActiveJob::TestHelper
 
   before(:each) do

--- a/spec/request/assets_controller_spec.rb
+++ b/spec/request/assets_controller_spec.rb
@@ -4,13 +4,8 @@ RSpec.describe AssetsController, type: :request do
   include ActiveJob::TestHelper
 
   before(:each) do
-    DatabaseCleaner.start
     clear_enqueued_jobs
     clear_performed_jobs
-  end
-
-  append_after(:each) do
-    DatabaseCleaner.clean
   end
 
   context "#latest" do

--- a/spec/request/following_controller_spec.rb
+++ b/spec/request/following_controller_spec.rb
@@ -1,8 +1,6 @@
 require "rails_helper"
 
 RSpec.describe FollowingController, type: :request do
-  fixtures :users
-
   before :each do
     create_user_session(users(:brand_new_user))
   end

--- a/spec/request/thredded_spec.rb
+++ b/spec/request/thredded_spec.rb
@@ -1,7 +1,6 @@
 require "rails_helper"
-RSpec.describe "Thredded", type: :request do
-  fixtures :users
 
+RSpec.describe "Thredded", type: :request do
   it "loads the thredded index" do
     get "/discuss"
     expect(response).to be_successful

--- a/spec/request/user_sessions_controller_spec.rb
+++ b/spec/request/user_sessions_controller_spec.rb
@@ -1,8 +1,6 @@
 require "rails_helper"
 
 RSpec.describe UserSessionsController, type: :request do
-  fixtures :users
-
   it "should fail to login with wrong password" do
     post '/user_sessions', params: { user_session: { login: 'arthur', password: 'incorrect' } }
     expect(session[:user_credentials]).to_not be_present

--- a/spec/request/users_controller_spec.rb
+++ b/spec/request/users_controller_spec.rb
@@ -1,8 +1,6 @@
 require "rails_helper"
 
 RSpec.describe UsersController, type: :request do
-  fixtures :users, :profiles
-
   before :each do
     create_user_session(users(:sudara))
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,32 +1,34 @@
+# frozen_string_literal: true
+
 RSpec.configure do |config|
+  # The following three options will be default in RSpec 4.
   config.expect_with :rspec do |expectations|
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true
   end
-
   config.mock_with :rspec do |mocks|
     mocks.verify_partial_doubles = true
   end
+  config.shared_context_metadata_behavior = :apply_to_host_groups
 
-  config.filter_run :focus
-  config.run_all_when_everything_filtered = true
+  # Allows context or example to be tagged with :focus to only run those specs.
+  config.filter_run_when_matching :focus
 
-  config.disable_monkey_patching!
+  # Use the documentation formatter by default when running just one spec.
+  config.default_formatter = 'doc' if config.files_to_run.one?
 
-  if config.files_to_run.one?
-    config.default_formatter = 'doc'
-  end
-
+  # Show 10 slowest examples.
   config.profile_examples = 10
+
+  # Run in random order to reduce chance for interdependencies.
   config.order = :random
 
+  # Allows the suite to be re-run with a particular seed using --seed
   Kernel.srand config.seed
 
-  # Setting this config option `false` removes rspec-core's monkey patching of the
-  # top level methods like `describe`, `shared_examples_for` and `shared_context`
-  # on `main` and `Module`. The methods are always available through the `RSpec`
-  # module like `RSpec.describe` regardless of this setting.
-  # For backwards compatibility this defaults to `true`.
-  #
-  # https://relishapp.com/rspec/rspec-core/v/3-0/docs/configuration/global-namespace-dsl
+  # Require specs to begin with RSpec.describe so the global namespace is not
+  # contaminated with RSpec methods.
   config.expose_dsl_globally = false
+
+  # Limits the available syntax (e.g. forces expect(…).to)
+  config.disable_monkey_patching!
 end

--- a/spec/support/login_helpers.rb
+++ b/spec/support/login_helpers.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'authlogic/test_case'
+
+module RSpec
+  module Support
+    module LoginHelpers
+      include Authlogic::TestCase
+
+      def login(user)
+        login_as = user.is_a?(User) ? user : users(user)
+
+        expect(session = UserSession.create(login_as)).to be_truthy
+        allow(controller).to receive(:current_user_session).and_return(session)
+        allow(controller).to receive(:current_user).and_return(login_as)
+      end
+
+      def logout
+        UserSession.find.destroy if UserSession.find
+      end
+
+      def create_user_session(user)
+        post(
+          '/user_sessions',
+          params: { user_session: { login: user.login, password: 'test' } }
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
* Use transactional fixtures instead of Database Cleaner to manage the test database.
* Set all fixtures for all tests (they don't get loaded until used and are then kept around using transactions).
* Move all helpers from `rails_helper.rb` to their own support files.
* Review all configuration in `spec_helper.rb` and `rails_helper.rb` and clean up where possible.
* Add some documentation _why_ certain things are there.