### PR TITLE
Reduce and merge setup for Rails and dependencies in spec suite.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -70,8 +70,6 @@ gem 'skylight'
 gem 'sidekiq'
 gem 'dalli'
 
-
-
 group :production do
   gem 'puma'
   gem 'bugsnag'
@@ -97,8 +95,7 @@ group :test do
   gem 'rb-fsevent', :require => false
   gem 'guard', :require => false
   gem 'listen', :require => false
-  # https://github.com/thoughtbot/factory_bot/wiki/Usage
-  gem 'factory_bot_rails',:require => false
+  gem 'factory_bot_rails'
   gem 'rails-controller-testing'
 end
 

--- a/spec/controllers/assets_controller_spec.rb
+++ b/spec/controllers/assets_controller_spec.rb
@@ -1,12 +1,6 @@
 require "rails_helper"
-include ActiveJob::TestHelper
 
 RSpec.describe AssetsController, type: :controller do
-  before :each do
-    clear_enqueued_jobs
-    clear_performed_jobs
-  end
-
   context "new" do
     it 'should display limit reached flash for new users with >= 25 tracks' do
       login(:brand_new_user)

--- a/spec/controllers/assets_controller_spec.rb
+++ b/spec/controllers/assets_controller_spec.rb
@@ -2,8 +2,6 @@ require "rails_helper"
 include ActiveJob::TestHelper
 
 RSpec.describe AssetsController, type: :controller do
-  render_views
-
   before :each do
     clear_enqueued_jobs
     clear_performed_jobs

--- a/spec/controllers/comments_controller_spec.rb
+++ b/spec/controllers/comments_controller_spec.rb
@@ -1,8 +1,6 @@
 require "rails_helper"
 
 RSpec.describe CommentsController, type: :controller do
-  include ActiveJob::TestHelper
-
   context "basics" do
     it 'should allow anyone to view the comments index' do
       get :index

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -1,8 +1,6 @@
 require "rails_helper"
 
 RSpec.describe UsersController, type: :controller do
-  render_views
-
   context 'show' do
     it "should show delete user button for admins" do
       login(:sudara)

--- a/spec/jobs/create_audio_feature_job_spec.rb
+++ b/spec/jobs/create_audio_feature_job_spec.rb
@@ -1,13 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe CreateAudioFeatureJob, type: :job do
-  include ActiveJob::TestHelper
-
-  after do
-    clear_enqueued_jobs
-    clear_performed_jobs
-  end
-
   subject(:job) { described_class.perform_later(assets(:valid_arthur_mp3).id) }
 
   it "queues the job" do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -39,16 +39,16 @@ RSpec.configure do |config|
   # Use transactional fixtures.
   config.use_transactional_fixtures = true
 
-  config.before(:suite) { Percy::Capybara.initialize_build }
-  config.after(:suite) { Percy::Capybara.finalize_build }
-
-  config.render_views
-
-  config.infer_base_class_for_anonymous_controllers = false
+  # Spec directory determines its type (e.g. models, requests, etc).
   config.infer_spec_type_from_file_location!
 
+  # Filter lines from Rails gems in backtraces.
+  config.filter_rails_from_backtrace!
+
+  # Render views in controller specs by default.
+  config.render_views
+
   config.include ActiveSupport::Testing::TimeHelpers
-  config.include Authlogic::TestCase
   config.include Authlogic::TestCase, type: :controller
   config.include Authlogic::TestCase, type: :request
   config.include FactoryBot::Syntax::Methods
@@ -57,6 +57,7 @@ RSpec.configure do |config|
   config.include RSpec::Support::LoginHelpers
 
   config.before(:suite) do
+    Percy::Capybara.initialize_build
     InvisibleCaptcha.timestamp_enabled = false
   end
 
@@ -66,5 +67,9 @@ RSpec.configure do |config|
 
   config.before(:example, type: :controller) do
     activate_authlogic
+  end
+
+  config.after(:suite) do
+    Percy::Capybara.finalize_build
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -7,7 +7,6 @@ require File.expand_path('../config/environment', __dir__)
 
 require 'rspec/rails'
 require 'authlogic/test_case'
-require 'factory_bot_rails'
 require "selenium/webdriver"
 Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
 
@@ -46,18 +45,19 @@ RSpec.configure do |config|
   config.infer_base_class_for_anonymous_controllers = false
   config.infer_spec_type_from_file_location!
 
-  config.include Authlogic::TestCase
-  config.include RSpec::Support::Logging
-  config.include RSpec::Support::LittleHelpers
-  config.include RSpec::Support::LoginHelpers
   config.include ActiveSupport::Testing::TimeHelpers
+  config.include Authlogic::TestCase
+  config.include Authlogic::TestCase, type: :controller
+  config.include Authlogic::TestCase, type: :request
+  config.include FactoryBot::Syntax::Methods
+  config.include RSpec::Support::LittleHelpers
+  config.include RSpec::Support::Logging
+  config.include RSpec::Support::LoginHelpers
 
   config.before(:suite) do
     InvisibleCaptcha.timestamp_enabled = false
   end
 
-  config.include Authlogic::TestCase, type: :request
-  config.include Authlogic::TestCase, type: :controller
 
   config.before(:example, type: :request) do
     activate_authlogic
@@ -67,5 +67,3 @@ RSpec.configure do |config|
     activate_authlogic
   end
 end
-
-FactoryBot.reload

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -48,6 +48,7 @@ RSpec.configure do |config|
   # Render views in controller specs by default.
   config.render_views
 
+  config.include ActiveJob::TestHelper
   config.include ActiveSupport::Testing::TimeHelpers
   config.include Authlogic::TestCase, type: :controller
   config.include Authlogic::TestCase, type: :request
@@ -59,6 +60,11 @@ RSpec.configure do |config|
   config.before(:suite) do
     Percy::Capybara.initialize_build
     InvisibleCaptcha.timestamp_enabled = false
+  end
+
+  config.before(:each) do
+    clear_enqueued_jobs
+    clear_performed_jobs
   end
 
   config.before(:example, type: :request) do

--- a/spec/request/assets_controller_spec.rb
+++ b/spec/request/assets_controller_spec.rb
@@ -1,13 +1,6 @@
 require "rails_helper"
 
 RSpec.describe AssetsController, type: :request do
-  include ActiveJob::TestHelper
-
-  before(:each) do
-    clear_enqueued_jobs
-    clear_performed_jobs
-  end
-
   context "#latest" do
     it "should render the home page" do
       get '/'


### PR DESCRIPTION
* Remove unnecessary FactoryBot setup from helper.
* Merge all callbacks so there is just one for each stage (e.g. `:suite` or `:example`)
* Setup and manage Active Job centrally and remove it from each of the spec files.
* Remove `render_views` calls from specs because was already configured for the entire suite.