### PR TITLE
Switch to xenial on TravisCI and install less

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,25 +1,22 @@
-dist: trusty
+dist: xenial
 sudo: required
 language: ruby
 rvm:
   2.6.0
 addons:
   chrome: stable
+services:
+  - mysql
 cache:
 - bundler
 - yarn
 - npm
 before_install:
 - npm i -g node@latest
-- sudo add-apt-repository -y ppa:isage-dna/imagick
-- sudo apt-get update -qq
 - sudo apt-get install -y libsndfile-dev lame
-- sudo apt-get -y --reinstall install imagemagick
-- printf "\n" | pecl install imagick-beta
 - yarn
 before_script:
 - mysql -e 'create database alonetone_test';
-- gem update --system
 - bundle exec rake setup:copy_config setup:touch_js db:drop db:create db:schema:load
 - bundle exec rake db:seed
 script: bundle exec rake spec


### PR DESCRIPTION
* Switch to Xenial.
* Xenial has a more recent version of ImageMagick installed by default, so we don't have to do that any more.
* We don't have to update Rubygems because Ruby ships with a version that is recent enough for Bundler.
* We now need to specify MySQL because it's no longer available by default any more.