### PR TITLE
Use WebMock to disallow HTTP request from the suite and speed it up a bit

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -96,6 +96,7 @@ group :test do
   gem 'rspec-mocks', require: false
   gem 'rspec-rails', require: false
   gem 'selenium-webdriver'
+  gem 'webmock', require: false
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -143,6 +143,8 @@ GEM
     country_select (4.0.0)
       countries (~> 3.0)
       sort_alphabetical (~> 1.0)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
     crass (1.0.4)
     daemons (1.3.1)
     dalli (2.7.9)
@@ -185,6 +187,7 @@ GEM
       guard-compat (~> 1.1)
       rspec (>= 2.99.0, < 4.0)
     has_permalink (0.1.7)
+    hashdiff (0.3.8)
     html-pipeline (2.9.1)
       activesupport (>= 2)
       nokogiri (>= 1.4)
@@ -391,6 +394,7 @@ GEM
       jquery-fileupload-rails (~> 0.4.1)
       rails (>= 3.1)
       sass-rails (>= 3.1)
+    safe_yaml (1.0.4)
     sanitize (5.0.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.8.0)
@@ -484,6 +488,10 @@ GEM
       execjs (>= 0.3.0, < 3)
     unicode-display_width (1.4.0)
     unicode_utils (1.4.0)
+    webmock (3.5.1)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff
     webpacker (4.0.0.rc.2)
       activesupport (>= 4.2)
       rack-proxy (>= 0.6.1)
@@ -564,6 +572,7 @@ DEPENDENCIES
   thredded
   turbolinks
   uglifier
+  webmock
   webpacker (>= 4.0.x)
   will_paginate
   yui-compressor

--- a/spec/controllers/assets_controller_spec.rb
+++ b/spec/controllers/assets_controller_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe AssetsController, type: :controller do
 
   context "edit" do
     it 'should allow user to upload new version of song' do
+      akismet_stub_response_ham
       login(:sudara)
       post :create, params: { user_id: users(:sudara).login, asset_data: [fixture_file_upload('assets/muppets.mp3', 'audio/mpeg')] }
       expect(users(:sudara).assets.first.mp3_file_name).to eq('muppets.mp3')
@@ -64,18 +65,19 @@ RSpec.describe AssetsController, type: :controller do
     end
 
     it 'should allow user to update track title and description' do
+      akismet_stub_response_ham
       put :update, params: { id: users(:arthur).assets.first, user_id: users(:arthur).login, asset: { description: 'normal description' } }, xhr: true
       expect(response).to be_successful
     end
 
     it 'should call out to rakismet on update' do
-      allow(Rakismet).to receive(:akismet_call).and_return('false')
+      akismet_stub_response_spam
       put :update, params: { id: users(:arthur).assets.first, user_id: users(:arthur).login, asset: { description: 'normal description' } }, xhr: true
       expect(users(:arthur).assets.first.private).to be_falsey
     end
 
     it 'should record track as spammy if it is spam' do
-      allow(Rakismet).to receive(:akismet_call).and_return('true')
+      akismet_stub_response_spam
       put :update, params: { id: users(:arthur).assets.first, user_id: users(:arthur).login, asset: { description: 'spammy description' } }, xhr: true
       expect(assigns(:asset).is_spam?).to be_truthy
     end

--- a/spec/controllers/comments_controller_spec.rb
+++ b/spec/controllers/comments_controller_spec.rb
@@ -1,6 +1,10 @@
 require "rails_helper"
 
 RSpec.describe CommentsController, type: :controller do
+  before do
+    akismet_stub_response_ham
+  end
+
   context "basics" do
     it 'should allow anyone to view the comments index' do
       get :index
@@ -37,7 +41,7 @@ RSpec.describe CommentsController, type: :controller do
 
     it 'should not email track owner if comment is spam' do
       login(:arthur)
-      # the "viagra-test-123" guarantees a spam response
+      akismet_stub_response_spam
       params = { :comment => { "body" => "viagra-test-123", "private" => 1, "commentable_type" => "Asset", "commentable_id" => 4 }, "user_id" => users(:sudara).login, "track_id" => assets(:valid_mp3).permalink }
       expect do
          post :create, params: params, xhr: true
@@ -51,7 +55,7 @@ RSpec.describe CommentsController, type: :controller do
     end
 
     it "should not increment comment_count if comment is spam" do
-      # the "viagra-test-123" guarantees a spam response
+      akismet_stub_response_spam
       params = { :comment => { "body" => "viagra-test-123", "private" => 1, "commentable_type" => "Asset", "commentable_id" => 4 }, "user_id" => users(:sudara).login, "track_id" => assets(:valid_mp3).permalink }
       post :create, params: params, xhr: true
       expect(Asset.find(1).comments_count).to eq(0)

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -6,6 +6,7 @@ ENV['RAILS_ENV'] ||= 'test'
 require File.expand_path('../config/environment', __dir__)
 
 require 'rspec/rails'
+require 'capybara/rspec'
 require 'selenium/webdriver'
 
 # The suite needs to be able to connect to localhost for feature specs. Percy
@@ -33,6 +34,9 @@ Capybara.register_driver(:headless_chrome) do |app|
   )
 end
 Capybara.javascript_driver = :headless_chrome
+# Configure the HTTP server to be silent. Note that Capybara would figure out
+# to use Puma on its own if we remove this line.
+Capybara.server = :puma, { Silent: true }
 
 # Set default resolutions for visual regression testing.
 Percy.config.default_widths = [375, 1280]

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -8,6 +8,9 @@ require File.expand_path('../config/environment', __dir__)
 require 'rspec/rails'
 require 'selenium/webdriver'
 
+# The suite needs to be able to connect to localhost for feature specs.
+WebMock.disable_net_connect!(allow_localhost: true)
+
 # Reloads schema.rb when database has pending migrations.
 ActiveRecord::Migration.maintain_test_schema!
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -8,8 +8,13 @@ require File.expand_path('../config/environment', __dir__)
 require 'rspec/rails'
 require 'selenium/webdriver'
 
-# The suite needs to be able to connect to localhost for feature specs.
-WebMock.disable_net_connect!(allow_localhost: true)
+# The suite needs to be able to connect to localhost for feature specs. Percy
+# sends its build response out of the test process so it also needs to connect
+# to its API.
+WebMock.disable_net_connect!(
+  allow_localhost: true,
+  allow: 'percy.io'
+)
 
 # Reloads schema.rb when database has pending migrations.
 ActiveRecord::Migration.maintain_test_schema!

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -55,6 +55,7 @@ RSpec.configure do |config|
   config.include ActiveSupport::Testing::TimeHelpers
   config.include Authlogic::TestCase, type: :controller
   config.include Authlogic::TestCase, type: :request
+  config.include RSpec::Support::AkismetHelpers
   config.include RSpec::Support::LittleHelpers
   config.include RSpec::Support::Logging
   config.include RSpec::Support::LoginHelpers

--- a/spec/request/admin/assets_controller_spec.rb
+++ b/spec/request/admin/assets_controller_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe Admin::AssetsController, type: :request do
     let(:track) { assets(:valid_mp3) }
 
     it "should mark asset as spam" do
+      akismet_stub_submit_spam
       expect(track.is_spam).to eq(false)
       put "/admin/assets/#{track.id}/spam"
       track.reload
@@ -25,6 +26,7 @@ RSpec.describe Admin::AssetsController, type: :request do
     let(:track) { assets(:spam_track) }
 
     it "should unspam the comment" do
+      akismet_stub_submit_ham
       put unspam_admin_asset_path(track.id)
       expect(track.reload.is_spam).to eq(false)
     end
@@ -41,6 +43,7 @@ RSpec.describe Admin::AssetsController, type: :request do
     let(:track3) { assets(:spam_track) }
 
     it "should mark all assets as spam" do
+      akismet_stub_submit_spam
       put mark_group_as_spam_admin_assets_path, params: { mark_spam_by: { user_id: 1 } }
 
       expect(track1.is_spam).to eq(true)

--- a/spec/request/admin/comments_controller_spec.rb
+++ b/spec/request/admin/comments_controller_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe Admin::CommentsController, type: :request do
     let(:comment) { comments(:valid_comment_on_asset_by_guest) }
 
     it "should mark comments as spam" do
+      akismet_stub_submit_spam
       expect(comment.is_spam).to eq(false)
       put "/admin/comments/#{comment.id}/spam"
       comment.reload
@@ -25,6 +26,7 @@ RSpec.describe Admin::CommentsController, type: :request do
     let(:comment) { comments(:public_spam_comment_on_asset_by_user) }
 
     it "should unspam the comment" do
+      akismet_stub_submit_ham
       put unspam_admin_comment_path(comment.id)
       expect(comment.reload.is_spam).to eq(false)
     end
@@ -35,6 +37,7 @@ RSpec.describe Admin::CommentsController, type: :request do
     end
 
     it "should send notification" do
+      akismet_stub_submit_ham
       expect do
         put unspam_admin_comment_path(comment.id)
       end.to change { ActionMailer::Base.deliveries.size }.by(1)
@@ -47,6 +50,8 @@ RSpec.describe Admin::CommentsController, type: :request do
     let(:comment3) { comments(:public_comment_on_asset_by_user) }
 
     it "should mark all comments as spam" do
+      akismet_stub_submit_spam
+
       put mark_group_as_spam_admin_comments_path, params: { mark_spam_by: { remote_ip: '127.0.0.2' } }
 
       expect(comment1.is_spam).to eq(true)
@@ -60,6 +65,8 @@ RSpec.describe Admin::CommentsController, type: :request do
     end
 
     it "should alow mass update by other attributes (like user_id)" do
+      akismet_stub_submit_spam
+
       put mark_group_as_spam_admin_comments_path, params: { mark_spam_by: { user_id: comment1.user_id } }
       expect(comment1.reload.is_spam).to eq(true)
       expect(comment3.reload.is_spam).to eq(true)

--- a/spec/request/assets_controller_spec.rb
+++ b/spec/request/assets_controller_spec.rb
@@ -169,8 +169,28 @@ RSpec.describe AssetsController, type: :request do
   end
 
   context '#create' do
+    let(:mp3_asset_url) do
+      'https://example.com/muppets.mp3'
+    end
+    let(:zip_asset_url) do
+      'https://example.com/1valid-1invalid.zip'
+    end
+
     before do
       create_user_session(users(:arthur))
+
+      stub_request(:get, mp3_asset_url).and_return(
+        body: Rails.root.join('spec/fixtures/assets/muppets.mp3').open(
+          encoding: 'binary'
+        ),
+        headers: { 'Content-Type' => 'audio/mpeg' }
+      )
+      stub_request(:get, zip_asset_url).and_return(
+        body: Rails.root.join('spec/fixtures/assets/1valid-1invalid.zip').open(
+          encoding: 'binary'
+        ),
+        headers: { 'Content-Type' => 'application/zip' }
+      )
     end
 
     it 'should successfully upload an mp3' do
@@ -209,13 +229,13 @@ RSpec.describe AssetsController, type: :request do
 
     it "should allow an mp3 upload from an url" do
       expect {
-        post '/arthur/tracks', params: { asset_data: ["https://github.com/sudara/alonetone/raw/master/spec/fixtures/assets/muppets.mp3"] }
+        post '/arthur/tracks', params: { asset_data: [mp3_asset_url] }
       }.to change { Asset.count }.by(1)
     end
 
-    it "should allow a zip upload from an url" do
+    it "should allow a zip upload from tan url" do
       expect {
-        post '/arthur/tracks', params: { asset_data: ["https://github.com/sudara/alonetone/raw/master/spec/fixtures/assets/1valid-1invalid.zip"] }
+        post '/arthur/tracks', params: { asset_data: [zip_asset_url] }
       }.to change { Asset.count }.by(1)
     end
   end

--- a/spec/request/assets_controller_spec.rb
+++ b/spec/request/assets_controller_spec.rb
@@ -1,6 +1,10 @@
 require "rails_helper"
 
 RSpec.describe AssetsController, type: :request do
+  before do
+    akismet_stub_response_ham
+  end
+
   context "#latest" do
     it "should render the home page" do
       get '/'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'webmock/rspec'
+
 RSpec.configure do |config|
   # The following three options will be default in RSpec 4.
   config.expect_with :rspec do |expectations|

--- a/spec/support/akismet_helpers.rb
+++ b/spec/support/akismet_helpers.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module RSpec
+  module Support
+    # WebMock helpers to quickly stub an Akismet response.
+    module AkismetHelpers
+      def akismet_url_expression(path)
+        %r{https://\w+.rest.akismet.com/1.1/#{path}}
+      end
+
+      def akismet_stub_response_ham
+        stub_request(
+          :post, akismet_url_expression('comment-check')
+        ).and_return(
+          body: 'false'
+        )
+      end
+
+      def akismet_stub_response_spam
+        stub_request(
+          :post, akismet_url_expression('comment-check')
+        ).and_return(
+          body: 'true'
+        )
+      end
+
+      def akismet_stub_submit_ham
+        stub_request(:post, akismet_url_expression('submit-ham'))
+      end
+
+      def akismet_stub_submit_spam
+        stub_request(:post, akismet_url_expression('submit-spam'))
+      end
+    end
+  end
+end


### PR DESCRIPTION
* Adds helper methods with stubs for Askimet. We might want to consider a mock client in the future.
* Adds stubs for creating assets over HTTP.
* Configures Capybara to boot silently.