### PR TITLE
Do not show comments by the same ip on main page

### DIFF
--- a/app/controllers/assets_controller.rb
+++ b/app/controllers/assets_controller.rb
@@ -271,7 +271,7 @@ class AssetsController < ApplicationController
     @favorites = Track.favorites_for_home
     @popular = Asset.published.order('hotness DESC').includes(user: :pic).limit(5)
     @playlists = white_theme_enabled? ? Playlist.for_home.limit(4) : Playlist.for_home.limit(5)
-    @comments = admin? ? Comment.last_5_private : Comment.to_other_members.last_5_public
+    @comments = admin? ? Comment.last_5_private : Comment.to_other_members.not_my_ip.last_5_public
     @followee_tracks = current_user.new_tracks_from_followees(5) if user_has_tracks_from_followees?
   end
 

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -10,6 +10,7 @@ class Comment < ActiveRecord::Base
   scope :last_5_public,      -> { on_track.only_public.limit(5).preload(commenter: :pic, commentable: { user: :pic }) }
   scope :made_between,       ->(start, finish) { where('comments.created_at BETWEEN ? AND ?', start, finish) }
   scope :to_other_members,   -> { where("commenter_id != user_id") }
+  scope :not_my_ip,          -> { joins(:commenter).where("users.current_login_ip != remote_ip") }
 
   has_many :replies, as: :commentable, class_name: 'Comment'
 


### PR DESCRIPTION
Add a check for commenter's ip to make sure it does not match comment's ip.

Fixes#369