### PR TITLE
BugFix: `undefined method `follows_user_ids' for nil:NilClass`

### DIFF
--- a/app/controllers/assets_controller.rb
+++ b/app/controllers/assets_controller.rb
@@ -79,9 +79,9 @@ class AssetsController < ApplicationController
   def radio
     params[:source] = (params[:source] || cookies[:radio] || 'latest')
     @channel = params[:source].humanize
-    if !logged_in? && ['those_you_follow', 'songs_you_have_not_heard', 'mangoz_shuffle'].include?(params[:source])
+    if !logged_in? && %w(those_you_follow songs_you_have_not_heard mangoz_shuffle).include?(params[:source])
       flash[:error] = "Sorry. Page you've been looking for is not found."
-      raise ActionController::RoutingError.new('Page Not Found')
+      raise ActionController::RoutingError, 'Page Not Found'
     end
     @page_title = "alonetone Radio: #{@channel}"
     @pagy, @assets = pagy(Asset.radio(params[:source], current_user), items: params[:items])

--- a/app/controllers/assets_controller.rb
+++ b/app/controllers/assets_controller.rb
@@ -79,6 +79,10 @@ class AssetsController < ApplicationController
   def radio
     params[:source] = (params[:source] || cookies[:radio] || 'latest')
     @channel = params[:source].humanize
+    if !logged_in? && ['those_you_follow', 'songs_you_have_not_heard', 'mangoz_shuffle'].include?(params[:source])
+      flash[:error] = "Sorry. Page you've been looking for is not found."
+      raise ActionController::RoutingError.new('Page Not Found')
+    end
     @page_title = "alonetone Radio: #{@channel}"
     @pagy, @assets = pagy(Asset.radio(params[:source], current_user), items: params[:items])
     render 'radio_white' if white_theme_enabled?

--- a/app/models/asset/radio.rb
+++ b/app/models/asset/radio.rb
@@ -32,7 +32,7 @@ class Asset
 
   # random radio, without playing the same track twice in a 24 hour period
   def self.mangoz(user)
-    ids = user.listened_more_than?(10) && user.listened_to_today_ids
+    ids = user&.listened_more_than?(10) && user&.listened_to_today_ids
     random_order.id_not_in(ids)
   end
 

--- a/app/models/asset/radio.rb
+++ b/app/models/asset/radio.rb
@@ -39,7 +39,7 @@ class Asset
   # random radio, sourcing from the user's favorite artists
   def self.from_favorite_artists_of(user)
       id_not_in(user.listened_to_today_ids)
-        .user_id_in(user.most_listened_to_user_ids(10))
+        .user_id_in(user&.most_listened_to_user_ids(10))
         .random_order
   end
 
@@ -49,6 +49,6 @@ class Asset
   end
 
   def self.new_tracks_from_followees(user, limit = DEFAULT_LIMIT)
-    recent.user_id_in(user.follows_user_ids).limit(limit)
+    recent.user_id_in(user&.follows_user_ids).limit(limit)
   end
 end

--- a/app/models/asset/radio.rb
+++ b/app/models/asset/radio.rb
@@ -32,23 +32,23 @@ class Asset
 
   # random radio, without playing the same track twice in a 24 hour period
   def self.mangoz(user)
-    ids = user&.listened_more_than?(10) && user&.listened_to_today_ids
+    ids = user.listened_more_than?(10) && user.listened_to_today_ids
     random_order.id_not_in(ids)
   end
 
   # random radio, sourcing from the user's favorite artists
   def self.from_favorite_artists_of(user)
       id_not_in(user.listened_to_today_ids)
-        .user_id_in(user&.most_listened_to_user_ids(10))
+        .user_id_in(user.most_listened_to_user_ids(10))
         .random_order
   end
 
   # finds all tracks not heard by the logged in user (or just the latest tracks for guests)
   def self.not_heard_by(user)
-    random_order.id_not_in(user&.listened_to_ids)
+    random_order.id_not_in(user.listened_to_ids)
   end
 
   def self.new_tracks_from_followees(user, limit = DEFAULT_LIMIT)
-    recent.user_id_in(user&.follows_user_ids).limit(limit)
+    recent.user_id_in(user.follows_user_ids).limit(limit)
   end
 end

--- a/app/views/assets/latest.html.erb
+++ b/app/views/assets/latest.html.erb
@@ -65,7 +65,7 @@
     </div>
     <div class="footer_box">
       <%= link_to radio_path(items: 40, source: 'those_you_follow'), class: 'view_all', title: 'alonetone radio: those you follow' do %>
-<span>        view all </span><span class="sprites-horizontal-arrow sprites-after-heading"></span>
+        <span> view all </span><span class="sprites-horizontal-arrow sprites-after-heading"></span>
       <% end %>
     </div>
   <% end %>

--- a/app/views/assets/radio_white.html.erb
+++ b/app/views/assets/radio_white.html.erb
@@ -20,8 +20,8 @@
             <li><%= link_to_unless_current 'Kicking ass', radio_source_home_path('popular') %></li>
             <li><%= link_to_unless_current 'Most Favorited', radio_source_home_path('most_favorited') %></li>
             <li><%= link_to_unless_current 'Recently Favorited', radio_source_home_path('favorites') %></li>
-            <% if logged_in? %>
             <li><%= link_to_unless_current 'The "Mangoz Shuffle"', radio_source_home_path('mangoz_shuffle') %></li>
+            <% if logged_in? %>
             <li><%= link_to_unless_current 'From those you follow', radio_source_home_path('those_you_follow') %></li>
             <li><%= link_to_unless_current "Songs you haven't heard", radio_source_home_path('songs_you_have_not_heard') %></li>
             <% end %>

--- a/app/views/assets/radio_white.html.erb
+++ b/app/views/assets/radio_white.html.erb
@@ -20,8 +20,8 @@
             <li><%= link_to_unless_current 'Kicking ass', radio_source_home_path('popular') %></li>
             <li><%= link_to_unless_current 'Most Favorited', radio_source_home_path('most_favorited') %></li>
             <li><%= link_to_unless_current 'Recently Favorited', radio_source_home_path('favorites') %></li>
-            <li><%= link_to_unless_current 'The "Mangoz Shuffle"', radio_source_home_path('mangoz_shuffle') %></li>
             <% if logged_in? %>
+            <li><%= link_to_unless_current 'The "Mangoz Shuffle"', radio_source_home_path('mangoz_shuffle') %></li>
             <li><%= link_to_unless_current 'From those you follow', radio_source_home_path('those_you_follow') %></li>
             <li><%= link_to_unless_current "Songs you haven't heard", radio_source_home_path('songs_you_have_not_heard') %></li>
             <% end %>

--- a/spec/controllers/assets_controller_spec.rb
+++ b/spec/controllers/assets_controller_spec.rb
@@ -27,6 +27,15 @@ RSpec.describe AssetsController, type: :controller do
     end
   end
 
+  context "#radio" do
+    ['those_you_follow', 'songs_you_have_not_heard', 'mangoz_shuffle'].each do |source|
+      it "should raise an error if trying to access #{source} with no current user" do
+        get :radio, params: { source: source }
+        expect(response.status).to eq(404)
+      end
+    end
+  end
+
   context "#mass_edit" do
     it 'should allow user to edit 1 track' do
       login(:arthur)


### PR DESCRIPTION
Add a check if user is present to avoid error. Might want to have better ui if no tracks are available but will do for now. 
Not sure why this happened, except if a user hit url directly.
I confirmed that on white theme this link is hidden and on dark theme it's greyed out.
<img width="889" alt="alonetone_radio__latest" src="https://user-images.githubusercontent.com/2320322/51356760-d3eee000-1a89-11e9-817f-d91815d2c474.png">
<img width="828" alt="alonetone_radio__popular" src="https://user-images.githubusercontent.com/2320322/51356781-e537ec80-1a89-11e9-905b-2ca80597feca.png">

https://app.bugsnag.com/alonetone/alonetone/errors/5c3ec38a682ed9001a787ff1?event_id=5c3ec38a0032e7d49f080000&i=em&m=nw