### PR TITLE
Add `pagy-overflow` to handle Pagy::Overflow exception

### DIFF
--- a/config/initializers/pagy.rb
+++ b/config/initializers/pagy.rb
@@ -1,1 +1,4 @@
+require 'pagy/extras/overflow'
+
 Pagy::VARS[:size] = [1,1,1,1]
+Pagy::VARS[:overflow] = :last_page


### PR DESCRIPTION
Pagy overflow will redirect to the last page rather than throwing an exception
More info:
https://github.com/ddnexus/pagy/blob/master/docs/extras/overflow.md