### PR TITLE
Encoding issue in comments

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -70,19 +70,14 @@ module ApplicationHelper
   end
 
   def markdown(text)
-    begin
+    return "" unless text
 
-      return "" unless text
-
-      text = emojify(text)
-      @@renderer ||= begin
-                       html = Redcarpet::Render::HTML.new(hard_wrap: true, filter_html: true, link_attributes: { rel: "nofollow" })
-                       Redcarpet::Markdown.new(html, autolink: true, no_intraemphasis: true)
-                     end
-        Redcarpet::Render::SmartyPants.render(@@renderer.render(text)).html_safe
-    rescue ActionView::Template::Error
-      binding.pry
-    end
+    text = emojify(text)
+    @@renderer ||= begin
+                     html = Redcarpet::Render::HTML.new(hard_wrap: true, filter_html: true, link_attributes: { rel: "nofollow" })
+                     Redcarpet::Markdown.new(html, autolink: true, no_intraemphasis: true)
+                   end
+    Redcarpet::Render::SmartyPants.render(@@renderer.render(text)).html_safe
   end
 
   def markdown_with_html(text)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -70,14 +70,19 @@ module ApplicationHelper
   end
 
   def markdown(text)
-    return "" unless text
+    begin
 
-    text = emojify(text)
-    @@renderer ||= begin
-                     html = Redcarpet::Render::HTML.new(hard_wrap: true, filter_html: true, link_attributes: { rel: "nofollow" })
-                     Redcarpet::Markdown.new(html, autolink: true, no_intraemphasis: true)
-                   end
-    Redcarpet::Render::SmartyPants.render(@@renderer.render(text)).html_safe
+      return "" unless text
+
+      text = emojify(text)
+      @@renderer ||= begin
+                       html = Redcarpet::Render::HTML.new(hard_wrap: true, filter_html: true, link_attributes: { rel: "nofollow" })
+                       Redcarpet::Markdown.new(html, autolink: true, no_intraemphasis: true)
+                     end
+        Redcarpet::Render::SmartyPants.render(@@renderer.render(text)).html_safe
+    rescue ActionView::Template::Error
+      binding.pry
+    end
   end
 
   def markdown_with_html(text)

--- a/app/views/pages/error.html.erb
+++ b/app/views/pages/error.html.erb
@@ -1,12 +1,9 @@
-
 <div class="box">
-<h2>Uh oh! Alonetone slipped and fell.</h2>
-<% content_for :left do %>
-
-<h2 class="box">What can YOU do to help?</h2>
-<div class="static_content">
-<h3 class="white">We've been notified, but feel free to bring this up in the forums if it keeps happening to you day after day!</h3>
-</h3>
+  <h2>Uh oh! Alonetone slipped and fell.</h2>
+  <% content_for :left do %>
+    <h2 class="box">What can YOU do to help?</h2>
+    <div class="static_content">
+      <h3 class="white">We've been notified, but feel free to bring this up in the forums if it keeps happening to you day after day!</h3>
+    </div>
+  <% end %>
 </div>
-</div>
-<% end %>


### PR DESCRIPTION
This is the comment that seem to be causing all the fuss on Bugsnag:
```
 => #<Comment id: 155203, commentable_type: "Asset", commentable_id: 25453, body: ":\r\nroshanakroshancheragh@yahoo.comسلام لینک آسانسو...", created_at: "2014-10-26 10:38:43", updated_at: "2014-10-26 10:38:43", commenter_id: nil, user_id: 3298, remote_ip: "65.49.68.156", user_agent: "Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/53...", referrer: "http://alonetone.com/behzad900/tracks/vaksy", is_spam: false, private: false, body_html: nil>
2.5.1 :006 > Asset.where(permalink: 'vaksy').first.comments.first.body
  Asset Load (0.5ms)  SELECT  `assets`.* FROM `assets` WHERE `assets`.`permalink` = 'vaksy' ORDER BY `assets`.`id` ASC LIMIT 1
  Comment Load (0.4ms)  SELECT  `comments`.* FROM `comments` WHERE `comments`.`commentable_id` = 25453 AND `comments`.`commentable_type` = 'Asset' ORDER BY `comments`.`id` ASC LIMIT 1
 => ":\r\nroshanakroshancheragh@yahoo.comسلام لینک آسانسور  را می خواهم  خیلی خاصه ایمیلم"
```

But when I try to run `.valid_encoding?` ( i did it from all the comments of that user (https://alonetone.com/behzad900) - they all returned `true`. I couldn't catch exactly where it's happening and how to fix it, but I know it might be happening in [def markdown(text)](https://github.com/sudara/alonetone/blob/master/app/helpers/application_helper.rb#L72-L81).
now that I deleted that comment from local db I can't test it anymore :) I'll get a new copy tomorrow... but I just deleted the body of that comment and it was no longer failing. Up to you @sudara 