### PR TITLE
Check for `asset.present?` before attempting to send notification email

### DIFF
--- a/app/jobs/asset_notification_job.rb
+++ b/app/jobs/asset_notification_job.rb
@@ -1,11 +1,11 @@
-class AssetNotificationJob < ActiveJob::Base
+class AssetNotificationJob < ApplicationJob
   queue_as :mailers
 
   def perform(asset_ids:, user_id:)
-    assets = Asset.where(id: asset_ids)
+    assets = Asset.where(id: asset_ids).to_a
     follower = User.find_by(id: user_id)
 
-    return unless follower&.email
+    return unless follower&.email && assets.present?
     return AssetNotification.upload_notification(assets.first, follower.email).deliver_now if assets.count == 1
     AssetNotification.upload_mass_notification(assets, follower.email).deliver_now
   end

--- a/app/mailers/asset_notification.rb
+++ b/app/mailers/asset_notification.rb
@@ -16,7 +16,7 @@ class AssetNotification < ApplicationMailer
     @unsubscribe_link = unsubscribe_link
     @exclamation = %w[Sweet Yes Oooooh Alright Booya Yum Celebrate OMG].sample
     @upload_user_url = user_link_for(assets.first)
-    mail subject: "[alonetone] '#{@artist.name}' uploaded a new track!", to: follower_email
+    mail subject: "[alonetone] '#{@artist.name}' uploaded new tracks!", to: follower_email
   end
 
   protected

--- a/spec/jobs/asset_notification_job_spec.rb
+++ b/spec/jobs/asset_notification_job_spec.rb
@@ -1,0 +1,56 @@
+require 'rails_helper'
+
+RSpec.describe AssetNotificationJob, type: :job do
+  describe "#upload_notification" do
+
+    subject(:job) { described_class.perform_later( asset_ids: [assets(:valid_mp3).id], user_id: users(:arthur).id ) }
+
+    it "sends a single notification" do
+      perform_enqueued_jobs do
+        expect(AssetNotification).to receive(:upload_notification)
+                                      .with(assets(:valid_mp3), users(:arthur).email)
+                                      .and_call_original
+        job
+      end
+
+      assert_performed_jobs 1
+    end
+  end
+
+  describe "#upload_mass_notification" do
+    subject(:job) { described_class.perform_later( asset_ids: [assets(:valid_mp3_2).id, assets(:valid_mp3).id], user_id: users(:arthur).id ) }
+
+    it "sends a single notification" do
+      perform_enqueued_jobs do
+        expect(AssetNotification).to receive(:upload_mass_notification)
+                                      .with(a_collection_including(assets(:valid_mp3), assets(:valid_mp3_2)), users(:arthur).email)
+                                      .and_call_original
+        job
+      end
+      assert_performed_jobs 1
+    end
+  end
+
+  describe "does not send notification" do
+    subject(:job) { described_class.perform_later( asset_ids: [999999], user_id: users(:arthur).id ) }
+
+    it "when assets not found" do
+      perform_enqueued_jobs do
+        expect(AssetNotification).not_to receive(:upload_mass_notification)
+        expect(AssetNotification).not_to receive(:upload_notification)
+        job
+      end
+      assert_performed_jobs 1
+    end
+
+    it "when follower doesn't have an email" do
+      users(:arthur).email = nil
+      perform_enqueued_jobs do
+        expect(AssetNotification).not_to receive(:upload_mass_notification)
+        expect(AssetNotification).not_to receive(:upload_notification)
+        job
+      end
+      assert_performed_jobs 1
+    end
+  end
+end

--- a/spec/mailers/asset_notification_spec.rb
+++ b/spec/mailers/asset_notification_spec.rb
@@ -18,4 +18,19 @@ RSpec.describe AssetNotification, type: :mailer do
       expect(mail.body).to include("https://#{Rails.configuration.alonetone.hostname}/notifications/unsubscribe")
     end
   end
+
+  describe "mass_upload_notification" do
+    let(:mail) { AssetNotification.upload_mass_notification([assets(:valid_mp3), assets(:valid_arthur_mp3)], users(:sudara).email) }
+
+    it "should render the headers" do
+      expect(mail.subject).to eq("[alonetone] '#{assets(:valid_mp3).user.name}' uploaded new tracks!")
+      expect(mail.to).to eq(["#{users(:sudara).email}"])
+      expect(mail.from).to eq(["#{Rails.configuration.alonetone.email}"])
+    end
+
+    it "includes all titles of songs" do
+      expect(mail.body).to include(assets(:valid_mp3).title)
+      expect(mail.body).to include(assets(:valid_arthur_mp3).title)
+    end
+  end
 end


### PR DESCRIPTION
If a user deletes a new asset within 10 minutes of its creation, notification mailer will error when trying to look for it.
- [x] Add an extra check for `asset.present?`
- [x] Add better test coverage 

https://app.bugsnag.com/alonetone/alonetone/errors/5c6c1be864f039001838a01e?event_id=5c6c1cc10035a795c5920000&i=sk&m=fq&pivot_tab=event