### PR TITLE
Don't configure global mailer URL options and fix constant confusion

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -16,9 +16,9 @@ module Alonetone
     # Load config/alonetone.yml and rescue when it's not there so the setup
     # tasks work.
     begin
-      config.alonetone = Configurable.new(Rails.env.to_s, config_for(:alonetone))
+      config.alonetone = ::Configurable.new(Rails.env.to_s, config_for(:alonetone))
     rescue RuntimeError
-      config.alonetone = Configurable.new(Rails.env.to_s, {})
+      config.alonetone = ::Configurable.new(Rails.env.to_s, {})
     end
 
     config.load_defaults 5.2

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -28,7 +28,6 @@ Rails.application.configure do
 
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false
-  config.action_mailer.default_url_options = { host: "localhost:3000" }
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -31,7 +31,6 @@ Rails.application.configure do
 
   config.action_mailer.perform_caching = false
   config.action_mailer.delivery_method = :postmark
-  config.action_mailer.default_url_options = { :host => "alonetone.com" }
   config.action_mailer.postmark_settings = { api_token: config_for(:alonetone)['postmark_api_token'] }
 
   config.active_job.queue_adapter = :sidekiq

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -30,7 +30,6 @@ Rails.application.configure do
   # Disable request forgery protection in test environment.
   config.action_controller.allow_forgery_protection = false
   config.action_mailer.perform_caching = false
-  config.action_mailer.default_url_options = { :host => "test.host" }
 
   # Tell Action Mailer not to deliver emails to the real world.
   # The :test delivery method accumulates sent emails in the

--- a/spec/lib/configurable_spec.rb
+++ b/spec/lib/configurable_spec.rb
@@ -3,26 +3,26 @@
 require 'spec_helper'
 require 'configurable'
 
-RSpec.describe Configurable do
+RSpec.describe ::Configurable do
   let(:hostname) { 'alonetone.example.com' }
 
   it "initializes" do
     expect do
-      configurable = Configurable.new('test', hostname: hostname)
+      configurable = ::Configurable.new('test', hostname: hostname)
       expect(configurable.hostname).to eq(hostname)
     end.to_not output.to_stdout
   end
 
   it "rewrites deprecated configuration keys" do
     expect do
-      configurable = Configurable.new('test', url: hostname)
+      configurable = ::Configurable.new('test', url: hostname)
       expect(configurable.hostname).to eq(hostname)
     end.to output.to_stdout
   end
 
   it "prints deprecated configuration keys" do
     expect do
-      configurable = Configurable.new('development', url: hostname, unknown: 1)
+      configurable = ::Configurable.new('development', url: hostname, unknown: 1)
     end.to output(
       "[!] Please apply the following changes to `config/alonetone.yml' in development:\n\n" \
       " * Remove unknown\n" \


### PR DESCRIPTION
Remove default URL options for the mailer from all environment configuration because it is now handled by the `ApplicationMailer`.

Prefix `Configurable` because there is also a similar class in the `Rails` module.