### PR TITLE
Generate no waveform for audio files we can't process

### DIFF
--- a/app/models/waveform.rb
+++ b/app/models/waveform.rb
@@ -1,6 +1,8 @@
 # Generates a list of RMS-like amplitudes which can be used to render a
 # waveform for an MP3.
 module Waveform
+  LENGTH = 500
+
   class Reduction
     attr_reader :sound
     attr_reader :slice_size
@@ -19,7 +21,7 @@ module Waveform
       while signal = read
         rms = 0.0
         for frame in signal
-          rms += (mono? ? frame : frame.sum) ** 2
+          rms += (mono? ? frame : frame.sum)**2
         end
         samples << Math.sqrt(rms).round
       end
@@ -32,7 +34,7 @@ module Waveform
 
     def info=(info)
       @mono = info.channels == 1
-      @slice_size = (info.frames / 500.0).ceil
+      @slice_size = (info.frames / Waveform::LENGTH.to_f).ceil
     end
 
     def read

--- a/app/models/waveform.rb
+++ b/app/models/waveform.rb
@@ -1,46 +1,50 @@
+# Generates a list of RMS-like amplitudes which can be used to render a
+# waveform for an MP3.
 module Waveform
   def self.extract(file)
-    tmp = Tempfile.new(['resampled-upload', '.wav'])
+    Tempfile.open(['resampled-upload', '.wav']) do |tempfile|
+      reduce_file(tempfile) if resample(file, tempfile)
+    end
+  end
 
-    # resample the mp3 down to 8KHz to make it more manageable
+  # Resample the source MP3 down to 8KHz to make it more manageable.
+  def self.resample(file, tempfile)
     system(
       'lame',
       '--quiet',
       '--mp3input',
       '--resample', '8',
       '--decode', Shellwords.shellescape(file),
-      Shellwords.shellescape(tmp.path)
+      Shellwords.shellescape(tempfile.path),
+      out: File::NULL, err: File::NULL
     )
+  end
 
-    # lame can only downsample to 8KHz, but that's still
-    # way too high so we do a second resampling here
-    # computing a RMS-like quantity over 500 slices
+  def self.reduce_file(tempfile)
+    RubyAudio::Sound.open(tempfile.path) { |sound| reduce(sound) }
+  rescue RubyAudio::Error
+  end
+
+  # Compute RMS-like values to reduce the number of slices to less than 500.
+  def self.reduce(sound)
     waveform = []
-    input = RubyAudio::Sound.open(tmp.path)
-    begin
-      rms = 0.0
-      rms_size = islice = 0
-      slice_size = input.info.frames / 500
-      is_mono = input.info.channels == 1
-      until (signal = input.read(:int, 300)).real_size.zero?
-        signal.each do |frame|
-          mono = is_mono ? frame : frame.sum
-          rms += mono * mono
-        end
-
-        rms_size += signal.real_size
-        next unless rms_size > slice_size
-
-        waveform << Math.sqrt(rms).round
-        rms = 0.0
-        rms_size = 0
+    rms = 0.0
+    rms_size = islice = 0
+    slice_size = sound.info.frames / 500
+    is_mono = sound.info.channels == 1
+    until (signal = sound.read(:int, 300)).real_size.zero?
+      signal.each do |frame|
+        mono = is_mono ? frame : frame.sum
+        rms += mono * mono
       end
-      waveform << Math.sqrt(rms)
-    ensure
-      input.close
-      tmp.close!
-    end
 
-    waveform
+      rms_size += signal.real_size
+      next unless rms_size > slice_size
+
+      waveform << Math.sqrt(rms).round
+      rms = 0.0
+      rms_size = 0
+    end
+    waveform << Math.sqrt(rms)
   end
 end

--- a/app/models/waveform.rb
+++ b/app/models/waveform.rb
@@ -1,14 +1,54 @@
 # Generates a list of RMS-like amplitudes which can be used to render a
 # waveform for an MP3.
 module Waveform
+  class Reduction
+    attr_reader :sound
+    attr_reader :slice_size
+
+    def initialize(sound)
+      @sound = sound
+      self.info = sound.info
+    end
+
+    def mono?
+      @mono
+    end
+
+    def samples
+      samples = []
+      while signal = read
+        rms = 0.0
+        for frame in signal
+          rms += (mono? ? frame : frame.sum) ** 2
+        end
+        samples << Math.sqrt(rms).round
+      end
+      samples
+    end
+
+    private
+
+    attr_reader :signal
+
+    def info=(info)
+      @mono = info.channels == 1
+      @slice_size = (info.frames / 500.0).ceil
+    end
+
+    def read
+      signal = sound.read(:int, slice_size)
+      signal.real_size == 0 ? nil : signal
+    end
+  end
+
   def self.extract(file)
     Tempfile.open(['resampled-upload', '.wav']) do |tempfile|
-      reduce_file(tempfile) if resample(file, tempfile)
+      reduce_file(tempfile) if decode_resample(file, tempfile)
     end
   end
 
   # Resample the source MP3 down to 8KHz to make it more manageable.
-  def self.resample(file, tempfile)
+  def self.decode_resample(file, tempfile)
     system(
       'lame',
       '--quiet',
@@ -25,26 +65,8 @@ module Waveform
   rescue RubyAudio::Error
   end
 
-  # Compute RMS-like values to reduce the number of slices to less than 500.
+  # Compute RMS-like values to reduce the number of aplitudes to 500.
   def self.reduce(sound)
-    waveform = []
-    rms = 0.0
-    rms_size = islice = 0
-    slice_size = sound.info.frames / 500
-    is_mono = sound.info.channels == 1
-    until (signal = sound.read(:int, 300)).real_size.zero?
-      signal.each do |frame|
-        mono = is_mono ? frame : frame.sum
-        rms += mono * mono
-      end
-
-      rms_size += signal.real_size
-      next unless rms_size > slice_size
-
-      waveform << Math.sqrt(rms).round
-      rms = 0.0
-      rms_size = 0
-    end
-    waveform << Math.sqrt(rms)
+    Waveform::Reduction.new(sound).samples
   end
 end

--- a/spec/models/waveform_spec.rb
+++ b/spec/models/waveform_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Waveform do
     it 'generates RMS samples' do
       data = Waveform.extract(path)
       expect(data).to_not be_empty
-      expect(data.length).to eq(500)
+      expect(data.length).to be_within(1).of(500)
       data.each { |sample| expect(sample).to be_kind_of(Numeric) }
     end
   end

--- a/spec/models/waveform_spec.rb
+++ b/spec/models/waveform_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Waveform do
     it 'generates RMS samples' do
       data = Waveform.extract(path)
       expect(data).to_not be_empty
-      expect(data.length).to be < 500
+      expect(data.length).to eq(500)
       data.each { |sample| expect(sample).to be_kind_of(Numeric) }
     end
   end

--- a/spec/models/waveform_spec.rb
+++ b/spec/models/waveform_spec.rb
@@ -3,9 +3,36 @@
 require 'rails_helper'
 
 RSpec.describe Waveform do
-  it 'processes a file on disk without raising errors' do
-    data = Waveform.extract(file_fixture_pathname('muppets.mp3').to_s)
-    expect(data).to_not be_empty
-    data.each { |sample| expect(sample).to be_kind_of(Numeric) }
+  context 'operating on an audio file' do
+    let(:path) do
+      file_fixture_pathname('muppets.mp3').to_s
+    end
+
+    it 'generates RMS samples' do
+      data = Waveform.extract(path)
+      expect(data).to_not be_empty
+      expect(data.length).to be < 500
+      data.each { |sample| expect(sample).to be_kind_of(Numeric) }
+    end
+  end
+
+  context 'operating on an empty audio file' do
+    let(:path) do
+      file_fixture_pathname('empty.mp3').to_s
+    end
+
+    it 'generates no data' do
+      expect(Waveform.extract(path)).to be_nil
+    end
+  end
+
+  context 'operating on a non-audio file' do
+    let(:path) do
+      file_fixture_pathname('smallest.zip').to_s
+    end
+
+    it 'generates no data' do
+      expect(Waveform.extract(path)).to be_nil
+    end
   end
 end


### PR DESCRIPTION
Tested locally and it still generated waveforms for valid files. I can't actually get a file uploaded that triggers this issue, but that might happen through ZIP file uploads.

<img width="734" alt="Screen Shot 2019-03-12 at 14 28 43" src="https://user-images.githubusercontent.com/1195/54203775-2c16f100-44d3-11e9-985c-abab44a27b14.png">
