### PR TITLE
Deal with warnings on Rails 6

### DIFF
--- a/app/models/track.rb
+++ b/app/models/track.rb
@@ -32,8 +32,9 @@ class Track < ActiveRecord::Base
   end
 
   def ensure_playlist_if_favorite
-    self.playlist_id = Playlist.favorites.where(user_id: user_id).first_or_create.id if is_favorite?
-    true
+    return unless is_favorite?
+
+    self.playlist = Playlist.favorites.where(user_id: user_id).first_or_initialize
   end
 end
 

--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -114,7 +114,7 @@ RSpec.describe Asset, type: :model do
     end
 
     it 'should handle umlauts and non english characters in the filename' do
-      filename = 'müppets.mp3'.mb_chars.normalize
+      filename = 'müppets.mp3'.unicode_normalize(:nfc)
       asset = file_fixture_asset(
         'muppets.mp3',
         filename: filename,

--- a/spec/models/track_spec.rb
+++ b/spec/models/track_spec.rb
@@ -14,12 +14,23 @@ RSpec.describe Track, type: :model do
   end
 
   context "as a fav" do
-    subject { users(:arthur).tracks.favorites.create(asset: assets(:valid_mp3)) }
+    let(:user) { users(:will_studd) }
+
     it "should create a favorite playlist if its the first fav" do
-      expect { subject }.to change { Track.count }
+      expect(user.playlists.favorites.count).to eq(0)
+      expect do
+        user.tracks.favorites.create(asset: assets(:henri_willig_finest_cheese))
+      end.to change(Track, :count).by(+1)
+      expect(user.playlists.favorites.count).to eq(1)
     end
 
     it 'should use an existing favorites playlist' do
+      expect(user.playlists.favorites.count).to eq(0)
+      expect do
+        user.tracks.favorites.create(asset: assets(:henri_willig_finest_cheese))
+        user.tracks.favorites.create(asset: assets(:henri_willig_the_goat))
+      end.to change(Track, :count).by(+2)
+      expect(user.playlists.favorites.count).to eq(1)
     end
   end
 end


### PR DESCRIPTION
Playlists are built instead of created when favoriting so they aren't saved in case of a validation error. This fixed a deprecation warning when trying to create a favorite through User.

Change call to `mb_chars.normalize` in asset spec and choose composed form because we're mostly interested in creating a normalized string regardless of how editors save the spec source.