### PR TITLE
Implement upload metadata processing for uploads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@
 /public/source_files
 /public/system
 /stats.json
+/storage
 /vendor/bundle
 /yarn-debug.log*
 /yarn-error.log

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -45,7 +45,7 @@ class Asset < ApplicationRecord
                   user_role: proc { role },
                   comment_type: 'mp3-post' # this can't be "mp3", it calls paperclip
 
-  validates_presence_of :user_id
+  validates :user, presence: true
 
   def self.latest(limit = 10)
     includes(user: :pic).limit(limit).order('assets.id DESC')

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -34,8 +34,7 @@ class Asset < ApplicationRecord
     source: :user,
     through: :tracks
 
-  has_permalink :name, true
-  before_update :generate_permalink!, if: :title_changed?
+  before_save :ensure_unique_permalink, if: :permalink_changed?
   after_commit :create_waveform, on: :create
 
   include Rakismet::Model
@@ -47,12 +46,6 @@ class Asset < ApplicationRecord
                   comment_type: 'mp3-post' # this can't be "mp3", it calls paperclip
 
   validates_presence_of :user_id
-
-  # override has_permalink method to ensure we don't get empty permas
-  def generate_permalink!
-    self.permalink = fix_duplication(normalize(send(generate_from)))
-    self.permalink = fix_duplication("untitled") unless permalink.present?
-  end
 
   def self.latest(limit = 10)
     includes(user: :pic).limit(limit).order('assets.id DESC')
@@ -83,12 +76,21 @@ class Asset < ApplicationRecord
     object_id
   end
 
+  def title=(title)
+    super
+    rename
+  end
+
+  def mp3_file_name=(mp3_file_name)
+    super
+    rename
+  end
+
   # make sure the title is there, and if not, the filename is used...
   def name
     return title.strip if title.present?
 
-    name = File.basename(mp3_file_name.to_s, '.*').humanize
-    name.blank? ? 'untitled' : name
+    basename.humanize.presence || 'untitled'
   end
 
   def first_playlist
@@ -164,6 +166,27 @@ class Asset < ApplicationRecord
     else
       'user'
     end
+  end
+
+  private
+
+  include HasPermalink::InstanceMethods
+
+  # Required when calling fix_duplication.
+  def auto_fix_duplication
+    true
+  end
+
+  def rename
+    self.permalink = normalize(name).presence || 'untitled'
+  end
+
+  def ensure_unique_permalink
+    self.permalink = fix_duplication(permalink)
+  end
+
+  def basename
+    File.basename(mp3_file_name.to_s, '.*')
   end
 end
 

--- a/app/models/asset/uploading.rb
+++ b/app/models/asset/uploading.rb
@@ -21,8 +21,8 @@ class Asset
   validates_attachment_content_type :mp3, content_type: ['audio/mpeg', 'audio/mp3', 'audio/x-mp3'], message: " was wrong, this doesn't look like an Mp3..."
 
   def self.parse_external_url(url)
-    url.gsub!('dl=0', 'dl=1') # make dropbox links easier to work with
-    URI.parse(url)
+    # make dropbox links easier to work with
+    URI.parse(url.gsub('dl=0', 'dl=1'))
   end
 
   def self.extract_mp3s(zip_file)

--- a/app/models/upload/metadata.rb
+++ b/app/models/upload/metadata.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+class Upload
+  # Helper class to extract metadata from an MP3 file.
+  class Metadata
+    ATTRIBUTE_TO_ID3_TAG_NAME = {
+      album: 'album',
+      artist: 'artist',
+      bitrate: 'bitrate',
+      length: 'length',
+      samplerate: 'samplerate',
+      title: 'title',
+      id3_track_num: 'tracknum',
+      genre: 'genre_s'
+    }.freeze
+
+    attr_reader :file
+
+    def initialize(file)
+      @file = file
+    end
+
+    def attributes
+      @attributes ||= extract_attributes
+    end
+
+    def self.sanitize_encoding(value)
+      if value.respond_to?(:encode)
+        value.encode(
+          'UTF-8', invalid: :replace, undef: :replace, replace: "\ufffd"
+        ).unicode_normalize(:nfkc)
+      else
+        value
+      end
+    end
+
+    private
+
+    def extract_attributes
+      Mp3Info.open(file.path) do |info|
+        ATTRIBUTE_TO_ID3_TAG_NAME.each_with_object({}) do |(name, tag_name), attributes|
+          value = info.respond_to?(tag_name) ? info.public_send(tag_name) : info.tag[tag_name]
+          attributes[name] = self.class.sanitize_encoding(value)
+        end.compact
+      end
+    rescue Mp3InfoError
+      {}
+    end
+  end
+end

--- a/app/models/upload/mp3_file.rb
+++ b/app/models/upload/mp3_file.rb
@@ -15,6 +15,9 @@ class Upload
     # file.
     attr_accessor :filename
 
+    # Content-type of the posted data if known.
+    attr_accessor :content_type
+
     # The user who originate the upload.
     attr_accessor :user
 
@@ -33,7 +36,7 @@ class Upload
 
     def process
       reset
-      @assets << Asset.new(asset_attributes.merge(user: user, mp3: file, mp3_file_name: filename))
+      @assets << Asset.new(combined_attributes)
       valid?
     end
 
@@ -45,6 +48,23 @@ class Upload
       mp3_file = new(attributes)
       mp3_file.process
       mp3_file
+    end
+
+    private
+
+    def metadata
+      @metadata ||= Upload::Metadata.new(file)
+    end
+
+    def combined_attributes
+      asset_attributes
+        .merge(metadata.attributes)
+        .merge({
+          user: user,
+          mp3: file,
+          mp3_file_name: filename,
+          mp3_content_type: content_type
+        }.compact)
     end
   end
 end

--- a/greenfield/app/models/greenfield/attached_asset.rb
+++ b/greenfield/app/models/greenfield/attached_asset.rb
@@ -31,9 +31,5 @@ module Greenfield
     def length
       Asset.formatted_time(self[:length])
     end
-
-    # This stuff is stubbed for compatibility with Mp3PaperclipProcessor
-    attr_accessor :title
-    def generate_permalink!; end
   end
 end

--- a/lib/paperclip_processors/mp3_paperclip_processor.rb
+++ b/lib/paperclip_processors/mp3_paperclip_processor.rb
@@ -19,7 +19,6 @@ module Paperclip
 
     def make
       process_id3_tags
-      attachment.instance.generate_permalink!
       File.open(@file.path, 'r', encoding: 'binary')
     end
 

--- a/spec/fixtures/active_storage/attachments.yml
+++ b/spec/fixtures/active_storage/attachments.yml
@@ -1,73 +1,80 @@
 # Attachments for all asset fixtures
 valid_mp3_original:
-  name: original
+  name: audio_file
   record: valid_mp3 (Asset)
   blob: valid_mp3_original
   created_at: <%= 10.years.ago %>
 valid_zip_original:
-  name: original
+  name: audio_file
   record: valid_zip (Asset)
   blob: valid_zip_original
   created_at: 2007-04-08 13:00:03
 invalid_file_original:
-  name: original
+  name: audio_file
   record: invalid_file (Asset)
   blob: invalid_file_original
   created_at: <%= 1.day.ago.to_s :db %>
 valid_arthur_mp3_original:
-  name: original
+  name: audio_file
   record: valid_arthur_mp3 (Asset)
   blob: valid_arthur_mp3_original
   created_at: 2007-04-08 13:00:03
 too_big_file_original:
-  name: original
+  name: audio_file
   record: too_big_file (Asset)
   blob: too_big_file_original
   created_at: 2007-04-08 13:00:03
 valid_mp3_2_original:
-  name: original
+  name: audio_file
   record: valid_mp3_2 (Asset)
   blob: valid_mp3_2_original
   created_at: 2007-04-08 13:00:03
 private_track_original:
-  name: original
+  name: audio_file
   record: private_track (Asset)
   blob: private_track_original
   created_at: 2007-04-08 13:00:03
 spam_track_original:
-  name: original
+  name: audio_file
   record: spam_track (Asset)
   blob: spam_track_original
   created_at: 2007-04-08 13:00:03
 
 will_studd_rockfort_combalou_original:
-  name: original
+  name: audio_file
   record: will_studd_rockfort_combalou (Asset)
   blob: will_studd_rockfort_combalou_original
   created_at: <%= 3.months.ago %>
 will_studd_rockfort_white_wild_tangy_original:
-  name: original
+  name: audio_file
   record: will_studd_rockfort_white_wild_tangy (Asset)
   blob: will_studd_rockfort_white_wild_tangy_original
   created_at: <%= 3.months.ago %>
 will_studd_magnificent_lacaune_original:
-  name: original
+  name: audio_file
   record: will_studd_magnificent_lacaune (Asset)
   blob: will_studd_magnificent_lacaune_original
   created_at: <%= 3.months.ago %>
 will_studd_appellation_controlee_original:
-  name: original
+  name: audio_file
   record: will_studd_appellation_controlee (Asset)
   blob: will_studd_appellation_controlee_original
   created_at: <%= 2.months.ago %>
 
 henri_willig_finest_cheese_original:
-  name: original
+  name: audio_file
   record: henri_willig_finest_cheese (Asset)
   blob: henri_willig_finest_cheese_original
   created_at: <%= 1.month.ago %>
 henri_willig_the_goat_original:
-  name: original
+  name: audio_file
   record: henri_willig_the_goat (Asset)
   blob: henri_willig_the_goat_original
   created_at: <%= 1.month.ago %>
+
+# Attachments for all playlist fixtures.
+will_studd_rockfort_cover:
+  name: cover_image
+  record: will_studd_rockfort (Playlist)
+  blob: will_studd_rockfort_cover
+  created_at: <%= 2.months.ago %>

--- a/spec/fixtures/active_storage/blobs.yml
+++ b/spec/fixtures/active_storage/blobs.yml
@@ -76,7 +76,7 @@ will_studd_rockfort_combalou_original:
   created_at: <%= 3.months.ago %>
 will_studd_rockfort_white_wild_tangy_original:
   key: <%= ActiveStorage::Blob.generate_unique_secure_token %>
-  filename:  Untitled Copy 2 premix.mp3
+  filename: Untitled Copy 2 premix.mp3
   content_type: audio/mpeg
   metadata: {}
   byte_size: <%= 2.8.megabytes %>
@@ -84,7 +84,7 @@ will_studd_rockfort_white_wild_tangy_original:
   created_at: <%= 3.months.ago %>
 will_studd_magnificent_lacaune_original:
   key: <%= ActiveStorage::Blob.generate_unique_secure_token %>
-  filename:  mixs for will 3.mp3
+  filename: mixs for will 3.mp3
   content_type: audio/mpeg
   metadata: {}
   byte_size: <%= 4.5.megabytes %>
@@ -92,7 +92,7 @@ will_studd_magnificent_lacaune_original:
   created_at: <%= 3.months.ago %>
 will_studd_appellation_controlee_original:
   key: <%= ActiveStorage::Blob.generate_unique_secure_token %>
-  filename:  4.mp3
+  filename: 4.mp3
   content_type: audio/mpeg
   metadata: {}
   byte_size: <%= 2.4.megabytes %>
@@ -101,7 +101,7 @@ will_studd_appellation_controlee_original:
 
 henri_willig_finest_cheese_original:
   key: <%= ActiveStorage::Blob.generate_unique_secure_token %>
-  filename:  track-1.mp3
+  filename: track-1.mp3
   content_type: audio/mpeg
   metadata: {}
   byte_size: <%= 1.3.megabytes %>
@@ -109,9 +109,19 @@ henri_willig_finest_cheese_original:
   created_at: <%= 1.month.ago %>
 henri_willig_the_goat_original:
   key: <%= ActiveStorage::Blob.generate_unique_secure_token %>
-  filename:  track-2.mp3
+  filename: track-2.mp3
   content_type: audio/mpeg
   metadata: {}
   byte_size: <%= 2.3.megabytes %>
   checksum: <%= Digest::MD5.base64digest('OK!') %>
   created_at: <%= 1.month.ago %>
+
+# Blobs for all playlist fixtures
+will_studd_rockfort_cover:
+  key: <%= ActiveStorage::Blob.generate_unique_secure_token %>
+  filename: cover.jpg
+  content_type: image/jpeg
+  metadata: {}
+  byte_size: <%= 200.kilobytes %>
+  checksum: <%= Digest::MD5.base64digest('OK!') %>
+  created_at: <%= 2.months.ago %>

--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -1,7 +1,9 @@
-require "rails_helper"
+# frozen_string_literal: true
+
+require 'rails_helper'
 
 RSpec.describe Asset, type: :model do
-  it 'supports characters outside of the in the title' do
+  it "supports characters outside of the basic multilingual plane in the title" do
     expect(Asset.new(title: '👍').title).to eq('👍')
   end
 
@@ -35,9 +37,9 @@ RSpec.describe Asset, type: :model do
     end
 
     it "should catch empty or bogus files" do
-      asset = file_fixture_asset('empty.mp3', content_type: 'audio/mpeg')
-      expect(asset).to be_new_record
-      expect(asset.errors).to be_present
+      expect do
+        file_fixture_asset('empty.mp3', content_type: 'audio/mpeg')
+      end.to raise_error(ArgumentError)
     end
 
     it "should increase the user's count" do

--- a/spec/models/upload/metadata_spec.rb
+++ b/spec/models/upload/metadata_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Upload::Metadata, type: :model do
+  let(:metadata) do
+    Upload::Metadata.new(file_fixture_tempfile(filename))
+  end
+
+  context 'valid MP3 with ID3 tags' do
+    let(:filename) { 'piano.mp3' }
+
+    it 'returns all attributes' do
+      expect(metadata.attributes).to eq(
+        album: 'Polderkaas',
+        artist: 'Henri Willig',
+        bitrate: 64,
+        genre: 'Rock',
+        id3_track_num: 2,
+        length: 4.51925,
+        samplerate: 44100,
+        title: 'Piano'
+      )
+    end
+  end
+
+  context 'valid MP3 with ID3 tags with completely broken character encoding' do
+    let(:filename) { 'japanese-characters.mp3' }
+
+    it 'returns all attributes' do
+      expect(metadata.attributes).to eq(
+        album: 'Îa°®×öμÄÉμÊÂ'.unicode_normalize(:nfc),
+        artist: ' ́÷°®Áá'.unicode_normalize(:nfc),
+        bitrate: 192,
+        genre: '(13)Pop',
+        id3_track_num: 1,
+        length: 277.78608333333335,
+        samplerate: 44100,
+        title: '01-¶ÔμÄÈË'.unicode_normalize(:nfc)
+      )
+    end
+  end
+
+  context 'valid MP3 without ID3 tags' do
+    let(:filename) { 'emptytags.mp3' }
+
+    it 'returns all attributes' do
+      expect(metadata.attributes).to eq(
+        bitrate: 128,
+        length: 213.451875,
+        samplerate: 44100
+      )
+    end
+  end
+
+  context 'empty file' do
+    let(:filename) { 'empty.mp3' }
+
+    it 'does not return attributes' do
+      expect(metadata.attributes).to be_empty
+    end
+  end
+
+  context 'not an MP3' do
+    let(:filename) { 'smallest.zip' }
+
+    it 'does not return attributes' do
+      expect(metadata.attributes).to be_empty
+    end
+  end
+end

--- a/spec/support/file_fixture_helpers.rb
+++ b/spec/support/file_fixture_helpers.rb
@@ -27,10 +27,25 @@ module RSpec
       end
 
       def file_fixture_asset(path, filename: nil, content_type: nil, user: nil)
-        Asset.create(
-          user: user || users(:sudara),
-          mp3: file_fixture_uploaded_file(path, filename: filename, content_type: content_type)
+        asset = process_file_fixture_uploaded_file(
+          path, filename: filename, content_type: content_type, user: user
         )
+        raise(
+          ArgumentError,
+          "Can't process file fixture at `#{file_fixture_pathname(path).to_s}'"
+        ) if asset.nil?
+        asset
+      end
+
+      private
+
+      def process_file_fixture_uploaded_file(path, filename: nil, content_type: nil, user: nil)
+        Upload.process(
+          user: user || users(:sudara),
+          files: [
+            file_fixture_uploaded_file(path, filename: filename, content_type: content_type)
+          ]
+        ).assets.first
       end
     end
   end


### PR DESCRIPTION
Implement the final plumbing we need to process uploads with the `Upload` class instead of relying on Paperclip.

Ham-fisted refactor for dealing with the permalink logic in Asset. I think we should discuss slugs and permalinks at some point and implement this in a more readable way.