### PR TITLE
Add column to playlists to track low quality covers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@
 /public/source_files
 /public/system
 /stats.json
+/storage
 /vendor/bundle
 /yarn-debug.log*
 /yarn-error.log

--- a/app/helpers/playlists_helper.rb
+++ b/app/helpers/playlists_helper.rb
@@ -17,22 +17,12 @@ module PlaylistsHelper
     content_tag(:div, '', class: 'no_pic')
   end
 
-  # Returns true when the Pic with this ID does not have a greenfield variant.
-  def no_greenfield_variant?(pic_id)
-    (69806..72848).cover?(pic_id)
-  end
-
-  # Returns true when the Pic with this ID does not have a greenfield nor an original variant.
-  def no_greenfield_and_original_variant?(pic_id)
-    pic_id < 69807
-  end
-
   # Returns a different variant when the Pic with the supplied ID does not have the variant.
-  def downgrade_variant(pic_id, variant:)
-    if no_greenfield_and_original_variant?(pic_id)
+  def downgrade_variant(playlist, variant:)
+    if playlist.ancient_cover_quality?
       downgrade_ancient_variant(variant: variant)
-    elsif no_greenfield_variant?(pic_id)
-      downgrade_old_variant(variant: variant)
+    elsif playlist.legacy_cover_quality?
+      downgrade_legacy_variant(variant: variant)
     else
       variant
     end
@@ -41,7 +31,7 @@ module PlaylistsHelper
   # Returns a URL to the playlist's cover or nil when there is no cover.
   def playlist_cover_url(playlist, variant:)
     if playlist.cover_image_present?
-      variant = downgrade_variant(playlist.pic.id, variant: variant)
+      variant = downgrade_variant(playlist, variant: variant)
       playlist.cover_url(variant: variant)
     end
   end
@@ -130,7 +120,7 @@ module PlaylistsHelper
     %i[greenfield original].include?(variant) ? :album : variant
   end
 
-  def downgrade_old_variant(variant:)
+  def downgrade_legacy_variant(variant:)
     variant == :greenfield ? :original : variant
   end
 end

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -45,7 +45,7 @@ class Asset < ApplicationRecord
                   user_role: proc { role },
                   comment_type: 'mp3-post' # this can't be "mp3", it calls paperclip
 
-  validates_presence_of :user_id
+  validates :user, presence: true
 
   def self.latest(limit = 10)
     includes(user: :pic).limit(limit).order('assets.id DESC')

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -34,8 +34,7 @@ class Asset < ApplicationRecord
     source: :user,
     through: :tracks
 
-  has_permalink :name, true
-  before_update :generate_permalink!, if: :title_changed?
+  before_save :ensure_unique_permalink, if: :permalink_changed?
   after_commit :create_waveform, on: :create
 
   include Rakismet::Model
@@ -47,12 +46,6 @@ class Asset < ApplicationRecord
                   comment_type: 'mp3-post' # this can't be "mp3", it calls paperclip
 
   validates_presence_of :user_id
-
-  # override has_permalink method to ensure we don't get empty permas
-  def generate_permalink!
-    self.permalink = fix_duplication(normalize(send(generate_from)))
-    self.permalink = fix_duplication("untitled") unless permalink.present?
-  end
 
   def self.latest(limit = 10)
     includes(user: :pic).limit(limit).order('assets.id DESC')
@@ -83,12 +76,21 @@ class Asset < ApplicationRecord
     object_id
   end
 
+  def title=(title)
+    super
+    rename
+  end
+
+  def mp3_file_name=(mp3_file_name)
+    super
+    rename
+  end
+
   # make sure the title is there, and if not, the filename is used...
   def name
     return title.strip if title.present?
 
-    name = File.basename(mp3_file_name.to_s, '.*').humanize
-    name.blank? ? 'untitled' : name
+    basename.humanize.presence || 'untitled'
   end
 
   def first_playlist
@@ -164,6 +166,27 @@ class Asset < ApplicationRecord
     else
       'user'
     end
+  end
+
+  private
+
+  include HasPermalink::InstanceMethods
+
+  # Required when calling fix_duplication.
+  def auto_fix_duplication
+    true
+  end
+
+  def rename
+    self.permalink = normalize(name).presence || 'untitled'
+  end
+
+  def ensure_unique_permalink
+    self.permalink = fix_duplication(permalink)
+  end
+
+  def basename
+    File.basename(mp3_file_name.to_s, '.*')
   end
 end
 

--- a/app/models/asset/uploading.rb
+++ b/app/models/asset/uploading.rb
@@ -21,8 +21,8 @@ class Asset
   validates_attachment_content_type :mp3, content_type: ['audio/mpeg', 'audio/mp3', 'audio/x-mp3'], message: " was wrong, this doesn't look like an Mp3..."
 
   def self.parse_external_url(url)
-    url.gsub!('dl=0', 'dl=1') # make dropbox links easier to work with
-    URI.parse(url)
+    # make dropbox links easier to work with
+    URI.parse(url.gsub('dl=0', 'dl=1'))
   end
 
   def self.extract_mp3s(zip_file)

--- a/app/models/playlist.rb
+++ b/app/models/playlist.rb
@@ -33,6 +33,15 @@ class Playlist < ActiveRecord::Base
   before_update :set_mix_or_album, :check_for_new_permalink, :ensure_private_if_less_than_two_tracks,
     :set_published_at, :notify_followers_if_publishing_album
 
+  enum(
+    cover_quality: {
+      ancient: 0,
+      legacy: 1,
+      modern: 2
+    },
+    _suffix: true
+  )
+
   def to_param
     permalink.to_s
   end
@@ -133,28 +142,29 @@ end
 #
 # Table name: playlists
 #
-#  id           :integer          not null, primary key
-#  credits      :text(4294967295)
-#  description  :text(4294967295)
-#  has_details  :boolean          default(FALSE)
-#  image        :string(255)
-#  is_favorite  :boolean          default(FALSE)
-#  is_mix       :boolean
-#  link1        :string(255)
-#  link2        :string(255)
-#  link3        :string(255)
-#  permalink    :string(255)
-#  position     :integer          default(1)
-#  private      :boolean
-#  published_at :datetime
-#  theme        :string(255)
-#  title        :string(255)
-#  tracks_count :integer          default(0)
-#  year         :string(255)
-#  created_at   :datetime
-#  updated_at   :datetime
-#  pic_id       :integer
-#  user_id      :integer
+#  id            :integer          not null, primary key
+#  cover_quality :integer          default("modern")
+#  credits       :text(4294967295)
+#  description   :text(4294967295)
+#  has_details   :boolean          default(FALSE)
+#  image         :string(255)
+#  is_favorite   :boolean          default(FALSE)
+#  is_mix        :boolean
+#  link1         :string(255)
+#  link2         :string(255)
+#  link3         :string(255)
+#  permalink     :string(255)
+#  position      :integer          default(1)
+#  private       :boolean
+#  published_at  :datetime
+#  theme         :string(255)
+#  title         :string(255)
+#  tracks_count  :integer          default(0)
+#  year          :string(255)
+#  created_at    :datetime
+#  updated_at    :datetime
+#  pic_id        :integer
+#  user_id       :integer
 #
 # Indexes
 #

--- a/app/models/upload/metadata.rb
+++ b/app/models/upload/metadata.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+class Upload
+  # Helper class to extract metadata from an MP3 file.
+  class Metadata
+    ATTRIBUTE_TO_ID3_TAG_NAME = {
+      album: 'album',
+      artist: 'artist',
+      bitrate: 'bitrate',
+      length: 'length',
+      samplerate: 'samplerate',
+      title: 'title',
+      id3_track_num: 'tracknum',
+      genre: 'genre_s'
+    }.freeze
+
+    attr_reader :file
+
+    def initialize(file)
+      @file = file
+    end
+
+    def attributes
+      @attributes ||= extract_attributes
+    end
+
+    def self.sanitize_encoding(value)
+      if value.respond_to?(:encode)
+        value.encode(
+          'UTF-8', invalid: :replace, undef: :replace, replace: "\ufffd"
+        ).unicode_normalize(:nfkc)
+      else
+        value
+      end
+    end
+
+    private
+
+    def extract_attributes
+      Mp3Info.open(file.path) do |info|
+        ATTRIBUTE_TO_ID3_TAG_NAME.each_with_object({}) do |(name, tag_name), attributes|
+          value = info.respond_to?(tag_name) ? info.public_send(tag_name) : info.tag[tag_name]
+          attributes[name] = self.class.sanitize_encoding(value)
+        end.compact
+      end
+    rescue Mp3InfoError
+      {}
+    end
+  end
+end

--- a/app/models/upload/mp3_file.rb
+++ b/app/models/upload/mp3_file.rb
@@ -15,6 +15,9 @@ class Upload
     # file.
     attr_accessor :filename
 
+    # Content-type of the posted data if known.
+    attr_accessor :content_type
+
     # The user who originate the upload.
     attr_accessor :user
 
@@ -33,7 +36,7 @@ class Upload
 
     def process
       reset
-      @assets << Asset.new(asset_attributes.merge(user: user, mp3: file, mp3_file_name: filename))
+      @assets << Asset.new(combined_attributes)
       valid?
     end
 
@@ -45,6 +48,23 @@ class Upload
       mp3_file = new(attributes)
       mp3_file.process
       mp3_file
+    end
+
+    private
+
+    def metadata
+      @metadata ||= Upload::Metadata.new(file)
+    end
+
+    def combined_attributes
+      asset_attributes
+        .merge(metadata.attributes)
+        .merge({
+          user: user,
+          mp3: file,
+          mp3_file_name: filename,
+          mp3_content_type: content_type
+        }.compact)
     end
   end
 end

--- a/db/migrate/20190313133104_add_cover_quality_to_playlists.rb
+++ b/db/migrate/20190313133104_add_cover_quality_to_playlists.rb
@@ -1,0 +1,5 @@
+class AddCoverQualityToPlaylists < ActiveRecord::Migration[5.2]
+  def change
+    add_column :playlists, :cover_quality, :integer, default: 2
+  end
+end

--- a/db/migrate/20190313134953_downgrade_cover_quality_for_older_playlists.rb
+++ b/db/migrate/20190313134953_downgrade_cover_quality_for_older_playlists.rb
@@ -1,0 +1,6 @@
+class DowngradeCoverQualityForOlderPlaylists < ActiveRecord::Migration[5.2]
+  def change
+    Playlist.where(pic_id: 0..69807).update(cover_quality: :ancient)
+    Playlist.where(pic_id: 69806..72848).update(cover_quality: :legacy)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_03_13_121546) do
+ActiveRecord::Schema.define(version: 2019_03_13_134953) do
 
   create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
@@ -252,6 +252,7 @@ ActiveRecord::Schema.define(version: 2019_03_13_121546) do
     t.boolean "has_details", default: false
     t.string "theme"
     t.datetime "published_at"
+    t.integer "cover_quality", default: 2
     t.index ["permalink"], name: "index_playlists_on_permalink"
     t.index ["position"], name: "index_playlists_on_position"
     t.index ["user_id"], name: "index_playlists_on_user_id"

--- a/greenfield/app/models/greenfield/attached_asset.rb
+++ b/greenfield/app/models/greenfield/attached_asset.rb
@@ -31,9 +31,5 @@ module Greenfield
     def length
       Asset.formatted_time(self[:length])
     end
-
-    # This stuff is stubbed for compatibility with Mp3PaperclipProcessor
-    attr_accessor :title
-    def generate_permalink!; end
   end
 end

--- a/lib/paperclip_processors/mp3_paperclip_processor.rb
+++ b/lib/paperclip_processors/mp3_paperclip_processor.rb
@@ -19,7 +19,6 @@ module Paperclip
 
     def make
       process_id3_tags
-      attachment.instance.generate_permalink!
       File.open(@file.path, 'r', encoding: 'binary')
     end
 

--- a/spec/fixtures/active_storage/attachments.yml
+++ b/spec/fixtures/active_storage/attachments.yml
@@ -1,73 +1,80 @@
 # Attachments for all asset fixtures
 valid_mp3_original:
-  name: original
+  name: audio_file
   record: valid_mp3 (Asset)
   blob: valid_mp3_original
   created_at: <%= 10.years.ago %>
 valid_zip_original:
-  name: original
+  name: audio_file
   record: valid_zip (Asset)
   blob: valid_zip_original
   created_at: 2007-04-08 13:00:03
 invalid_file_original:
-  name: original
+  name: audio_file
   record: invalid_file (Asset)
   blob: invalid_file_original
   created_at: <%= 1.day.ago.to_s :db %>
 valid_arthur_mp3_original:
-  name: original
+  name: audio_file
   record: valid_arthur_mp3 (Asset)
   blob: valid_arthur_mp3_original
   created_at: 2007-04-08 13:00:03
 too_big_file_original:
-  name: original
+  name: audio_file
   record: too_big_file (Asset)
   blob: too_big_file_original
   created_at: 2007-04-08 13:00:03
 valid_mp3_2_original:
-  name: original
+  name: audio_file
   record: valid_mp3_2 (Asset)
   blob: valid_mp3_2_original
   created_at: 2007-04-08 13:00:03
 private_track_original:
-  name: original
+  name: audio_file
   record: private_track (Asset)
   blob: private_track_original
   created_at: 2007-04-08 13:00:03
 spam_track_original:
-  name: original
+  name: audio_file
   record: spam_track (Asset)
   blob: spam_track_original
   created_at: 2007-04-08 13:00:03
 
 will_studd_rockfort_combalou_original:
-  name: original
+  name: audio_file
   record: will_studd_rockfort_combalou (Asset)
   blob: will_studd_rockfort_combalou_original
   created_at: <%= 3.months.ago %>
 will_studd_rockfort_white_wild_tangy_original:
-  name: original
+  name: audio_file
   record: will_studd_rockfort_white_wild_tangy (Asset)
   blob: will_studd_rockfort_white_wild_tangy_original
   created_at: <%= 3.months.ago %>
 will_studd_magnificent_lacaune_original:
-  name: original
+  name: audio_file
   record: will_studd_magnificent_lacaune (Asset)
   blob: will_studd_magnificent_lacaune_original
   created_at: <%= 3.months.ago %>
 will_studd_appellation_controlee_original:
-  name: original
+  name: audio_file
   record: will_studd_appellation_controlee (Asset)
   blob: will_studd_appellation_controlee_original
   created_at: <%= 2.months.ago %>
 
 henri_willig_finest_cheese_original:
-  name: original
+  name: audio_file
   record: henri_willig_finest_cheese (Asset)
   blob: henri_willig_finest_cheese_original
   created_at: <%= 1.month.ago %>
 henri_willig_the_goat_original:
-  name: original
+  name: audio_file
   record: henri_willig_the_goat (Asset)
   blob: henri_willig_the_goat_original
   created_at: <%= 1.month.ago %>
+
+# Attachments for all playlist fixtures.
+will_studd_rockfort_cover:
+  name: cover_image
+  record: will_studd_rockfort (Playlist)
+  blob: will_studd_rockfort_cover
+  created_at: <%= 2.months.ago %>

--- a/spec/fixtures/active_storage/blobs.yml
+++ b/spec/fixtures/active_storage/blobs.yml
@@ -76,7 +76,7 @@ will_studd_rockfort_combalou_original:
   created_at: <%= 3.months.ago %>
 will_studd_rockfort_white_wild_tangy_original:
   key: <%= ActiveStorage::Blob.generate_unique_secure_token %>
-  filename:  Untitled Copy 2 premix.mp3
+  filename: Untitled Copy 2 premix.mp3
   content_type: audio/mpeg
   metadata: {}
   byte_size: <%= 2.8.megabytes %>
@@ -84,7 +84,7 @@ will_studd_rockfort_white_wild_tangy_original:
   created_at: <%= 3.months.ago %>
 will_studd_magnificent_lacaune_original:
   key: <%= ActiveStorage::Blob.generate_unique_secure_token %>
-  filename:  mixs for will 3.mp3
+  filename: mixs for will 3.mp3
   content_type: audio/mpeg
   metadata: {}
   byte_size: <%= 4.5.megabytes %>
@@ -92,7 +92,7 @@ will_studd_magnificent_lacaune_original:
   created_at: <%= 3.months.ago %>
 will_studd_appellation_controlee_original:
   key: <%= ActiveStorage::Blob.generate_unique_secure_token %>
-  filename:  4.mp3
+  filename: 4.mp3
   content_type: audio/mpeg
   metadata: {}
   byte_size: <%= 2.4.megabytes %>
@@ -101,7 +101,7 @@ will_studd_appellation_controlee_original:
 
 henri_willig_finest_cheese_original:
   key: <%= ActiveStorage::Blob.generate_unique_secure_token %>
-  filename:  track-1.mp3
+  filename: track-1.mp3
   content_type: audio/mpeg
   metadata: {}
   byte_size: <%= 1.3.megabytes %>
@@ -109,9 +109,19 @@ henri_willig_finest_cheese_original:
   created_at: <%= 1.month.ago %>
 henri_willig_the_goat_original:
   key: <%= ActiveStorage::Blob.generate_unique_secure_token %>
-  filename:  track-2.mp3
+  filename: track-2.mp3
   content_type: audio/mpeg
   metadata: {}
   byte_size: <%= 2.3.megabytes %>
   checksum: <%= Digest::MD5.base64digest('OK!') %>
   created_at: <%= 1.month.ago %>
+
+# Blobs for all playlist fixtures
+will_studd_rockfort_cover:
+  key: <%= ActiveStorage::Blob.generate_unique_secure_token %>
+  filename: cover.jpg
+  content_type: image/jpeg
+  metadata: {}
+  byte_size: <%= 200.kilobytes %>
+  checksum: <%= Digest::MD5.base64digest('OK!') %>
+  created_at: <%= 2.months.ago %>

--- a/spec/fixtures/playlists.yml
+++ b/spec/fixtures/playlists.yml
@@ -4,6 +4,7 @@ owp:
   permalink: owp
   title: obsessed with progression
   tracks_count: 3
+  cover_quality: modern
   description: sudara's album
   created_at: <%= 1.day.ago.to_s :db %>
 
@@ -11,6 +12,7 @@ empty:
   user: sudara
   permalink: empty-playlist
   title: Empty Playlist
+  cover_quality: modern
   description: something coming
   created_at: <%= 1.day.ago.to_s :db %>
 
@@ -19,6 +21,7 @@ arthurs_playlist:
   user: arthur
   permalink: arthurs-playlist
   title: Arthur's Playlist
+  cover_quality: modern
   description: arthurs playlist
   private: false
   created_at: <%= 1.day.ago.to_s :db %>
@@ -29,6 +32,7 @@ mix:
   permalink: mix-tape
   title: mix tape
   tracks_count: 3
+  cover_quality: modern
   description: "a mix tape, daring and wonderful"
   created_at: <%= 1.day.ago.to_s :db %>
 
@@ -37,6 +41,7 @@ arthurs_favorites:
   is_favorite: true
   permalink: arthurs-favorites
   title: Arthur's favorites
+  cover_quality: modern
   description: arthur's favorites
   tracks_count: 1
   user: arthur
@@ -48,6 +53,7 @@ will_studd_rockfort:
   permalink: rockfort
   title: Rockfort
   tracks_count: 3
+  cover_quality: modern
   description: >
     Roquefort (US: /ˈroʊkfərt/ or UK: /rɒkˈfɔːr/; French: [ʁɔkfɔʁ]; Occitan: ròcafòrt [ˌrɔkɔˈfɔɾt])
     is a sheep milk cheese from the south of France. Rockfort is Will's award winning musical
@@ -59,6 +65,7 @@ henri_willig_polderkaas:
   permalink: polderkaas
   title: Polderkaas
   tracks_count: 2
+  cover_quality: modern
   description: >
     Polderkaas is a distinctive cheese brand by Henri Willig. The album has the same creamy
     goodness as they cheese it was named after.
@@ -69,6 +76,18 @@ william_shatners_favorites:
   is_favorite: true
   permalink: bills-favorites
   title: Bill's favorites
+  cover_quality: ancient
   description: What I like to listen to when I'm eating cheese in the captain's chair.
   tracks_count: 1
   user: william_shatner
+
+# Jamie added all her favorite tracks to a playlist.
+jamie_kiesl_loves:
+  is_mix: true
+  is_favorite: true
+  permalink: jamie-loves
+  title: Jamie Loves
+  cover_quality: legacy
+  description: Did I mention that I'm really good at naming cheeses really quickly?
+  tracks_count: 1
+  user: jamie_kiesl

--- a/spec/fixtures/tracks.yml
+++ b/spec/fixtures/tracks.yml
@@ -86,3 +86,11 @@ william_shatners_favorites_1:
   asset: henri_willig_finest_cheese
   position: 1
   created_at: <%= 2.days.ago %>
+
+# Jamie's loves.
+jamie_kiesl_loves_1:
+  playlist: jamie_kiesl_loves
+  user: jamie_kiesl
+  asset: henri_willig_finest_cheese
+  position: 1
+  created_at: <%= 1.day.ago %>

--- a/spec/helpers/playlists_helper_spec.rb
+++ b/spec/helpers/playlists_helper_spec.rb
@@ -1,79 +1,82 @@
 # frozen_string_literal: true
 
-require "rails_helper"
+require 'rails_helper'
 
 RSpec.describe PlaylistsHelper, type: :helper do
   def white_theme_enabled?
     @white_theme_enable
   end
 
-  it "generates a div which is filled by the JavaScript with generated cover" do
+  it 'generates a div which is filled by the JavaScript with generated cover' do
     element = playlist_cover_div
     expect(element).to match_css('div[class]')
   end
 
-  it "downgrades original variant to album for ancient covers" do
-    [1, 69806].each do |pic_id|
-      expect(
-        downgrade_variant(pic_id, variant: :original)
-      ).to eq(:album)
-    end
-  end
-
-  it "downgrades greenfield variant to album for ancient covers" do
-    [1, 69806].each do |pic_id|
-      expect(
-        downgrade_variant(pic_id, variant: :greenfield)
-      ).to eq(:album)
-    end
-  end
-
-  it "does not downgrade album variant for ancient covers" do
-    expect(downgrade_variant(1, variant: :album)).to eq(:album)
-  end
-
-  it "downgrades greenfield variant to original for old covers" do
-    [69807, 72848].each do |pic_id|
-      expect(
-        downgrade_variant(pic_id, variant: :greenfield)
-      ).to eq(:original)
-    end
-  end
-
-  it "does not downgrade original variant for old covers" do
-    expect(downgrade_variant(69807, variant: :original)).to eq(:original)
-  end
-
-  it "does not downgrade variants for current covers" do
-    [72849, 3452345345].each do |pic_id|
-      expect(
-        downgrade_variant(pic_id, variant: :greenfield)
-      ).to eq(:greenfield)
-    end
-  end
-
-  it "returns a default dark cover URL" do
-    [:small, :large, :album, :greenfield].each do |variant|
+  it 'returns a default dark cover URL' do
+    %i[small large album greenfield].each do |variant|
       url = dark_default_cover_url(variant: variant)
       expect(url).to start_with('/images/default/no-cover')
       expect(url).to end_with('.jpg')
     end
   end
 
-  context "playlist with a cover" do
+  context 'playlist with an ancient cover' do
+    let(:playlist) { playlists(:william_shatners_favorites) }
+
+    it 'downgrades greenfield variant to album' do
+      expect(
+        downgrade_variant(playlist, variant: :greenfield)
+      ).to eq(:album)
+    end
+
+    it 'downgrades original variant to album' do
+      expect(
+        downgrade_variant(playlist, variant: :original)
+      ).to eq(:album)
+    end
+
+    it 'does not downgrade album variant' do
+      expect(
+        downgrade_variant(playlist, variant: :album)
+      ).to eq(:album)
+    end
+  end
+
+  context 'playlist with a legacy cover' do
+    let(:playlist) { playlists(:jamie_kiesl_loves) }
+
+    it 'downgrades greenfield variant to original' do
+      expect(
+        downgrade_variant(playlist, variant: :greenfield)
+      ).to eq(:original)
+    end
+
+    it 'does not downgrade original variant' do
+      expect(
+        downgrade_variant(playlist, variant: :original)
+      ).to eq(:original)
+    end
+
+    it 'does not downgrade album variant' do
+      expect(
+        downgrade_variant(playlist, variant: :album)
+      ).to eq(:album)
+    end
+  end
+
+  context 'playlist with a cover' do
     let(:playlist) { playlists(:will_studd_rockfort) }
 
-    it "formats a cover URL" do
-      [:large, :album, :greenfield].each do |variant|
+    it 'formats a cover URL' do
+      %i[large album greenfield].each do |variant|
         url = playlist_cover_url(playlist, variant: variant)
         expect(url).to start_with('/system/pics')
         expect(url).to end_with('.jpg')
       end
     end
 
-    it "downgrades the cover URL for older covers" do
-      # Pretend this is an old pic
-      playlist.pic.id = 1
+    it 'downgrades the cover URL for ancient covers' do
+      playlist.cover_quality = :ancient
 
       url = playlist_cover_url(playlist, variant: :greenfield)
       expect(url).to start_with('/system/pics')
@@ -81,45 +84,45 @@ RSpec.describe PlaylistsHelper, type: :helper do
       expect(url).to include('album')
     end
 
-    it "formats an image element with the cover" do
+    it 'formats an image element with the cover' do
       element = playlist_cover_image(playlist, variant: :greenfield)
       expect(element).to match_css('img[src][alt="Playlist cover"]')
       expect(element).to include(playlist_cover_url(playlist, variant: :greenfield))
     end
 
-    it "formats an image for the cover element" do
+    it 'formats an image for the cover element' do
       element = playlist_cover(playlist, variant: :greenfield)
       expect(element).to match_css('img')
     end
 
-    it "formats a URL to the dark playlist's cover" do
+    it 'formats a URL to the dark playlist cover' do
       expect(
         dark_playlist_cover_url(playlist, variant: :large)
       ).to eq(playlist_cover_url(playlist, variant: :large))
     end
   end
 
-  context "playlist without a cover" do
+  context 'playlist without a cover' do
     let(:playlist) { playlists(:henri_willig_polderkaas) }
 
-    it "does not format a cover URL" do
-      [:large, :album, :greenfield].each do |variant|
+    it 'does not format a cover URL' do
+      %i[large album greenfield].each do |variant|
         expect(playlist_cover_url(playlist, variant: variant)).to be_nil
       end
     end
 
-    it "raises exception when trying to create a cover image" do
+    it 'raises exception when trying to create a cover image' do
       expect do
         playlist_cover_image(playlist, variant: :greenfield)
       end.to raise_error(ArgumentError)
     end
 
-    it "formats a div for the cover element" do
+    it 'formats a div for the cover element' do
       element = playlist_cover(playlist, variant: :greenfield)
       expect(element).to match_css('div')
     end
 
-    it "formats a URL to the dark playlist's default cover" do
+    it 'formats a URL to the dark playlist default cover' do
       expect(
         dark_playlist_cover_url(playlist, variant: :large)
       ).to eq(dark_default_cover_url(variant: :large))

--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -1,7 +1,9 @@
-require "rails_helper"
+# frozen_string_literal: true
+
+require 'rails_helper'
 
 RSpec.describe Asset, type: :model do
-  it 'supports characters outside of the in the title' do
+  it "supports characters outside of the basic multilingual plane in the title" do
     expect(Asset.new(title: '👍').title).to eq('👍')
   end
 
@@ -35,9 +37,9 @@ RSpec.describe Asset, type: :model do
     end
 
     it "should catch empty or bogus files" do
-      asset = file_fixture_asset('empty.mp3', content_type: 'audio/mpeg')
-      expect(asset).to be_new_record
-      expect(asset.errors).to be_present
+      expect do
+        file_fixture_asset('empty.mp3', content_type: 'audio/mpeg')
+      end.to raise_error(ArgumentError)
     end
 
     it "should increase the user's count" do

--- a/spec/models/playlist_spec.rb
+++ b/spec/models/playlist_spec.rb
@@ -53,6 +53,26 @@ RSpec.describe Playlist, type: :model do
     end
   end
 
+  describe 'cover quality' do
+    it 'defaults to modern' do
+      playlist = Playlist.new
+      expect(playlist.cover_quality).to eq('modern')
+      expect(playlist.modern_cover_quality?).to eq(true)
+    end
+
+    it 'can be ancient' do
+      playlist = playlists(:henri_willig_polderkaas)
+      playlist.update(cover_quality: :ancient)
+      expect(playlist.cover_quality).to eq('ancient')
+    end
+
+    it 'can be legacy' do
+      playlist = playlists(:henri_willig_polderkaas)
+      playlist.update(cover_quality: :legacy)
+      expect(playlist.cover_quality).to eq('legacy')
+    end
+  end
+
   describe "generating URLs to their cover" do
     context "with a cover" do
       let(:playlist) { playlists(:will_studd_rockfort) }

--- a/spec/models/upload/metadata_spec.rb
+++ b/spec/models/upload/metadata_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Upload::Metadata, type: :model do
+  let(:metadata) do
+    Upload::Metadata.new(file_fixture_tempfile(filename))
+  end
+
+  context 'valid MP3 with ID3 tags' do
+    let(:filename) { 'piano.mp3' }
+
+    it 'returns all attributes' do
+      expect(metadata.attributes).to eq(
+        album: 'Polderkaas',
+        artist: 'Henri Willig',
+        bitrate: 64,
+        genre: 'Rock',
+        id3_track_num: 2,
+        length: 4.51925,
+        samplerate: 44100,
+        title: 'Piano'
+      )
+    end
+  end
+
+  context 'valid MP3 with ID3 tags with completely broken character encoding' do
+    let(:filename) { 'japanese-characters.mp3' }
+
+    it 'returns all attributes' do
+      expect(metadata.attributes).to eq(
+        album: 'Îa°®×öμÄÉμÊÂ'.unicode_normalize(:nfc),
+        artist: ' ́÷°®Áá'.unicode_normalize(:nfc),
+        bitrate: 192,
+        genre: '(13)Pop',
+        id3_track_num: 1,
+        length: 277.78608333333335,
+        samplerate: 44100,
+        title: '01-¶ÔμÄÈË'.unicode_normalize(:nfc)
+      )
+    end
+  end
+
+  context 'valid MP3 without ID3 tags' do
+    let(:filename) { 'emptytags.mp3' }
+
+    it 'returns all attributes' do
+      expect(metadata.attributes).to eq(
+        bitrate: 128,
+        length: 213.451875,
+        samplerate: 44100
+      )
+    end
+  end
+
+  context 'empty file' do
+    let(:filename) { 'empty.mp3' }
+
+    it 'does not return attributes' do
+      expect(metadata.attributes).to be_empty
+    end
+  end
+
+  context 'not an MP3' do
+    let(:filename) { 'smallest.zip' }
+
+    it 'does not return attributes' do
+      expect(metadata.attributes).to be_empty
+    end
+  end
+end

--- a/spec/request/playlists_controller_spec.rb
+++ b/spec/request/playlists_controller_spec.rb
@@ -20,4 +20,28 @@ RSpec.describe PlaylistsController, type: :request do
       )
     end
   end
+
+  context "a musician" do
+    let(:user) { users(:jamie_kiesl) }
+    before do
+      create_user_session(user)
+    end
+
+    it "creates a new playlist" do
+      post(
+        "/Jamiek/playlists",
+        params: {
+          playlist: {
+            title: '🧀 THE FUNK 🧀',
+            year: '',
+            description: 'Best of Danny de Funk'
+          }
+        }
+      )
+      expect(response).to be_redirect
+      uri = URI.parse(response.headers['Location'])
+      expect(uri.path).to start_with('/Jamiek/playlists')
+      expect(uri.path).to end_with('/edit')
+    end
+  end
 end

--- a/spec/support/file_fixture_helpers.rb
+++ b/spec/support/file_fixture_helpers.rb
@@ -27,10 +27,25 @@ module RSpec
       end
 
       def file_fixture_asset(path, filename: nil, content_type: nil, user: nil)
-        Asset.create(
-          user: user || users(:sudara),
-          mp3: file_fixture_uploaded_file(path, filename: filename, content_type: content_type)
+        asset = process_file_fixture_uploaded_file(
+          path, filename: filename, content_type: content_type, user: user
         )
+        raise(
+          ArgumentError,
+          "Can't process file fixture at `#{file_fixture_pathname(path).to_s}'"
+        ) if asset.nil?
+        asset
+      end
+
+      private
+
+      def process_file_fixture_uploaded_file(path, filename: nil, content_type: nil, user: nil)
+        Upload.process(
+          user: user || users(:sudara),
+          files: [
+            file_fixture_uploaded_file(path, filename: filename, content_type: content_type)
+          ]
+        ).assets.first
       end
     end
   end


### PR DESCRIPTION
Allows us to eventually remove the `pic_id` column currently used by Paperclip backed models when we switch to Active Storage.