### PR TITLE
Add github PR template to help with PR reviews/comments

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,19 @@
+#### What does this PR do?
+
+[Issue](LINK_TO_STORY)
+
+##### Why are we doing this? Any context or related work?
+
+#### Where should a reviewer start?
+
+#### Manual testing steps?
+
+#### Screenshots
+
+---
+
+#### Database changes
+
+#### Deployment instructions
+
+#### New ENV variables


### PR DESCRIPTION
#### What does this PR do?
Adds a github template for PRs. This will be automatically added to every created PR that we can fill up to help with context sharing.
##### Why are we doing this? Any context or related work?
(Original article)[https://andycroll.com/ruby/use-a-pull-request-template/]
#### Where should a reviewer start?

#### Manual testing steps?

#### Screenshots

---

#### Database changes

#### Deployment instructions

#### New ENV variables