### PR TITLE
Configure GitHub sources to use HTTPS and update gems.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,7 @@
 source 'https://rubygems.org'
 
+git_source(:github) { |name| "https://github.com/#{name}.git" }
+
 gem 'rails', '~> 6.0.0.beta3'
 gem 'mysql2'
 gem 'puma'

--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,7 @@ gem 'sometimes'
 gem 'awesome_print', require: 'ap'
 
 # uploading
+gem 'http-2' # used by AWS SDK but not in dependencies
 gem 'aws-sdk-s3'
 gem 'paperclip', '~> 6.0.0'
 gem 'rubyzip'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,13 +1,13 @@
 GIT
-  remote: git://github.com/rails/coffee-rails.git
-  revision: 4cdd5fcc5c8e4b113e693c30f1376ac7d4085b25
+  remote: https://github.com/rails/coffee-rails.git
+  revision: 800d7abbe2fd08776443e444a72fa43de7b7cd64
   specs:
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
-      railties (>= 4.0.0)
+      railties (>= 5.2.0)
 
 GIT
-  remote: git://github.com/sudara/thredded.git
+  remote: https://github.com/sudara/thredded.git
   revision: f6aa8cefbe4ad7d31cb99c6955691d85191495e8
   specs:
     thredded (0.16.9)
@@ -120,17 +120,16 @@ GEM
     awesome_print (1.8.0)
     aws-eventstream (1.0.2)
     aws-partitions (1.144.0)
-    aws-sdk-core (3.47.0)
+    aws-sdk-core (3.48.0)
       aws-eventstream (~> 1.0, >= 1.0.2)
       aws-partitions (~> 1.0)
       aws-sigv4 (~> 1.1)
-      http-2 (~> 0.10)
       jmespath (~> 1.0)
-    aws-sdk-kms (1.14.0)
-      aws-sdk-core (~> 3, >= 3.47.0)
+    aws-sdk-kms (1.15.0)
+      aws-sdk-core (~> 3, >= 3.48.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-s3 (1.32.0)
-      aws-sdk-core (~> 3, >= 3.47.0)
+    aws-sdk-s3 (1.33.0)
+      aws-sdk-core (~> 3, >= 3.48.0)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.0)
     aws-sigv4 (1.1.0)
@@ -142,7 +141,7 @@ GEM
     bugsnag (6.11.1)
       concurrent-ruby (~> 1.0)
     builder (3.2.3)
-    byebug (11.0.0)
+    byebug (11.0.1)
     capybara (3.14.0)
       addressable
       mini_mime (>= 0.1.3)
@@ -193,7 +192,7 @@ GEM
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     crass (1.0.4)
-    dalli (2.7.9)
+    dalli (2.7.10)
     db_text_search (0.3.0)
       activerecord (>= 4.1.15, < 6.0)
     diff-lcs (1.3)
@@ -295,13 +294,13 @@ GEM
     mini_mime (1.0.1)
     mini_portile2 (2.4.0)
     minitest (5.11.3)
-    moneta (1.0.0)
+    moneta (1.1.0)
     multi_json (1.13.1)
     multipart-post (2.0.0)
     mustache (1.1.0)
     mysql2 (0.5.2)
     nenv (0.3.0)
-    newrelic_rpm (6.1.0.352)
+    newrelic_rpm (6.2.0.354)
     nio4r (2.3.1)
     nokogiri (1.10.1)
       mini_portile2 (~> 2.4.0)
@@ -526,7 +525,7 @@ GEM
     xpath (3.2.0)
       nokogiri (~> 1.8)
     yui-compressor (0.12.0)
-    zeitwerk (1.3.4)
+    zeitwerk (1.4.0)
 
 PLATFORMS
   ruby
@@ -552,6 +551,7 @@ DEPENDENCIES
   guard
   guard-rspec
   has_permalink
+  http-2
   invisible_captcha
   jquery-fileupload-rails
   jquery-rails


### PR DESCRIPTION
Changes default GitHub source to use the HTTPS transport instead of the Git protocol. According to Bundler this is more secure, so let's do that.

Adds http-2 as a full dependency because it has been demoted by AWS-SDK as an optional dependency. AWS-SDK will warn about not being able to load the library when it's not there, so let's just help them out by adding it.

Updates Gemfile.lock to newest versions of gems because newer is better.