### PR TITLE
Copies all Paperclip attachments to Active Storage attachments

### DIFF
--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -34,6 +34,8 @@ class Asset < ApplicationRecord
     source: :user,
     through: :tracks
 
+  has_one_attached :audio_file
+
   before_save :ensure_unique_permalink, if: :permalink_changed?
   after_commit :create_waveform, on: :create
 

--- a/app/models/playlist.rb
+++ b/app/models/playlist.rb
@@ -23,6 +23,8 @@ class Playlist < ActiveRecord::Base
   has_many :greenfield_downloads, class_name: '::Greenfield::PlaylistDownload', dependent: :destroy
   accepts_nested_attributes_for :greenfield_downloads
 
+  has_one_attached :cover_image
+
   validates_presence_of :title, :user_id
   validates_length_of   :title, within: 3..100
   validates_length_of   :year, within: 2..4, allow_blank: true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -114,6 +114,8 @@ class User < ActiveRecord::Base
   # will be removed along with /greenfield
   has_many :greenfield_posts, through: :assets
 
+  has_one_attached :avatar_image
+
   # tokens and activation
   def clear_token!
     update_attribute(:perishable_token, nil)

--- a/bin/migrate-storage
+++ b/bin/migrate-storage
@@ -1,0 +1,344 @@
+#!/usr/bin/env ruby
+
+require File.expand_path('../config/environment', __dir__)
+require 'optparse'
+require 'parallel'
+require 'ruby-progressbar'
+
+module Storage
+  class VariantMigration
+    attr_reader :blob
+    attr_reader :variant_name
+    attr_reader :paperclip_attachment
+    attr_reader :storage_attachment
+    attr_reader :options
+
+    def initialize(
+      blob,
+      variant_name:,
+      paperclip_attachment:,
+      storage_attachment:,
+      options:
+    )
+      @blob = blob
+      @variant_name = variant_name
+      @paperclip_attachment = paperclip_attachment
+      @storage_attachment = storage_attachment
+      @options = options
+    end
+
+    def storage_variant
+      storage_attachment.variant(resize_to_limit: resize_to_limit)
+    end
+
+    def original_s3_object
+      @original_s3_object ||= ActiveStorage::Blob.service.send(
+        :object_for, paperclip_attachment.path(variant_name)[1..]
+      )
+    end
+
+    def copy_s3_object
+      @copy_s3_object ||= ActiveStorage::Blob.service.send(
+        :object_for, storage_variant.key
+      )
+    end
+
+    def migrate
+      return if copy_s3_object.exists?
+
+      if original_s3_object.exists?
+        Storage.copy_object(
+          original_s3_object,
+          copy_s3_object,
+          content_type: blob.content_type,
+          options: options
+        )
+      else
+        storage_variant.processed
+      end
+    end
+
+    private
+
+    def resize_to_limit
+      ImageVariant.resize_to_fit(variant_name)
+    end
+  end
+
+  class RecordMigration
+    attr_reader :record
+    attr_reader :storage_attachment_names
+    attr_reader :paperclip_attachment_name
+    attr_reader :options
+
+    def initialize(
+      record,
+      storage_attachment_names:,
+      paperclip_attachment_name:,
+      options:
+    )
+      @record = record
+      @storage_attachment_names = storage_attachment_names
+      @paperclip_attachment_name = paperclip_attachment_name
+      @options = options
+    end
+
+    def storage_record
+      # The Active Storage attachment is not always on the record where the Paperclip attachment
+      # came from.
+      case paperclip_attachment_name
+      when 'pic'
+        record.picable
+      else
+        record
+      end
+    end
+
+    # Returns Paperclip::Attachment
+    def paperclip_attachment
+      @paperclip_attachment ||= record.send(paperclip_attachment_name)
+    end
+
+    def storage_attachment_name
+      storage_attachment_names[storage_record.class]
+    end
+
+    # Returns ActiveStorage attachable
+    def storage_attachment
+      @storage_attachment ||= storage_record.send(storage_attachment_name)
+    end
+
+    def original_filename
+      record.send("#{paperclip_attachment_name}_file_name")
+    end
+
+    def original_byte_size
+      record.send("#{paperclip_attachment_name}_file_size")
+    end
+
+    def original_content_type
+      record.send("#{paperclip_attachment_name}_content_type")
+    end
+
+    def blob
+      @blob ||= ActiveStorage::Blob.new(
+        filename: original_filename,
+        byte_size: original_byte_size,
+        content_type: original_content_type,
+        checksum: checksum
+      )
+    end
+
+    def original_s3_object
+      @original_s3_object ||= ActiveStorage::Blob.service.send(
+        :object_for, paperclip_attachment.path[1..]
+      )
+    end
+
+    def copy_s3_object
+      @copy_s3_object ||= ActiveStorage::Blob.service.send(:object_for, blob.key)
+    end
+
+    def migrate
+      unless storage_attachment.attached?
+        attach_blob
+      end
+      # Copy over all variants in case we are working on a Pic.
+      if paperclip_attachment_name == 'pic'
+        copy_variants
+      end
+    end
+
+    private
+
+    def variant_names
+      ImageVariant::VARIANTS.keys
+    end
+
+    # A MD5 checksum of the file data is required Blob. Unfortunately that means we need to
+    # fetch the entire file from storage so this might take a while for large MP3s.
+    def checksum
+      # For local files this returns an absolute path (e.g. /systems/pics/…) so we need to
+      # differentiate between an actual URL and a local file.
+      url = paperclip_attachment.url
+      if url.start_with?('http')
+        # Unfortunately we need to download the entire object to compute its MD5.
+        Digest::MD5.base64digest(Net::HTTP.get(URI(url)))
+      else
+        Digest::MD5.file(Rails.root.join('public' + url)).base64digest
+      end
+    end
+
+    def attach_blob
+      # Perform copy and Blob creation in a transaction so it rolls back when something goes
+      # wrong.
+      record.class.transaction do
+        Storage.copy_object(
+          original_s3_object,
+          copy_s3_object,
+          content_type: blob.content_type,
+          options: options
+        )
+        storage_attachment = storage_record.send(
+          "build_#{storage_attachment_name}_attachment",
+          name: storage_attachment_name ,
+          blob: blob
+        )
+        unless options.dry_run?
+          # Create Blob and Attachment based on the copied object.
+          storage_attachment.save!
+        end
+      end
+    end
+
+    def copy_variants
+      variant_names.each do |variant_name|
+        Storage::VariantMigration.new(
+          blob,
+          variant_name: variant_name,
+          paperclip_attachment: paperclip_attachment,
+          storage_attachment: storage_attachment,
+          options: options
+        ).migrate
+      end
+    end
+  end
+
+  class Migration
+    attr_reader :model
+    attr_reader :storage_attachment_names
+    attr_reader :options
+
+    def initialize(model, storage_attachment_names:, options:)
+      @model = model
+      @storage_attachment_names = storage_attachment_names
+      @options = options
+    end
+
+    def migrate
+      options.logger.info("Migrate #{model.name} (#{paperclip_attachments_names.to_sentence})")
+      paperclip_attachments_names.each do |paperclip_attachment_name|
+        model.find_in_batches do |batch|
+          Parallel.each(batch) do |record|
+            # Don't re-use the connection from the main thread.
+            ActiveRecord::Base.connection_pool.with_connection do
+              migrate_record(record, paperclip_attachment_name: paperclip_attachment_name)
+              options.progress.increment
+            end
+          end
+        end
+      end
+    end
+
+    private
+
+    FILE_NAME_COLUMN_RE = /(.+)_file_name$/.freeze
+
+    def paperclip_attachments_names
+      model.column_names.map do |column_name|
+        if match = FILE_NAME_COLUMN_RE.match(column_name)
+          match[1]
+        end
+      end.compact
+    end
+
+    def migrate_record(record, paperclip_attachment_name:)
+      Storage::RecordMigration.new(
+        record,
+        storage_attachment_names: storage_attachment_names,
+        paperclip_attachment_name: paperclip_attachment_name,
+        options: options
+      ).migrate
+    end
+  end
+
+  def self.options
+    @options ||= begin
+      options = OpenStruct.new(
+        dry_run: false
+      )
+      def options.dry_run?
+        dry_run
+      end
+      options
+    end
+  end
+
+  # rubocop:disable AbcSize
+  # rubocop:disable Metrics/BlockLength
+  def self.option_parser
+    OptionParser.new do |parser|
+      parser.banner = "Usage: #{$0} [options]"
+
+      parser.separator ""
+      parser.separator "Options:"
+
+      parser.on(
+        "-d", "--dry-run",
+        "Run without changes to S3 and database."
+      ) do
+        options.dry_run = true
+      end
+
+      parser.on_tail("-h", "--help", "Show this message") do
+        options.run = false
+        STDOUT.puts parser
+        exit
+      end
+    end
+  end
+  # rubocop:enable Metrics/BlockLength
+  # rubocop:enable AbcSize
+
+  def self.logger_filename
+    File.expand_path('../log/storage_migration.log', __dir__)
+  end
+
+  def self.migrate(argv, paperclip_models:, storage_attachment_names:)
+    option_parser.parse!(argv)
+
+    FileUtils.mkdir_p(File.dirname(logger_filename))
+    options.logger = Logger.new(logger_filename)
+    options.logger.info("Starting run")
+
+    options.progress = ProgressBar.create(
+      title: 'Migrating',
+      format: '%t |%E | %B',
+      total: paperclip_models.sum { |model| model.count }
+    )
+
+    paperclip_models.each do |model|
+      Storage::Migration.new(
+        model, storage_attachment_names: storage_attachment_names, options: options
+      ).migrate
+    end
+
+    options.progress.finish
+  end
+
+  def self.copy_object(original, copy, content_type:, options:)
+    options.logger.info("COPY #{original.key} TO #{copy.key} (#{content_type})")
+    unless options.dry_run?
+      # Using copy_from to work around a bug in the AWS SDK S3 library. Note that the library
+      # performs all types of network optimizations and retries for us behind the scenes.
+      copy.copy_from(original, content_type: content_type)
+    end
+  end
+end
+
+Storage.migrate(
+  ARGV,
+  paperclip_models: [
+    Pic,
+    Asset,
+    Greenfield::AttachedAsset,
+    Greenfield::PlaylistDownload
+  ],
+  storage_attachment_names: {
+    User => 'avatar_image',
+    Playlist => 'cover_image',
+    Asset => 'audio_file',
+    Greenfield::AttachedAsset => 'audio_file',
+    Greenfield::PlaylistDownload => 'zip_file'
+  }
+)

--- a/greenfield/app/models/greenfield/attached_asset.rb
+++ b/greenfield/app/models/greenfield/attached_asset.rb
@@ -24,6 +24,8 @@ module Greenfield
     validates_attachment_presence :mp3, message: 'must be set. Make sure you chose a file to upload!'
     validates_attachment_content_type :mp3, content_type: ['audio/mpeg', 'audio/mp3'], message: " was wrong. It doesn't look like you uploaded a valid mp3 file. Could you double check?"
 
+    has_one_attached :audio_file
+
     def permalink
       "#{id}-@attachment"
     end

--- a/greenfield/app/models/greenfield/playlist_download.rb
+++ b/greenfield/app/models/greenfield/playlist_download.rb
@@ -22,6 +22,8 @@ module Greenfield
 
     after_validation :destroy_s3_object_if_invalid, on: :create
 
+    has_one_attached :zip_file
+
     def url
       Aws::CF::Signer.sign_url attachment.url, expires: Time.now + 20.minutes
     end


### PR DESCRIPTION
Defines Active Storage attachments for all models with Paperclip attachments. Adds a script to create Active Storage attachments for all existing uploads and copy the S3 objects to the new locations.