### PR TITLE
Explain how to install front-end dependencies

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -120,9 +120,11 @@ Thirdly, fork away on github.
 `git clone REPO_GIT`
 
 - `brew install libsndfile lame` (required for id3 tags and waveforms)
-
+- `brew install yarn` (required for building assets)
 - Install gems
 `bundle install`
+- Install front-end dependencies
+`yarn install --check-files`
 
 - To create needed config, database, and load db/seeds*:
 `rake setup`


### PR DESCRIPTION
I was forced to reinstall my Mac today and I found that `yarn` is never mentioned in the README. This PR adds instructions about installing `yarn` when setting up the application.