### PR TITLE
Cache versioning. Fixes #322 Fixes #495 Fixes #477 Fixes #458

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -6,7 +6,7 @@ class UsersController < ApplicationController
   def index
     @page_title = "#{params[:sort] ? params[:sort].titleize + ' - ' : ''} Musicians and Listeners"
     @tab = 'browse'
-    @users = User.includes(:pic).paginate_by_params(params)
+    @users = User.includes(:pic, :profile).paginate_by_params(params)
     @sort = params[:sort]
     @user_count = User.count
     @active     = User.where("assets_count > 0").count

--- a/app/helpers/assets_helper.rb
+++ b/app/helpers/assets_helper.rb
@@ -1,5 +1,4 @@
 module AssetsHelper
-
   def radio_option(path, name, default = false, disabled_if_not_logged_in = false)
     classes = "radio_channel #{params[:source] == path ? 'selected' : ''} #{!logged_in? && disabled_if_not_logged_in ? 'disabled' : ''}"
     content_tag :li, (radio_button_tag('source', path, (params[:source] == path || !params[:source] && default),

--- a/app/helpers/assets_helper.rb
+++ b/app/helpers/assets_helper.rb
@@ -1,13 +1,5 @@
 module AssetsHelper
 
-  def asset_cache_key(asset, favorite)
-    [ asset.cache_key,
-      logged_in? ? "user" : "guest",
-      favorite.nil? ? "no_fav" : 'favorite.user_id',
-      theme_name
-    ].join('/')
-  end
-
   def radio_option(path, name, default = false, disabled_if_not_logged_in = false)
     classes = "radio_channel #{params[:source] == path ? 'selected' : ''} #{!logged_in? && disabled_if_not_logged_in ? 'disabled' : ''}"
     content_tag :li, (radio_button_tag('source', path, (params[:source] == path || !params[:source] && default),

--- a/app/views/assets/_asset_tabs.html.erb
+++ b/app/views/assets/_asset_tabs.html.erb
@@ -1,4 +1,4 @@
-<%= cache( logged_in? ? "tabs#{asset.cache_key}/#{theme_name}" : "guest_tabs#{asset.cache_key}/#{theme_name}" ) do %>
+<%= cache([asset, logged_in?]) do %>
 <div class="more tabs" style="display:none;">
     <ul>
 	  <% if logged_in? || asset.guest_can_comment? %>

--- a/app/views/assets/_asset_white.html.erb
+++ b/app/views/assets/_asset_white.html.erb
@@ -1,4 +1,4 @@
-<%= cache([asset, logged_in?, local_assigns[:favorite]]) do %>
+<%= cache([asset, asset.user, logged_in?, local_assigns[:favorite]]) do %>
   <div class="asset_top">
     <div class="asset_top_row">
       <div class="play-button button" data-target="normal-playback.play" data-action="click->normal-playback#togglePlay">

--- a/app/views/assets/_asset_white.html.erb
+++ b/app/views/assets/_asset_white.html.erb
@@ -1,4 +1,4 @@
-<%= cache(asset_cache_key(asset, local_assigns[:favorite])) do %>
+<%= cache([asset, logged_in?, local_assigns[:favorite]]) do %>
   <div class="asset_top">
     <div class="asset_top_row">
       <div class="play-button button" data-target="normal-playback.play" data-action="click->normal-playback#togglePlay">

--- a/app/views/assets/index_white.html.erb
+++ b/app/views/assets/index_white.html.erb
@@ -5,12 +5,12 @@
 <div id='columns'>
   <div id="left">
     <div id="user_tracks box">
-      <% cache("alltracks/#{moderator?}/#{@assets.cache_key}") do %>
+      <%= cache([@user, moderator?]) do %>
       <% if @user.assets_count > 0 %>
         <div class="mini_paginator top_paginator">
           <%== pagy_nav @pagy %>
         </div>
-        <%= render partial: 'asset', collection: @assets %>
+        <%= render partial: 'asset', collection: @assets, cached: true %>
       <% else %>
        <h2>Looks like <%= @user.name %> hasn't uploaded anything yet!</h2>
       <% end %>

--- a/app/views/assets/latest.html.erb
+++ b/app/views/assets/latest.html.erb
@@ -1,21 +1,13 @@
 <!-- alonetone home page -->
-<%= cache("home/playlists/#{@playlists.cache_key}/#{theme_name}") do %>
-    <div class="latest-playlists-header">
-      <div class="sprites-latest-playlists sprites-before-heading"></div>
-      <h2>
-      <%= link_to "Latest playlists".html_safe, all_playlists_path, title: 'view latest playlists' %>
-      </h2>
-    </div>
-    <% if white_theme_enabled? %>
-    <ul class="playlists">
-      <%= render partial: 'shared/playlist_white', collection: @playlists, as: :playlist %>
-    </ul>
-    <% else %>
-    <ul class="playlists_row">
-      <%= render partial: 'playlists/row', collection: @playlists, as: :playlist %>
-    </ul>
-    <% end %>
-<% end unless @playlists.blank? %>
+<div class="latest-playlists-header">
+  <div class="sprites-latest-playlists sprites-before-heading"></div>
+  <h2>
+  <%= link_to "Latest playlists".html_safe, all_playlists_path, title: 'view latest playlists' %>
+  </h2>
+</div>
+<ul class="playlists_row">
+  <%= render partial: 'playlists/row', collection: @playlists, as: :playlist, cached: true %>
+</ul>
 
 <% content_for :left do%>
   <div class="sprites-latest-uploaded sprites-before-heading"></div>

--- a/app/views/assets/latest_white.html.erb
+++ b/app/views/assets/latest_white.html.erb
@@ -1,6 +1,6 @@
 <div id="home_grid">
-  <div id="home_playlists_area">
   <% if @playlists.present? %>
+  <div id="home_playlists_area">
     <div class="latest-playlists-header">
       <h2>
       <%= link_to "Latest Playlists".html_safe, all_playlists_path, title: 'view latest playlists' %>
@@ -9,8 +9,8 @@
     <ul class="playlists">
       <%= render partial: 'shared/playlist_white', collection: @playlists, as: :playlist, cached: true %>
     </ul>
-  <% end %>
   </div>
+  <% end %>
   <div id="home_left_column">
     <div id="home_latest_area">
       <h2>

--- a/app/views/assets/latest_white.html.erb
+++ b/app/views/assets/latest_white.html.erb
@@ -1,25 +1,15 @@
 <div id="home_grid">
-  <%= cache("home/playlists/#{@playlists.first.cache_key}/#{theme_name}") do %>
-    <div id="home_playlists_area">
-      <div class="latest-playlists-header">
-        <h2>
-        <%= link_to "Latest Playlists".html_safe, all_playlists_path, title: 'view latest playlists' %>
-        </h2>
-      </div>
-      <% if white_theme_enabled? %>
-      <ul class="playlists">
-        <%= render partial: 'shared/playlist_white', collection: @playlists, as: :playlist %>
-      </ul>
-      <% else %>
-      <ul class="playlists_row">
-        <%= render partial: 'playlists/row', collection: @playlists, as: :playlist %>
-      </ul>
-      <% end %>
+  <div id="home_playlists_area">
+    <div class="latest-playlists-header">
+      <h2>
+      <%= link_to "Latest Playlists".html_safe, all_playlists_path, title: 'view latest playlists' %>
+      </h2>
     </div>
-  <% end unless @playlists.blank? %>
-
+    <ul class="playlists">
+      <%= render partial: 'shared/playlist_white', collection: @playlists, as: :playlist, cached: true %>
+    </ul>
+  </div>
   <div id="home_left_column">
-  
     <div id="home_latest_area">
       <h2>
         <%= link_to radio_path(items: 40, source: 'latest'), title: 'latest music on alonetone' do %>
@@ -38,7 +28,6 @@
         </span>
         <% end %>
       </div>
-
     </div>
 
     <div id="home_comments_area">
@@ -48,7 +37,7 @@
         <% end %>
       </h2>
       <div class="box">
-        <%= render partial: 'shared/comment', collection: @comments %>
+        <%= render partial: 'shared/comment', collection: @comments, cached: true %>
       </div>
       <div class="below_box">
         <%= link_to all_comments_path, class: 'view_all', title: 'view latest comments' do %>
@@ -59,13 +48,10 @@
         </span>
         <% end %>
       </div>
-
     </div>
-
   </div>
-  
+
   <div id="home_right_column">
-    
     <div id="home_popular_area">
       <h2>
         <%= link_to radio_path(items: 40, source: 'popular'), title: 'alonetone radio: currently kicking ass' do %>
@@ -82,7 +68,7 @@
             <%= render file: svg_path('svg/icon_caret.svg') %>
           </i>
         </span>
-        <% end %>      
+        <% end %>
       </div>
     </div>
 

--- a/app/views/assets/latest_white.html.erb
+++ b/app/views/assets/latest_white.html.erb
@@ -1,5 +1,6 @@
 <div id="home_grid">
   <div id="home_playlists_area">
+  <% if @playlists.present? %>
     <div class="latest-playlists-header">
       <h2>
       <%= link_to "Latest Playlists".html_safe, all_playlists_path, title: 'view latest playlists' %>
@@ -8,6 +9,7 @@
     <ul class="playlists">
       <%= render partial: 'shared/playlist_white', collection: @playlists, as: :playlist, cached: true %>
     </ul>
+  <% end %>
   </div>
   <div id="home_left_column">
     <div id="home_latest_area">

--- a/app/views/playlists/edit_white.html.erb
+++ b/app/views/playlists/edit_white.html.erb
@@ -48,11 +48,6 @@
           </div>
         </div>
 
-        <% if moderator? %>
-          <%= f.simple_fields_for :greenfield_downloads do |sf| %>
-            <%= sf.input :title, label: sf.object.attachment_file_name + ':' %>
-          <% end %>
-        <% end %>
         <div class="edit_playlist_info_right_column_private_and_hidden">
           <div class="input"><%= f.check_box :private %></div> <label for="">&nbsp;&nbsp;Private</label> &nbsp;&nbsp; <span>| (Playlists are always private until they have more than 2 tracks)</span>
         </div>


### PR DESCRIPTION
Rails 6 changed the way caching works https://github.com/rails/rails/pull/29092/files

Summary: `@asset.cache_key` no longer returns a string with `updated_at` baked in, so caches don't break on Rails 6 by default if they are manually going off `cache_key`.

Instead of using `@asset.cache_key_with_version` which does include the `updated_at` and would break the caches, I'm cleaning up how we are doing cache keys. 

We used to manually specficy `@asset.cache_key` everywhere, but view helper calls to `cache` actually have key and version logic baked into them now, so we just want to hand the active record object.

Additionally a lot of the prefixing I had like `all_tracks` as well as `theme_name` were excessive — Due to automated template digesting `theme_name` is redundant when the templates are suffixed `_white`. 

Also I added `user` to the cache key on track chunks to make sure avatar / name updates break cache.