### PR TITLE
Fix legacy sitewidth padding

### DIFF
--- a/app/assets/stylesheets/white_theme/layout.scss
+++ b/app/assets/stylesheets/white_theme/layout.scss
@@ -11,8 +11,11 @@ body {
         margin-top: $baseline;
     }
     #static_header {
-      @include match-dynamic-site-width();
-      max-width: 960px;
+      max-width: 1032px;
+      padding: 0 $baseline * 1.5;
+      box-sizing: border-box;
+      margin-left: auto;
+      margin-right: auto;
     }
     #columns_header {
       max-width: 1032px;

--- a/app/assets/stylesheets/white_theme/playlists.scss
+++ b/app/assets/stylesheets/white_theme/playlists.scss
@@ -82,6 +82,11 @@ ul.playlists {
 }
 
 .playlists_container {
+  h2 {
+    color: $samo-orange;
+    margin-top: 0;
+    margin-bottom: 16px;
+  }
   max-width: 1032px;
   padding: 0 $baseline * 1.5;
   box-sizing: border-box;

--- a/app/assets/stylesheets/white_theme/playlists.scss
+++ b/app/assets/stylesheets/white_theme/playlists.scss
@@ -82,8 +82,11 @@ ul.playlists {
 }
 
 .playlists_container {
-  @include match-dynamic-site-width();
-  max-width: 960px;
+  max-width: 1032px;
+  padding: 0 $baseline * 1.5;
+  box-sizing: border-box;
+  margin-left: auto;
+  margin-right: auto;
   ul.playlists {
     margin-right: -36px;
     li {

--- a/app/assets/stylesheets/white_theme/users_index.scss
+++ b/app/assets/stylesheets/white_theme/users_index.scss
@@ -1,12 +1,18 @@
 #user_index {
   display: flex;
-  @include match-dynamic-site-width();
+  
   flex-wrap: wrap;
   justify-content: space-between;
-  max-width: 960px;
+  box-sizing: border-box;
+  max-width: 1032px;
+  padding: 0 $baseline * 1.5;
+  margin-left: auto;
+  margin-right: auto;
+
   #static_header {
     width: 30%;
     line-height: 1.1;
+    padding-left: 0;
     @media #{$one-column} {
       width: 100%;
     }

--- a/app/assets/stylesheets/white_theme/users_index.scss
+++ b/app/assets/stylesheets/white_theme/users_index.scss
@@ -49,7 +49,7 @@
     width: 70%;
     margin-top: 52px;
     flex-wrap: wrap;
-    justify-content: space-between;
+    margin-right: -18px;
     @media #{$one-column} {
       width: 100%;
     }
@@ -61,6 +61,7 @@
       width: 150px;
       margin-bottom: 30px;
       text-align: center;
+      margin-right: 18px;
       img.cover {
         width: 125px;
         height: 125px;

--- a/app/assets/stylesheets/white_theme/users_index.scss
+++ b/app/assets/stylesheets/white_theme/users_index.scss
@@ -2,16 +2,20 @@
   display: flex;
   flex-wrap: wrap;
   justify-content: space-between;
+  align-items: flex-start;
   box-sizing: border-box;
   max-width: 1032px;
   padding: 0 $baseline * 1.5;
   margin-left: auto;
   margin-right: auto;
 
-  #static_header {
+  .users_menu {
     width: 30%;
     line-height: 1.1;
     padding-left: 0;
+    h2 {
+      color: $samo-orange;
+    }
     @media #{$one-column} {
       width: 100%;
     }

--- a/app/assets/stylesheets/white_theme/users_index.scss
+++ b/app/assets/stylesheets/white_theme/users_index.scss
@@ -10,7 +10,8 @@
   margin-right: auto;
 
   .users_menu {
-    width: 30%;
+    width: 25%;
+    margin-right: 5%;
     line-height: 1.1;
     padding-left: 0;
     h2 {
@@ -21,28 +22,31 @@
     }
     #links {
       ul.links {
+        margin-top: 0;
+        margin-bottom: 0;
         li {
-          line-height: 34px;
-          float: left;
+          line-height: 40px;
           display: block;
-          height: 32px;
-          width: 230px;
+          height: 40px;
+          width: 100%;
+          box-sizing: border-box;
+          &:hover {
+            background: $light_gray;
+            a {
+              text-decoration: none;
+            }
+          }
           a {
             font-size: 14px;
             font-weight: 400;
-            line-height: 34px;
             display: block;
-            float: left;
             padding: 0 15px;
-          }
-          a:hover {
-            text-decoration: none;
-            background: $light_gray;
           }
         }
         li.current {
           padding: 0 15px;
-          background: $gray;
+          background: $samo-orange;
+          color: #FFF;
         }
       }
     }
@@ -50,7 +54,6 @@
   #large_users_grid {
     display: flex;
     width: 70%;
-    margin-top: 52px;
     flex-wrap: wrap;
     margin-right: -18px;
     @media #{$one-column} {

--- a/app/assets/stylesheets/white_theme/users_index.scss
+++ b/app/assets/stylesheets/white_theme/users_index.scss
@@ -10,6 +10,7 @@
   margin-right: auto;
 
   .users_menu {
+    box-shadow: none;
     width: 25%;
     margin-right: 5%;
     line-height: 1.1;

--- a/app/assets/stylesheets/white_theme/users_index.scss
+++ b/app/assets/stylesheets/white_theme/users_index.scss
@@ -1,6 +1,5 @@
 #user_index {
   display: flex;
-  
   flex-wrap: wrap;
   justify-content: space-between;
   box-sizing: border-box;

--- a/app/assets/stylesheets/white_theme/users_index.scss
+++ b/app/assets/stylesheets/white_theme/users_index.scss
@@ -15,8 +15,10 @@
     min-width: 185px;
     margin-right: 5%;
     padding-left: 0;
+    overflow: hidden;
     h2 {
       color: $samo-orange;
+      margin-bottom: 0;
     }
     @media #{$one-column} {
       width: 100%;

--- a/app/assets/stylesheets/white_theme/users_index.scss
+++ b/app/assets/stylesheets/white_theme/users_index.scss
@@ -12,8 +12,8 @@
   .users_menu {
     box-shadow: none;
     width: 25%;
+    min-width: 185px;
     margin-right: 5%;
-    line-height: 1.1;
     padding-left: 0;
     h2 {
       color: $samo-orange;

--- a/app/views/playlists/all.html.erb
+++ b/app/views/playlists/all.html.erb
@@ -1,19 +1,23 @@
+<% if white_theme_enabled? %>
+
+  <div class="playlists_container">
+
+    <h2>Browse all alonetone playlists</h2>
+
+    <ul class="playlists">
+      <%= render partial: 'shared/playlist_white', collection: @playlists, as: :playlist %>
+    </ul>
+  </div>
+
+<% else %>
+
 <div id="static_header">
   <div class="title">
     <h1 class="static">Browse all alonetone playlists</h1>
   </div>
 </div>
-<% if white_theme_enabled? %>
 
-  <div class="playlists_container">
-  
-  <ul class="playlists">
-    <%= render partial: 'shared/playlist_white', collection: @playlists, as: :playlist %>
-  </ul>
 
-  </div>
-
-<% else %>
 <div style="margin-top: 28px">
   <% @playlists.each_slice(5) do |playlists| %>
     <ul class="playlists_row">
@@ -21,4 +25,5 @@
     </ul>
   <% end %>
 </div>
+
 <% end %>

--- a/app/views/playlists/all.html.erb
+++ b/app/views/playlists/all.html.erb
@@ -1,8 +1,7 @@
 <% if white_theme_enabled? %>
 
   <div class="playlists_container">
-
-    <h2>Browse all alonetone playlists</h2>
+    <h2>Browse Playlists</h2>
 
     <ul class="playlists">
       <%= render partial: 'shared/playlist_white', collection: @playlists, as: :playlist %>

--- a/app/views/shared/_footer_white.html.erb
+++ b/app/views/shared/_footer_white.html.erb
@@ -34,7 +34,7 @@
   <div class="footer_columns">
     <div class="footer_column">
       <h3 class="footer_column_header">alone<em>tone</em> radio</h3>
-      <a href="/radio/">
+      <a href="/radio/latest">
         <%= render file: svg_path('svg/icon_radio.svg') %>
       </a>
     </div>

--- a/app/views/users/_users.html.erb
+++ b/app/views/users/_users.html.erb
@@ -1,20 +1,47 @@
 <div id="user_index">
-  <div id="static_header">
-    <div class="title">
-      <h1 class="static">Browse all alonetone artists</h1>
+
+
+  <% if white_theme_enabled? %>
+
+     <div class="users_menu box">
+  
+      <h2>Browse all alonetone artists</h2>
+      
+      <div id="links">
+        <ul class="links">
+        <%= navigation_item "last online", {action: 'index', sort: nil} %>
+        <%= navigation_item "last uploaded", {action: 'index', sort: 'last_uploaded'} %>
+        <%= navigation_item "most listened to", {action: 'index', sort: 'most_listened_to'} %>
+        <%= navigation_item "new artists", {action: 'index', sort: 'new_artists'} %>
+        <%= navigation_item "all time most uploaded", {action: 'index', sort: 'monster_uploaders'} %>
+        <%= navigation_item "dedicated listeners", {action: 'index', sort: 'dedicated_listeners'}%>
+        </ul>
+      </div>
+      
     </div>
 
-    <div id="links">
-      <ul class="links">
-       <%= navigation_item "last online", {action: 'index', sort: nil} %>
-       <%= navigation_item "last uploaded", {action: 'index', sort: 'last_uploaded'} %>
-       <%= navigation_item "most listened to", {action: 'index', sort: 'most_listened_to'} %>
-       <%= navigation_item "new artists", {action: 'index', sort: 'new_artists'} %>
-       <%= navigation_item "all time most uploaded", {action: 'index', sort: 'monster_uploaders'} %>
-       <%= navigation_item "dedicated listeners", {action: 'index', sort: 'dedicated_listeners'}%>
-      </ul>
+  
+  <% else %>
+    <div id="static_header">
+  
+      <div class="title">
+        <h1 class="static">Browse all alonetone artists</h1>
+      </div>
+
+      <div id="links">
+        <ul class="links">
+        <%= navigation_item "last online", {action: 'index', sort: nil} %>
+        <%= navigation_item "last uploaded", {action: 'index', sort: 'last_uploaded'} %>
+        <%= navigation_item "most listened to", {action: 'index', sort: 'most_listened_to'} %>
+        <%= navigation_item "new artists", {action: 'index', sort: 'new_artists'} %>
+        <%= navigation_item "all time most uploaded", {action: 'index', sort: 'monster_uploaders'} %>
+        <%= navigation_item "dedicated listeners", {action: 'index', sort: 'dedicated_listeners'}%>
+        </ul>
+      </div>
+      
     </div>
-  </div>
+    
+  <% end %>
 
   <div id="large_users_grid">
     <% if @sort == 'dedicated_listeners'%>

--- a/app/views/users/_users.html.erb
+++ b/app/views/users/_users.html.erb
@@ -5,7 +5,7 @@
 
      <div class="users_menu box">
   
-      <h2>Browse all alonetone artists</h2>
+      <h2>Browse Artists</h2>
       
       <div id="links">
         <ul class="links">

--- a/app/views/users/_users.html.erb
+++ b/app/views/users/_users.html.erb
@@ -9,12 +9,12 @@
       
       <div id="links">
         <ul class="links">
-        <%= navigation_item "last online", {action: 'index', sort: nil} %>
-        <%= navigation_item "last uploaded", {action: 'index', sort: 'last_uploaded'} %>
-        <%= navigation_item "most listened to", {action: 'index', sort: 'most_listened_to'} %>
-        <%= navigation_item "new artists", {action: 'index', sort: 'new_artists'} %>
-        <%= navigation_item "all time most uploaded", {action: 'index', sort: 'monster_uploaders'} %>
-        <%= navigation_item "dedicated listeners", {action: 'index', sort: 'dedicated_listeners'}%>
+        <%= navigation_item "Last Online", {action: 'index', sort: nil} %>
+        <%= navigation_item "Last Uploaded", {action: 'index', sort: 'last_uploaded'} %>
+        <%= navigation_item "Most Listened To", {action: 'index', sort: 'most_listened_to'} %>
+        <%= navigation_item "New Artists", {action: 'index', sort: 'new_artists'} %>
+        <%= navigation_item "All Time Top Uploaders", {action: 'index', sort: 'monster_uploaders'} %>
+        <%= navigation_item "Dedicated Listeners", {action: 'index', sort: 'dedicated_listeners'}%>
         </ul>
       </div>
       


### PR DESCRIPTION
This branch fixed some bad horizontal paddings on /users and /playlists, so those will now collapse similarly to the rest of the site on overall browser width. I also removed those old large black headings to match the Orange headings on the rest of the site. Also, made a new white theme menu for /users. So yeah, sorta escaped the original scope of this branch. But it should be all non conflicting and positive changes.