### PR TITLE
Run migration in 4 threads

### DIFF
--- a/bin/migrate-storage
+++ b/bin/migrate-storage
@@ -219,7 +219,7 @@ module Storage
       options.logger.info("Migrate #{model.name} (#{paperclip_attachments_names.to_sentence})")
       paperclip_attachments_names.each do |paperclip_attachment_name|
         model.find_in_batches do |batch|
-          Parallel.each(batch) do |record|
+          Parallel.each(batch, in_threads: 4) do |record|
             # Don't re-use the connection from the main thread.
             ActiveRecord::Base.connection_pool.with_connection do
               migrate_record(record, paperclip_attachment_name: paperclip_attachment_name)


### PR DESCRIPTION
Parallel defaults to processes, which seemed to break locally for me. I assume that would also break in production so let's force threads. I chose 4 because each thread will attempt to create a database connection and those are probably limited.