### PR TITLE
Ignore AbstractController::ActionNotFound.

### DIFF
--- a/config/initializers/bugsnag.rb
+++ b/config/initializers/bugsnag.rb
@@ -3,7 +3,15 @@ if api_key = Rails.configuration.alonetone.bugsnag_api_key
     config.release_stage = "production"
     config.api_key = api_key
     config.auto_capture_sessions = true
+    # Controller does not implement the action that was requested; happens when
+    # someone hits an action because overmatching routes.
+    config.ignore_classes << AbstractController::ActionNotFound
+    # Action does not support for a certain format (e.g. xml); happens when
+    # someone hits an action with a weird accept header or adds the format
+    # param with an unsupported value.
     config.ignore_classes << ActionController::UnknownFormat
+    # When a model doesn't find a record; this already renders a 404 and is not
+    # really interesting.
     config.ignore_classes << ActiveRecord::RecordNotFound
   end
 end


### PR DESCRIPTION
Controller does not implement the action that was requested; happens when someone hits an action because overmatching routes.

This already renders a not-found page and doesn't have to be reported to Bugsnag.