### PR TITLE
Improve user admin

### DIFF
--- a/Guardfile
+++ b/Guardfile
@@ -1,38 +1,3 @@
-# # A sample Guardfile
-# # More info at https://github.com/guard/guard#readme
-#
-# guard 'spork', :cucumber_env => { 'RAILS_ENV' => 'test' }, :rspec_env => { 'RAILS_ENV' => 'test' } do
-#   watch('config/application.rb')
-#   watch('config/environment.rb')
-#   watch(%r{^config/environments/.+\.rb$})
-#   watch(%r{^config/initializers/.+\.rb$})
-#   watch('Gemfile')
-#   watch('Gemfile.lock')
-#   watch('spec/spec_helper.rb') { :rspec }
-#   watch('test/test_helper.rb') { :test_unit }
-#   watch(%r{features/support/}) { :cucumber }
-# end
-
-# guard 'rspec', :spring => true, :cli => '--colour' do
-#   watch(%r{^lib/(.+)\.rb$})     { |m| "spec/lib/#{m[1]}_spec.rb" }
-#
-#   # Rails example
-#   watch(%r{^spec/.+_spec\.rb$})
-#   watch(%r{^app/(.+)\.rb$})                           { |m| "spec/#{m[1]}_spec.rb" }
-#   watch(%r{^app/(.*)(\.erb|\.haml)$})                 { |m| "spec/#{m[1]}#{m[2]}_spec.rb" }
-#   watch(%r{^lib/(.+)\.rb$})                           { |m| "spec/lib/#{m[1]}_spec.rb" }
-#   watch(%r{^app/controllers/(.+)_(controller)\.rb$})  { |m| ["spec/#{m[2]}s/#{m[1]}_#{m[2]}_spec.rb", "spec/acceptance/#{m[1]}_spec.rb"] }
-#   watch(%r{^spec/support/(.+)\.rb$})                  { "spec" }
-#   watch('spec/spec_helper.rb')                        { "spec" }
-#   watch('config/routes.rb')                           { "spec" }
-#   watch('app/controllers/application_controller.rb')  { "spec/controllers" }
-#   # Capybara request specs
-#   watch(%r{^app/views/(.+)/.*\.(erb|haml)$})          { |m| "spec/requests/#{m[1]}_spec.rb" }
-#   watch(%r{^spec/.+_spec\.rb$})
-#   watch('spec/spec_helper.rb')  { "spec" }
-#
-# end
-
 guard :rspec, cmd: 'bundle exec rspec', all_on_start: false, all_after_pass: false, cli: '--colour' do
   watch('spec/spec_helper.rb')                        { "spec" }
   watch('app/controllers/application_controller.rb')  { "spec/controllers" }
@@ -41,4 +6,5 @@ guard :rspec, cmd: 'bundle exec rspec', all_on_start: false, all_after_pass: fal
   watch(%r{^app/(.*)(\.erb|\.haml|\.slim)$})          { |m| "spec/#{m[1]}#{m[2]}_spec.rb" }
   watch(%r{^lib/(.+)\.rb$})                           { |m| "spec/lib/#{m[1]}_spec.rb" }
   watch(%r{^app/controllers/(.+)_(controller)\.rb$})  { |m| ["spec/#{m[2]}s/#{m[1]}_#{m[2]}_spec.rb", "spec/acceptance/#{m[1]}_spec.rb"] }
+  ignore %r{^node_modules}, /node_modules/
 end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -3,12 +3,7 @@ module Admin
     before_action :set_user, except: %i[index]
 
     def index
-      scope = User.only_deleted if permitted_params[:deleted]
-      scope ||= User.with_deleted.recent
-
-      scope = scope.where(permitted_params[:filter_by]) if permitted_params[:filter_by]
-
-      @pagy, @users = pagy(scope)
+      @pagy, @users = pagy(User.filter_by(permitted_params[:filter_by]))
     end
 
     # should we rescue/display any error that occured to admin user
@@ -41,7 +36,7 @@ module Admin
     private
 
     def permitted_params
-      params.permit(:filter_by, :deleted)
+      params.permit(:filter_by)
     end
 
     def set_user

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -30,7 +30,7 @@ module Admin
       ip = @user.current_login_ip
       count = User.where(current_login_ip: ip).count
       MarkAllUsersWithIpAsSpam.perform_later(ip)
-      redirect_to :index, notice: "#{count} accounts by #{ip} being marked as spam..."
+      redirect_back fallback_location: { action: :index }, notice: "#{count} accounts by #{ip} being marked as spam..."
     end
 
     private

--- a/app/jobs/mark_all_users_with_ip_as_spam.rb
+++ b/app/jobs/mark_all_users_with_ip_as_spam.rb
@@ -1,0 +1,9 @@
+class MarkAllUsersWithIpAsSpam < ApplicationJob
+  queue_as :default
+
+  def perform(ip)
+    User.where(current_login_ip: ip).each do |user|
+      user.spam_and_mark_for_deletion!
+    end
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -269,6 +269,21 @@ class User < ApplicationRecord
     DeletedUserCleanupJob.set(wait: 30.days).perform_later(id)
   end
 
+  def self.filter_by(filter)
+    case filter
+    when "deleted"
+      only_deleted.order('deleted_at DESC')
+    when "is_spam"
+      with_deleted.where(is_spam: true).recent
+    when "not_spam"
+      with_deleted.where(is_spam: false).recent
+    when String
+      where("email like '%#{filter}%' or login like '%#{filter}%'").recent
+    else
+      with_deleted.recent
+    end
+  end
+
   protected
 
   def efficiently_restore_relations

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -245,6 +245,12 @@ class User < ApplicationRecord
     deleted_at != nil
   end
 
+  def spam_and_mark_for_deletion!
+    @user.spam!   # makes an api request
+    @user.update_column :is_spam, true
+    @user.soft_delete_with_relations
+  end
+
   def soft_delete_with_relations
     soft_delete_relations
     enqueue_real_destroy_job

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -246,9 +246,9 @@ class User < ApplicationRecord
   end
 
   def spam_and_mark_for_deletion!
-    @user.spam!   # makes an api request
-    @user.update_column :is_spam, true
-    @user.soft_delete_with_relations
+    spam! # makes an api request
+    update_column :is_spam, true
+    soft_delete_with_relations
   end
 
   def soft_delete_with_relations

--- a/app/views/admin/_navigation.html.erb
+++ b/app/views/admin/_navigation.html.erb
@@ -1,8 +1,9 @@
 <ul class="admin_nav">
   <%= navigation_item "Users", admin_users_path %>
   <ul>
-    <%= navigation_item 'Deleted', admin_users_path({deleted: true}) %>
+    <%= navigation_item 'Not Spam', admin_users_path({filter_by: :not_spam}) %>
     <%= navigation_item 'Spam', admin_users_path({filter_by: :is_spam}) %>
+    <%= navigation_item 'Deleted', admin_users_path({filter_by: :deleted}) %>
   </ul>
   <%= navigation_item 'Tracks', admin_assets_path %>
   <ul>

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -39,7 +39,7 @@
               <div>
                 <div><%= link_to user.login, user_path(user.login) %></div>
                 <div><%= user.email %></div>
-                <div><%= user.current_login_ip %><%= link_to "Mark Spam", mark_all_users_with_ip_as_spam_admin_user_path(user), method: :put %>
+                <div><%= user.current_login_ip %> <%= link_to "Spam!", mark_all_users_with_ip_as_spam_admin_user_path(user), method: :put %>
 </div>
               </div>
             </div>

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -13,7 +13,9 @@
       <%== pagy_nav @pagy %>
     </div>
     <div class="admin_search_field">
-      <%= text_field_tag 'filter_by', nil, placeholder: 'search by login/email' %>
+    <%= form_for 'filter_by', method: :get do |f| %>
+      <%= text_field_tag 'filter_by',nil, placeholder: 'search by login/email' %>
+    <% end %>
     </div>
     <div class="admin_column_right_inner box">
       <header class="admin_users_header">

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -12,10 +12,12 @@
     <div class="mini_paginator top_paginator">
       <%== pagy_nav @pagy %>
     </div>
-
+    <div class="admin_search_field">
+      <%= text_field_tag 'filter_by', nil, placeholder: 'search by login/email' %>
+    </div>
     <div class="admin_column_right_inner box">
       <header class="admin_users_header">
-        <div class="date_column">Date</div>
+        <div class="date_column">Joined</div>
         <div class="user_column">User</div>
         <div class="bio_column">Bio</div>
       </header>
@@ -23,7 +25,11 @@
       <div class="admin_users_rows">
         <% @users.each do |user| %>
           <div data-controller="admin--user" data-admin--user-deleted="<%= user.soft_deleted? %>" data-admin--user-spam="<%= user.is_spam? %>">
-            <div class="date_column"><%= local_time_ago user.created_at %></div>
+            <div class="date_column">
+            <%= local_time_ago user.created_at %>
+            <div><%== "Deleted #{local_time_ago user.deleted_at}" if user.deleted_at %></div>
+
+            </div>
             <div class="user_column">
               <div class="avatar">
                 <%= user_image(@user, variant: :original) %>
@@ -31,7 +37,8 @@
               <div>
                 <div><%= link_to user.login, user_path(user.login) %></div>
                 <div><%= user.email %></div>
-                <div><%= user.current_login_ip %></div>
+                <div><%= user.current_login_ip %><%= link_to "Mark Spam", mark_all_users_with_ip_as_spam_admin_user_path(user), method: :put %>
+</div>
               </div>
             </div>
             <div class="bio_column">
@@ -39,7 +46,6 @@
               <div><%= link_to "#{user.assets.count} tracks", user_tracks_path(user) if user.assets.count > 0 %></div>
             </div>
             <div class="button_column">
-              <%#= button_to "Spam All 4/IP", mark_group_as_spam_admin_assets_path, params: { mark_spam_by: { user_id: user.id }},  method: :put %>
               <%= button_to "Unspam User", unspam_admin_user_path(user), method: :put, remote: true, data: { target: 'admin--user.unspamButton', action: 'click->admin--user#hideUnspamButton' } %>
               <%= button_to "Spam User", spam_admin_user_path(user), method: :put, remote: true, data: { target: 'admin--user.spamButton', action: 'click->admin--user#hideSpamAndShowRestoreButton' } %>
               <%= button_to "Delete User", delete_admin_user_path(user), method: :put, remote: true, data: { target: 'admin--user.deleteButton', action: 'admin--user#showRestoreButton' } %></td>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,7 @@ Alonetone::Application.routes.draw do
         put :restore
         put :unspam
         put :spam
+        put :mark_all_users_with_ip_as_spam
       end
     end
     resources :comments, path: 'comments/(:filter_by)', only: [:index] do

--- a/spec/request/admin/users_controller_spec.rb
+++ b/spec/request/admin/users_controller_spec.rb
@@ -128,7 +128,7 @@ RSpec.describe Admin::AssetsController, type: :request do
 
     context "if deleted: true flag is passed" do
       it "should return users with deleted" do
-        get admin_users_path(deleted: true)
+        get admin_users_path(filter_by: :deleted)
         expect(response.body).to match(/arthur/)
         expect(response.body).not_to match(/ben/)
       end
@@ -144,14 +144,14 @@ RSpec.describe Admin::AssetsController, type: :request do
 
     context "with filter_by" do
       it "should return spam users only if flag is passed" do
-        get admin_users_path({filter_by: { is_spam: true}})
+        get admin_users_path(filter_by: :is_spam)
         expect(response.body).to match(/aaron/)
         expect(response.body).not_to match(/arthur/)
         expect(response.body).not_to match(/ben/)
       end
 
       it "should return only non spam users if is_spam is set to false" do
-        get admin_users_path({filter_by: { is_spam: false}})
+        get admin_users_path(filter_by: :not_spam)
         expect(response.body).not_to match(/aaron/)
         expect(response.body).to match(/arthur/)
         expect(response.body).to match(/ben/)


### PR DESCRIPTION
0) Cleans up menu logic so everything uses `filter_by`
1) Adds "Not Spam" as a menu item
2) Allows marking of all users by an IP as spam.
3) Adds "deleted_at" date for deleted users and sorts by that in "Deleted"

<img width="1170" alt="image" src="https://user-images.githubusercontent.com/472/59152559-b4f7e700-8a46-11e9-8456-c1b0908eee39.png">
