### PR TITLE
Add a checklist to the PR template

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,0 +1,18 @@
+
+
+## "Ready For Review" checklist
+
+* [ ] PR title accurately summarizes changes
+* [ ] PR description
+  * Does this fix any open issues?
+  * What changes are you making?
+  * Why did you implement it this way?
+  * Is there anything reviewers need to know or pay attention to?
+  * Does anything special need to happen for deployment?
+* [ ] Optional: Inline github PR comments explaining context of tricky / complicated / unexpected lines so reviewers can follow along.
+* [ ] If appropriate, new tests were added for isolated methods or new endpoints
+* [ ] All tests green
+* [ ] Percy changes are purposeful or explained
+* [ ] I booted up the branch locally, exercised any new code I wrote.
+* [ ] If css was touched, I verified changes are happy on mobile (via Percy is ok)
+* [ ] I opened an issue for any logical followups


### PR DESCRIPTION
Although I'm typically allergic to templates and anything copy/paste-y, @innatewonderer had some good points in https://github.com/sudara/alonetone/pull/478. 

How about a checklist? It exposes expectations for "Ready For Review" and might serve as a good reminder without having us jump through hoops or have a big fluffy PR description full of non-content.

## "Ready For Review" checklist

* [x] PR title accurately summarizes changes
* [x] PR description
  * Does this fix any open issues?
  * What changes are you making?
  * Why did you implement it this way?
  * Is there anything reviewers need to know or pay attention to?
  * Does anything special need to happen for deployment?
* [ ] Optional: Inline github PR comments explaining context of tricky / complicated / unexpected lines so reviewers can follow along.
* [ ] If appropriate, new tests were added for isolated methods or new endpoints
* [ ] All tests green
* [ ] Percy changes are purposeful or explained
* [ ] I booted up the branch locally, exercised any new code I wrote.
* [ ] If css was touched, I verified changes are happy on mobile (via Percy is ok)
* [ ] I opened an issue for any logical followups