### PR TITLE
Fix delete admin user path on views/admin/asset page

### DIFF
--- a/app/views/admin/assets/index.html.erb
+++ b/app/views/admin/assets/index.html.erb
@@ -38,7 +38,7 @@
             <div class="button_column">
               <%= button_to "Mark As Spam", spam_admin_asset_path(asset.id), method: :put %>
               <%= button_to "Spam All for IP", mark_group_as_spam_admin_assets_path, method: :put, params: { mark_spam_by: { user_id: asset.user_id } } %>
-              <%= button_to "Delete User", admin_user_path(asset.user_id), data: { confirm: 'This will delete user forevAr. Are you sure?'}, method: :delete %>
+              <%= button_to "Delete User", delete_admin_user_path(asset.user&.login), data: { confirm: 'This will delete user forevAr. Are you sure?'}, method: :put %>
             </div>
           </div>
         <% end %>


### PR DESCRIPTION
## "Ready For Review" checklist

* [x] PR title accurately summarizes changes
* [x] PR description
  * Does this fix any open issues?
<img width="1440" alt="Fullscreen_7_10_19__10_59_PM" src="https://user-images.githubusercontent.com/2320322/61019503-6486e880-a368-11e9-9ca3-a9684003f585.png">
https://app.bugsnag.com/alonetone/alonetone/errors/5cdb9b90ba8d770019f8d20d?filters[event.since][0]=30d&filters[error.status][0]=open

  * What changes are you making?
Fixing the path in the view template
  * Why did you implement it this way?
N/A
  * Is there anything reviewers need to know or pay attention to?
No
  * Does anything special need to happen for deployment?
No
* [ ] ~Optional: Inline github PR comments explaining context of tricky / complicated / unexpected lines so reviewers can follow along.~
* [ ] ~If appropriate, new tests were added for isolated methods or new endpoints~
* [ ] All tests green
* [x] Percy changes are purposeful or explained
* [x] I booted up the branch locally, exercised any new code I wrote.
* [ ] ~If css was touched, I verified changes are happy on mobile (via Percy is ok)~
* [ ] ~I opened an issue for any logical followups~
