### PR TITLE
Alright v2

### DIFF
--- a/app/assets/stylesheets/white_theme/variables.scss
+++ b/app/assets/stylesheets/white_theme/variables.scss
@@ -38,7 +38,7 @@ $one-column: 'only screen and (max-width: 748px)';
 
 @font-face {
   font-family: 'Alright-v2-Normal-Medium';
-  src: url('https://cdn.alonetone.com/fonts/Alright-v2-Normal/Alright-v2-Normal-Medium.woff2') format('woff2');
+  src: url('https://cdn.alonetone.com/fonts/Alright-v2-Normal-Medium.woff2') format('woff2');
   font-weight: normal;
 }
 

--- a/app/assets/stylesheets/white_theme/variables.scss
+++ b/app/assets/stylesheets/white_theme/variables.scss
@@ -30,10 +30,27 @@ $two-column-narrow: 'only screen and (min-width: 749px) and (max-width: 920px)';
 $one-column: 'only screen and (max-width: 748px)';
 
 // fonts
+@font-face {
+  font-family: 'Alright-v2-Normal-Regular';
+  src: url('https://cdn.alonetone.com/fonts/Alright-v2-Normal-Regular.woff2') format('woff2');
+  font-weight: normal;
+}
 
-$black-font: 'Alright Sans Black', sans-serif;
-$sans-font: 'Alright Sans', sans-serif; // "Alright Sans Bold" exists using font-weight: bold or <strong> on this fontface
-$medium-sans-font: 'Alright Sans Medium', sans-serif;
+@font-face {
+  font-family: 'Alright-v2-Normal-Medium';
+  src: url('https://cdn.alonetone.com/fonts/Alright-v2-Normal/Alright-v2-Normal-Medium.woff2') format('woff2');
+  font-weight: normal;
+}
+
+@font-face {
+  font-family: 'Alright-v2-Normal-Black';
+  src: url('https://cdn.alonetone.com/fonts/Alright-v2-Normal-Black.woff2') format('woff2');
+  font-weight: normal;
+}
+
+$sans-font: 'Alright-v2-Normal-Regular', sans-serif; // "Alright Sans Bold" exists using font-weight: bold or <strong> on this fontface
+$medium-sans-font: 'Alright-v2-Normal-Medium', sans-serif;
+$black-font: 'Alright-v2-Normal-Black', sans-serif;
 
 // site colors
 

--- a/app/assets/stylesheets/white_theme/variables.scss
+++ b/app/assets/stylesheets/white_theme/variables.scss
@@ -37,6 +37,12 @@ $one-column: 'only screen and (max-width: 748px)';
 }
 
 @font-face {
+  font-family: 'Alright-v2-Normal-Regular';
+  src: url('https://cdn.alonetone.com/fonts/Alright-v2-Normal-Bold.woff2') format('woff2');
+  font-weight: bold;
+}
+
+@font-face {
   font-family: 'Alright-v2-Normal-Medium';
   src: url('https://cdn.alonetone.com/fonts/Alright-v2-Normal-Medium.woff2') format('woff2');
   font-weight: normal;

--- a/app/assets/stylesheets/white_theme/variables.scss
+++ b/app/assets/stylesheets/white_theme/variables.scss
@@ -31,13 +31,13 @@ $one-column: 'only screen and (max-width: 748px)';
 
 // fonts
 @font-face {
-  font-family: 'Alright-v2-Normal-Regular';
+  font-family: 'Alright-v2-Normal';
   src: url('https://cdn.alonetone.com/fonts/Alright-v2-Normal-Regular.woff2') format('woff2');
   font-weight: normal;
 }
 
 @font-face {
-  font-family: 'Alright-v2-Normal-Regular';
+  font-family: 'Alright-v2-Normal';
   src: url('https://cdn.alonetone.com/fonts/Alright-v2-Normal-Bold.woff2') format('woff2');
   font-weight: bold;
 }
@@ -54,7 +54,7 @@ $one-column: 'only screen and (max-width: 748px)';
   font-weight: normal;
 }
 
-$sans-font: 'Alright-v2-Normal-Regular', sans-serif; // "Alright Sans Bold" exists using font-weight: bold or <strong> on this fontface
+$sans-font: 'Alright-v2-Normal', sans-serif; // "Alright Sans Bold" exists using font-weight: bold or <strong> on this fontface
 $medium-sans-font: 'Alright-v2-Normal-Medium', sans-serif;
 $black-font: 'Alright-v2-Normal-Black', sans-serif;
 

--- a/app/views/layouts/thredded.html.erb
+++ b/app/views/layouts/thredded.html.erb
@@ -5,7 +5,6 @@
     <meta content='width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0' name='viewport' />
     <meta name="turbolinks-root" content="/discuss">
     <%= stylesheet_link_tag('white_theme_thredded') %>
-    <link href="//cloud.webtype.com/css/5303dc7a-1cec-4666-a21e-bd0a60169f3d.css" rel="stylesheet" type="text/css" />
     <%= csrf_meta_tag %>
     <%= javascript_pack_tag "application", 'data-turbolinks-track': 'reload', defer: true  %>
     <%= javascript_include_tag 'thredded',

--- a/app/views/layouts/white_theme.html.erb
+++ b/app/views/layouts/white_theme.html.erb
@@ -9,7 +9,6 @@
   <%= stylesheet_link_tag ('white_theme') %>
   <%= javascript_pack_tag "application", 'data-turbolinks-track': 'reload', defer: true  %>
 
-  <link href="//cloud.webtype.com/css/5303dc7a-1cec-4666-a21e-bd0a60169f3d.css" rel="stylesheet" type="text/css" />
   <meta content="index,follow" name="robots"/>
   <% if @asset&.persisted? or @playlist&.persisted? %>
     <meta property="og:type"        content="music.<%= @playlist ? 'album' : 'song' %>" />

--- a/greenfield/app/views/layouts/greenfield/application.html.erb
+++ b/greenfield/app/views/layouts/greenfield/application.html.erb
@@ -8,8 +8,6 @@
 
     <%= stylesheet_link_tag 'greenfield/application' %>
 
-    <link href="//cloud.webtype.com/css/5303dc7a-1cec-4666-a21e-bd0a60169f3d.css" rel="stylesheet" type="text/css" />
-
     <meta content="index,follow" name="robots"/>
 
     <% if @post or @playlist %>


### PR DESCRIPTION
I just added a second @font-face for the  'Alright-v2-Normal-Regular' that tells the browser to use the Alright-v2-Normal-Bold.woff2 for bold weights.

This way I won't have to rewrite the CSS heading styles. Many of our 'bold' text comes from the default bold stylings on h1, h2. I would have to make a reset to stop the system from doing that. I really don't know which way is more semantically correct, but at least this way, nothing should change from how it was before.



## "Ready For Review" checklist

* [ ] PR title accurately summarizes changes
* [ ] PR description
  * Does this fix any open issues?
  * What changes are you making?
  * Why did you implement it this way?
  * Is there anything reviewers need to know or pay attention to?
  * Does anything special need to happen for deployment?
* [ ] Optional: Inline github PR comments explaining context of tricky / complicated / unexpected lines so reviewers can follow along.
* [ ] If appropriate, new tests were added for isolated methods or new endpoints
* [ ] All tests green
* [ ] Percy changes are purposeful or explained
* [ ] I booted up the branch locally, exercised any new code I wrote.
* [ ] If css was touched, I verified changes are happy on mobile (via Percy is ok)
* [ ] I opened an issue for any logical followups