### PR TITLE
Edit playlist hotfix

### DIFF
--- a/app/assets/stylesheets/white_theme/ajax.scss
+++ b/app/assets/stylesheets/white_theme/ajax.scss
@@ -91,7 +91,6 @@ div.small_spinner {
   font-size: 15px;
   padding-left: 24px;
   padding-right: 48px;
-  border: 1px solid #67c906;
   border-radius: 2px;
   margin-left: auto;
   margin-right: auto;
@@ -101,10 +100,16 @@ div.small_spinner {
   z-index: 100;
   font-weight: bold;
   box-shadow: 0px 2px 6px rgba(0, 0, 0, 0.30);
+  &.ajax_success {
+    border: 1px solid #67c906!important;
+  }
+  &.ajax_fail {
+    border: 1px solid #ff1f75!important;
+  }
+
   &.ajax_success > div  {
     padding-top: 9.75px;
     padding-right: 3px;
-    color: #2b8800;
     @media #{$mobile} {
       span {
         display: inline;
@@ -130,7 +135,6 @@ div.small_spinner {
   &.ajax_fail > div {
     padding-top: 9.75px;
     padding-right: 3px;
-    color: #b20035;
     @media #{$mobile} {
       span {
         display: inline;

--- a/app/assets/stylesheets/white_theme/playlist_edit.scss
+++ b/app/assets/stylesheets/white_theme/playlist_edit.scss
@@ -15,6 +15,8 @@
     height: 50px;
     line-height: 53px;
     font-family: $medium-sans-font;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
   form p {
     font-size: 14px;

--- a/app/assets/stylesheets/white_theme/playlist_edit.scss
+++ b/app/assets/stylesheets/white_theme/playlist_edit.scss
@@ -294,6 +294,7 @@
       }
       .mini_paginator {
         border-bottom: 1px solid $light-gray;
+        border-radius: 0;
       }
     }
     .playlist_asset {

--- a/app/views/playlists/edit_white.html.erb
+++ b/app/views/playlists/edit_white.html.erb
@@ -112,10 +112,10 @@
             <li><%= link_to 'your uploads', '#your_uploads', class: 'playlist_option', id: 'open_your_stuff' if @user.has_tracks? %></li>
           </ul>
         </div>
+        <div class="mini_paginator">
+          <%== pagy_nav @assets_pagy %>
+        </div>
         <div id="your_uploads" class="playlist_source">
-          <div class="mini_paginator">
-            <%== pagy_nav @assets_pagy %>
-          </div>
           <% @assets.each do |asset| %>
             <div class="asset playlist_asset" data-controller="normal-playback playlist-update" data-normal-playback-openable="false" id="asset_<%= asset.id %>"  data-time="<%= asset.seconds %>">
               <%= render partial: 'assets/asset_white', locals: { asset:asset } %>

--- a/app/views/playlists/edit_white.html.erb
+++ b/app/views/playlists/edit_white.html.erb
@@ -104,7 +104,7 @@
         <div class="right_column_box_header">
           <h2>Available tracks</h2>
           <div class="available_tracks_total">
-            2,181 tracks total
+            <%= @user.assets_count %> tracks total
           </div>
         </div>
         <div id="playlist_tabs">

--- a/spec/features/playlist_spec.rb
+++ b/spec/features/playlist_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe 'playlists', type: :feature, js: true do
       expect(page).to have_selector('.sortable .asset', count: 1)
 
       # add 2 new tracks
-      first_upload = find('#your_uploads .asset:first-child) .add')
+      first_upload = find('#your_uploads .asset:nth-child(1) .add')
       first_upload.click
       first_upload.click
       expect(page).to have_selector('.sortable .asset', count: 3)

--- a/spec/features/playlist_spec.rb
+++ b/spec/features/playlist_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe 'playlists', type: :feature, js: true do
       expect(page).to have_selector('.sortable .asset', count: 1)
 
       # add 2 new tracks
-      first_upload = find('#your_uploads .asset:nth-child(2) .add')
+      first_upload = find('#your_uploads .asset:first-child) .add')
       first_upload.click
       first_upload.click
       expect(page).to have_selector('.sortable .asset', count: 3)


### PR DESCRIPTION
1. take out 2181 tracks total, replace with user asset total

2. stop bad line breaks on mobile long titles ( editing playlists on mobile is a bit of a task, but not trying to address that entire issue here )

3. pull mini-paginator out of .assets parent div, and remove extra border-radius

4. clean up floating_feedback border styles for mobile


## "Ready For Review" checklist

* [ ] PR title accurately summarizes changes
* [ ] PR description
  * Does this fix any open issues?
  * What changes are you making?
  * Why did you implement it this way?
  * Is there anything reviewers need to know or pay attention to?
  * Does anything special need to happen for deployment?
* [ ] Optional: Inline github PR comments explaining context of tricky / complicated / unexpected lines so reviewers can follow along.
* [ ] If appropriate, new tests were added for isolated methods or new endpoints
* [ ] All tests green
* [ ] Percy changes are purposeful or explained
* [ ] I booted up the branch locally, exercised any new code I wrote.
* [ ] If css was touched, I verified changes are happy on mobile (via Percy is ok)
* [ ] I opened an issue for any logical followups