### PR TITLE
Clone the play animation SVG before animating it.

### DIFF
--- a/app/javascript/animation/play_animation.js
+++ b/app/javascript/animation/play_animation.js
@@ -4,7 +4,7 @@ import MorphSVGPlugin from './MorphSVGPlugin'
 const plugins = [CSSPlugin, AttrPlugin, MorphSVGPlugin, Linear, Elastic, Power1, Power2, Power3, Sine]
 
 export default function PlayAnimation() {
-  const mainSVG = document.getElementById('playAnimationSVG')
+  const mainSVG = document.getElementById('animating')
   const select = function (s) {
     return mainSVG.querySelector(s)
   }

--- a/app/javascript/animation/play_animation.js
+++ b/app/javascript/animation/play_animation.js
@@ -3,8 +3,7 @@ import MorphSVGPlugin from './MorphSVGPlugin'
 
 const plugins = [CSSPlugin, AttrPlugin, MorphSVGPlugin, Linear, Elastic, Power1, Power2, Power3, Sine]
 
-export default function PlayAnimation() {
-  const mainSVG = document.getElementById('animating')
+export default function PlayAnimation(mainSVG) {
   const select = function (s) {
     return mainSVG.querySelector(s)
   }

--- a/app/javascript/controllers/normal_playback_controller.js
+++ b/app/javascript/controllers/normal_playback_controller.js
@@ -2,21 +2,19 @@ import PlaybackController from './playback_controller'
 import PlayAnimation from '../animation/play_animation'
 
 let currentlyOpen
-let animation
 
 export default class extends PlaybackController {
   // these are added to the targets defined in PlaybackController
   static targets = ['playButton', 'details', 'time', 'seekBarPlayed', 'title']
 
   preInitialize() {
-    // animation = new PlayAnimation()
     this.preload = false
     this.url = this.playTarget.querySelector('a').getAttribute('href')
   }
 
   whilePlayingCallback() {
     if (!this.loaded) {
-      animation.showPause()
+      this.animation.showPause()
       this.loaded = true
     }
     this.updateSeekBarPlayed()
@@ -25,21 +23,13 @@ export default class extends PlaybackController {
 
   playCallback() {
     this.showAnimation()
-    if (!this.loaded) this.animateLoading()
-    else animation.setPause()
     this.openDetails()
     this.updateSeekBarLoaded()
     this.registeredListen = true
   }
 
   pauseCallback() {
-    animation.setPlay()
-
-    if (document.contains(document.getElementById("animating"))) {
-      document.getElementById('animating').remove()
-    }
-    
-    this.playButtonTarget.style.display = 'block'
+    this.animation.setPlay()
   }
 
   toggleDetails(e) {
@@ -75,20 +65,29 @@ export default class extends PlaybackController {
   }
 
   showAnimation() {
-    this.playButtonTarget.style.display = 'none'
-    
-    const clone = document.getElementById('playAnimationSVG').cloneNode(true);
-    clone.id = "animating";
-    this.playTarget.firstElementChild.append( clone )
+    this.cloneAnimationIfNeeded()
+    if (!this.loaded) {
+      this.playButtonTarget.style.display = 'none' // hide the dummy play button
+      this.animateLoading()
+    } else this.animation.setPause()
+  }
 
-    animation = new PlayAnimation()
-
+  // Print our own copy of #playAnimationSVG to animate freely as we like
+  // Until this point, the play button has been a placeholder icon SVG
+  // After this point, the play button is an animatable SVG
+  cloneAnimationIfNeeded() {
+    if (this.animation === undefined) {
+      const animationElement = document.getElementById('playAnimationSVG').cloneNode(true);
+      animationElement.id = this.data.get('id')
+      this.playTarget.firstElementChild.append(animationElement)
+      this.animation = new PlayAnimation(animationElement)
+    }
   }
 
   animateLoading() {
-    animation.init()
-    animation.setPlay()
-    animation.showLoading()
+    this.animation.init()
+    this.animation.setPlay()
+    this.animation.showLoading()
   }
 
   // With SoundManager we used to animate this width to display

--- a/app/javascript/controllers/normal_playback_controller.js
+++ b/app/javascript/controllers/normal_playback_controller.js
@@ -9,7 +9,7 @@ export default class extends PlaybackController {
   static targets = ['playButton', 'details', 'time', 'seekBarPlayed', 'title']
 
   preInitialize() {
-    animation = new PlayAnimation()
+    // animation = new PlayAnimation()
     this.preload = false
     this.url = this.playTarget.querySelector('a').getAttribute('href')
   }
@@ -34,7 +34,11 @@ export default class extends PlaybackController {
 
   pauseCallback() {
     animation.setPlay()
-    document.getElementById('play-svg-container').append(document.getElementById('playAnimationSVG'))
+
+    if (document.contains(document.getElementById("animating"))) {
+      document.getElementById('animating').remove()
+    }
+    
     this.playButtonTarget.style.display = 'block'
   }
 
@@ -72,7 +76,13 @@ export default class extends PlaybackController {
 
   showAnimation() {
     this.playButtonTarget.style.display = 'none'
-    this.playTarget.firstElementChild.append(document.getElementById('playAnimationSVG'))
+    
+    const clone = document.getElementById('playAnimationSVG').cloneNode(true);
+    clone.id = "animating";
+    this.playTarget.firstElementChild.append( clone )
+
+    animation = new PlayAnimation()
+
   }
 
   animateLoading() {

--- a/app/views/assets/_asset.html.erb
+++ b/app/views/assets/_asset.html.erb
@@ -1,5 +1,5 @@
 <% if white_theme_enabled? %>
-  <div class="asset" data-controller="normal-playback">
+  <div class="asset" data-controller="normal-playback" data-normal-playback-id="<% asset.id %>">
     <%= render partial: 'assets/asset_white', locals: {asset: asset } %>
   </div>
 <% else %>


### PR DESCRIPTION
We are still seeing glitching of the play animation svgs on playback.

Part of the reason why is because we have been working with just 1 svg vs. many tracks — so the state of the svg has to be manually managed and reset, etc. 

We revisited that decision, and now print a copy of the svg animation (`cloneNode`) to use each time play is clicked on a track. 

This seems to have resolved a lot of the problems.

Fixes #647 