### PR TITLE
Remove hardcoded 2018 date in playlist edit and empty <li>s in external links

### DIFF
--- a/app/views/playlists/_playlist_white.html.erb
+++ b/app/views/playlists/_playlist_white.html.erb
@@ -49,9 +49,11 @@
     <ul class="external-links">
       <% [:link1, :link2, :link3].collect do |link| %>
         <% if valid_link = @playlist.send(link) %>
+          <% if external_link_for(valid_link) %>
           <li>
             <%= external_link_for(valid_link) %>
           </li>
+          <% end %>  
         <% end %>
       <% end %>
     </ul>

--- a/app/views/playlists/edit_white.html.erb
+++ b/app/views/playlists/edit_white.html.erb
@@ -71,7 +71,7 @@
     </p>
     <div class="box">
       <div class="left_column_box_header">
-        <h2><%= @playlist.title %> <span class="playlist_date">(<%= @playlist.year %>)</span></h2>
+        <h2><%= @playlist.title %></h2>
         <div>
            <span class="playlist_track_size" data-target="playlist-sort.trackCount"><%= pluralize @playlist.tracks_count, 'track' %></span> <span class="playlist_dash">&mdash;</span>
            <span class="playlist_total_time" data-target="playlist-sort.totalTime"><%= @playlist.play_time %></span>

--- a/app/views/playlists/edit_white.html.erb
+++ b/app/views/playlists/edit_white.html.erb
@@ -71,7 +71,7 @@
     </p>
     <div class="box">
       <div class="left_column_box_header">
-        <h2><%= @playlist.title %> <span class="playlist_date">(2018)</span></h2>
+        <h2><%= @playlist.title %> <span class="playlist_date">(<%= @playlist.year %>)</span></h2>
         <div>
            <span class="playlist_track_size" data-target="playlist-sort.trackCount"><%= pluralize @playlist.tracks_count, 'track' %></span> <span class="playlist_dash">&mdash;</span>
            <span class="playlist_total_time" data-target="playlist-sort.totalTime"><%= @playlist.play_time %></span>


### PR DESCRIPTION
@sudara I tried to rubytune both of these changes myself, so let me know if there's a better solution. They both appeared to fix the issues.



## "Ready For Review" checklist

* [x] PR title accurately summarizes changes
* [ ] PR description
  * Does this fix any open issues?
  * What changes are you making?
  * Why did you implement it this way?
  * Is there anything reviewers need to know or pay attention to?
  * Does anything special need to happen for deployment?
* [ ] Optional: Inline github PR comments explaining context of tricky / complicated / unexpected lines so reviewers can follow along.
* [ ] If appropriate, new tests were added for isolated methods or new endpoints
* [ ] All tests green
* [ ] Percy changes are purposeful or explained
* [ ] I booted up the branch locally, exercised any new code I wrote.
* [ ] If css was touched, I verified changes are happy on mobile (via Percy is ok)
* [ ] I opened an issue for any logical followups
