### PR TITLE
Attempt to debug mysterious soft-deleted user.

### DIFF
--- a/app/commands/user_command.rb
+++ b/app/commands/user_command.rb
@@ -1,0 +1,72 @@
+class UserCommand
+  attr_reader :user
+  def initialize(user)
+    @user = user
+  end
+
+  def soft_delete_with_relations
+    efficiently_delete_relations
+    user.soft_delete
+  end
+
+  def restore_with_relations
+    efficiently_restore_relations
+    user.restore
+  end
+
+  def destroy_with_relations
+    efficiently_destroy_relations
+  end
+
+  private
+
+  def efficiently_delete_relations(time = Time.now)
+    Listen.where(track_owner_id: user.id).update_all(deleted_at: time)
+    Listen.where(listener_id: user.id).update_all(deleted_at: time)
+    Topic.where(user_id: user.id).where('posts_count < 2').destroy_all
+    Playlist.joins(:assets).where(assets: { user_id: user.id })
+            .update_all(['tracks_count = tracks_count - 1, playlists.updated_at = ?', time])
+    Track.joins(:asset).where(assets: { user_id: user.id }).update_all(deleted_at: time)
+    Comment.joins("INNER JOIN assets ON commentable_type = 'Asset' AND commentable_id = assets.id")
+           .joins('INNER JOIN users ON assets.user_id = users.id').where('users.id = ?', user.id).update_all(deleted_at: time)
+
+    user.assets.update_all(deleted_at: time)
+
+    %w[tracks playlists comments].each do |user_relation|
+      user.send(user_relation).update_all(deleted_at: time)
+    end
+  end
+
+  def efficiently_restore_relations
+    Asset.with_deleted.where(user_id: user.id).update_all(deleted_at: nil)
+    Listen.with_deleted.where(track_owner_id: user.id).update_all(deleted_at: nil)
+    Listen.with_deleted.where(listener_id: user.id).update_all(deleted_at: nil)
+    Playlist.with_deleted.joins(:assets).where(assets: { user_id: user.id })
+            .update_all(['tracks_count = tracks_count - 1, playlists.updated_at = ?', Time.now])
+    Track.with_deleted.joins(:asset).where(assets: { user_id: user.id }).update_all(deleted_at: nil)
+    Comment.with_deleted.joins("INNER JOIN assets ON commentable_type = 'Asset' AND commentable_id = assets.id")
+           .joins('INNER JOIN users ON assets.user_id = users.id').where('users.id = ?', user.id).update_all(deleted_at: nil)
+
+    Track.with_deleted.where(user_id: user.id).update_all(deleted_at: nil)
+    Playlist.with_deleted.where(user_id: user.id).update_all(deleted_at: nil)
+    Comment.with_deleted.where(user_id: user.id).update_all(deleted_at: nil)
+  end
+
+  def efficiently_destroy_relations
+    Listen.where(track_owner_id: user.id).delete_all
+    Listen.where(listener_id: user.id).delete_all
+    Playlist.joins(:assets).where(assets: { user_id: user.id })
+            .update_all(['tracks_count = tracks_count - 1, playlists.updated_at = ?', Time.now])
+    Track.joins(:asset).where(assets: { user_id: user.id }).delete_all
+
+    Comment.joins("INNER JOIN assets ON commentable_type = 'Asset' AND commentable_id = assets.id")
+           .joins('INNER JOIN users ON assets.user_id = users.id').where('users.id = ?', user.id).delete_all
+
+    user.assets.destroy_all
+
+    %w[tracks playlists posts comments].each do |user_relation|
+      user.send(user_relation).delete_all
+    end
+    true
+  end
+end

--- a/app/commands/user_command.rb
+++ b/app/commands/user_command.rb
@@ -18,6 +18,18 @@ class UserCommand
     efficiently_destroy_relations
   end
 
+  def spam_soft_delete_with_relations
+    user.spam!
+    user.update_attribute :is_spam, true
+    soft_delete_with_relations
+  end
+
+  def unspam_and_restore_with_relations
+    user.ham!
+    user.update_attribute :is_spam, false
+    restore_with_relations
+  end
+
   private
 
   def efficiently_delete_relations(time = Time.now)

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -7,24 +7,26 @@ module Admin
     end
 
     def delete
-      @user.soft_delete_with_relations
+      UserCommand.new(@user).soft_delete_with_relations
       redirect_to admin_users_path(filter_by: :deleted)
     end
 
     def restore
-      @user.restore
-      @user.restore_relations
+      UserCommand.new(@user).restore_with_relations
     end
 
     def unspam
       @user.ham!
       @user.update_attribute :is_spam, false
-      @user.restore
-      @user.restore_relations
+      UserCommand.new(@user).restore_with_relations
     end
 
     def spam
-      @user.spam_and_mark_for_deletion!
+      @user.spam!
+      @user.update_attribute :is_spam, true
+
+      UserCommand.new(@user).soft_delete_with_relations
+
       respond_to do |format|
         format.html { redirect_to admin_users_path(filter_by: :is_spam) }
         format.js

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -16,16 +16,11 @@ module Admin
     end
 
     def unspam
-      @user.ham!
-      @user.update_attribute :is_spam, false
-      UserCommand.new(@user).restore_with_relations
+      UserCommand.new(@user).unspam_and_restore_with_relations
     end
 
     def spam
-      @user.spam!
-      @user.update_attribute :is_spam, true
-
-      UserCommand.new(@user).soft_delete_with_relations
+      UserCommand.new(@user).spam_soft_delete_with_relations
 
       respond_to do |format|
         format.html { redirect_to admin_users_path(filter_by: :is_spam) }

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -6,7 +6,7 @@ class ProfilesController < ApplicationController
     if @user.spam?
       @user.update_attribute :is_spam, true
       # delete all user's associations
-      @user.soft_delete_with_relations
+      UserCommand.new(@user).soft_delete_with_relations
       flash[:error] = "Hrm, robots marked you as spam. If this was done in error, please email support@alonetone.com and magic fairies will fix it right up."
       redirect_to logout_path
     else

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -102,7 +102,7 @@ class UsersController < ApplicationController
     if admin_or_owner_with_delete
       flash[:ok] = "The alonetone account #{@user.login} has been permanently deleted."
 
-      @user.soft_delete_with_relations
+      UserCommand.new(@user).soft_delete_with_relations
 
       if moderator?
         redirect_to root_path

--- a/spec/controllers/profiles_controller_spec.rb
+++ b/spec/controllers/profiles_controller_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe ProfilesController, type: :controller do
       it "should soft delete users tracks" do
         expect do
           put :update, params: { user_id: 'sudara', profile: { bio: 'very spammy bio' } }
-        end.to change(Track, :count).by(-7)
+        end.to change(Track, :count).by(-8)
       end
 
       it "should soft delete users comments" do

--- a/spec/fixtures/tracks.yml
+++ b/spec/fixtures/tracks.yml
@@ -101,3 +101,10 @@ soft_deleted_track_on_asset:
   asset: asset_with_relations_for_soft_delete
   position: 1
   created_at: <%= 2.days.ago %>
+
+track_on_soft_deleted_of_other_user:
+  playlist: owp
+  user: sudara
+  asset: valid_arthur_mp3
+  position: 5
+  created_at: <%= 2.days.ago %>

--- a/spec/fixtures/tracks.yml
+++ b/spec/fixtures/tracks.yml
@@ -102,7 +102,7 @@ soft_deleted_track_on_asset:
   position: 1
   created_at: <%= 2.days.ago %>
 
-track_on_soft_deleted_of_other_user:
+sudaras_track_with_asset_on_other_user:
   playlist: owp
   user: sudara
   asset: valid_arthur_mp3

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -98,7 +98,7 @@ RSpec.describe User, type: :model do
 
     describe "soft delete" do
       it "should soft delete associated recored" do
-        user.soft_delete_relations
+        UserCommand.new(user).soft_delete_with_relations
         user.reload
 
         expect(user.assets).not_to be_present

--- a/spec/request/admin/users_controller_spec.rb
+++ b/spec/request/admin/users_controller_spec.rb
@@ -111,6 +111,17 @@ RSpec.describe Admin::UsersController, type: :request do
       expect(users(:arthur).topics.count).to eq(0)
       expect(users(:arthur).comments.count).to eq(0)
     end
+
+    it "soft deletes from other user's playlist" do
+      # sudara's playlist
+      playlists(:owp)
+      # arthur's track on owp playlist
+      tracks(:track_on_soft_deleted_of_other_user)
+
+      put delete_admin_user_path(users(:arthur))
+
+      expect(tracks(:track_on_soft_deleted_of_other_user).reload.deleted_at).not_to be_nil
+    end
   end
 
   describe '#index' do

--- a/spec/request/admin/users_controller_spec.rb
+++ b/spec/request/admin/users_controller_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe Admin::UsersController, type: :request do
 
   describe '#restore' do
     before :each do
-      users(:arthur).soft_delete_relations
+      UserCommand.new(users(:arthur)).soft_delete_with_relations
       users(:arthur).update(deleted_at: Time.now - 1.week)
     end
 

--- a/spec/request/admin/users_controller_spec.rb
+++ b/spec/request/admin/users_controller_spec.rb
@@ -116,11 +116,11 @@ RSpec.describe Admin::UsersController, type: :request do
       # sudara's playlist
       playlists(:owp)
       # arthur's track on owp playlist
-      tracks(:track_on_soft_deleted_of_other_user)
+      tracks(:sudaras_track_with_asset_on_other_user)
 
       put delete_admin_user_path(users(:arthur))
 
-      expect(tracks(:track_on_soft_deleted_of_other_user).reload.deleted_at).not_to be_nil
+      expect(tracks(:sudaras_track_with_asset_on_other_user).reload.deleted_at).not_to be_nil
     end
   end
 


### PR DESCRIPTION
Investigation into #653 

-  including a spec in this PR that confirms that all tracks are indeed deleted when a user and its assets are soft_deleted. 

Things I tried that didn't reproduce the bug:
:x: Soft-delete an `asset`. Observed all `tracks` are deleted
:x: Soft-delete a `user`. Observe all `assets` and `tracks` are deleted
:x: Investigated into `asset has_many :tracks` vs ` asset has_many :favorite tracks`. Both were deleted if `asset` is deleted
:x: Private playlist didn't make a difference in the above scenarios
:x: SoftDeleted user who is an asset owner, vs use who is an owner of the track. Both got deleted as part of `efficiently_delete_relations`
```
# user owned assets
Track.joins(:asset).where(assets: { user_id: user.id }).update_all(deleted_at: time)
# vs user's owned tracks
%w[tracks playlists comments].each do |user_relation|
    user.send(user_relation).update_all(deleted_at: time)
end
```
My current hypotheses are that if somehow we soft-deleted an asset (in the console) without going through the proper commands that take care of all relations then it would create this particular situation. 
```
2.6.0 :030 > Track.last
  Track Load (1.2ms)  SELECT `tracks`.* FROM `tracks` WHERE `tracks`.`deleted_at` IS NULL ORDER BY `tracks`.`id` DESC LIMIT 1
 => #<Track id: 151597, playlist_id: 10472, asset_id: 63602, position: 13, created_at: "2019-04-13 19:53:28", updated_at: "2019-04-13 19:53:28", is_favorite: true, user_id: 12880, deleted_at: nil>
2.6.0 :031 > track = _
 => #<Track id: 151597, playlist_id: 10472, asset_id: 63602, position: 13, created_at: "2019-04-13 19:53:28", updated_at: "2019-04-13 19:53:28", is_favorite: true, user_id: 12880, deleted_at: nil>
 2.6.0 :035 > track.asset.soft_delete
   (0.3ms)  BEGIN
  Asset Update (1.3ms)  UPDATE `assets` SET `assets`.`updated_at` = '2019-08-18 16:43:44', `assets`.`deleted_at` = '2019-08-18 16:43:44' WHERE `assets`.`id` = 63602
   (5.1ms)  COMMIT
 => true
2.6.0 :037 > track.reload
  Track Load (1.2ms)  SELECT `tracks`.* FROM `tracks` WHERE `tracks`.`id` = 151597 LIMIT 1
 => #<Track id: 151597, playlist_id: 10472, asset_id: 63602, position: 13, created_at: "2019-04-13 19:53:28", updated_at: "2019-04-13 19:53:28", is_favorite: true, user_id: 12880, deleted_at: nil>
2.6.0 :038 > track.asset
  Asset Load (1.6ms)  SELECT `assets`.* FROM `assets` WHERE `assets`.`deleted_at` IS NULL AND `assets`.`id` = 63602 LIMIT 1
 => nil
2.6.0 :039 > playlist.tracks.collect {|t| Asset.with_deleted.find(t.asset_id) }.count
  ...
  ...
 => 13
2.6.0 :040 > playlist.tracks.collect {|t| Asset.find(t.asset_id) }.count
...
Traceback (most recent call last):
        3: from (irb):40
        2: from (irb):40:in `collect'
        1: from (irb):40:in `block in irb_binding'
ActiveRecord::RecordNotFound (Couldn't find Asset with 'id'=63602 [WHERE `assets`.`deleted_at` IS NULL])
```
Still looking.
