### PR TITLE
Update PR template to encourage prose, detail, rational.

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,17 +1,22 @@
 ### [Bug] Provide step by step console or UI reproduction steps. When and how did the problem begin?
-### What changes are in this PR and why did you implement it this way?
 
-### Is there anything reviewers need to pay attention to? Anything difficult or tricky that should be explained?
+### What changes are in this PR? Why did you implement them this way?
+
+### Was anything tried that didn't work? Anything that reviewers should pay attention to or difficult or tricky that should be explained?
 
 ### Does anything special need to happen for deployment?
 
 ## "Ready For Review" checklist
 
+* [ ] Fixes #...
 * [ ] PR title accurately summarizes changes
-* [ ] Optional: Inline github PR comments explaining context of tricky / complicated / unexpected lines so reviewers can follow along.
-* [ ] If appropriate, new tests were added for isolated methods or new endpoints
-* [ ] All tests green
-* [ ] Percy changes are purposeful or explained
-* [ ] I booted up the branch locally, exercised any new code I wrote
-* [ ] If css was touched, I verified changes are happy on mobile (via Percy is ok)
+* [ ] New tests were added for isolated methods or new endpoints
 * [ ] I opened an issue for any logical followups
+
+
+## For review, as well as after each subsequent commit
+
+* [ ] All tests green
+* [ ] I booted up the branch locally, exercised any new code
+* [ ] Percy changes are purposeful or explained
+* [ ] I verified css changes are happy on mobile (via Percy is ok)

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,22 +1,28 @@
-### [Bug] Provide step by step console or UI reproduction steps. When and how did the problem begin?
+### [Bug] Step by step walkthrough of how to reproduce (console/UI/etc). When and how did the problem begin?
 
-### What changes are in this PR? Why did you implement them this way?
+
+### Iterate through the changes in this PR. Why did you implement them this way?
+
 
 ### Was anything tried that didn't work? Anything that reviewers should pay attention to or difficult or tricky that should be explained?
 
+
 ### Does anything special need to happen for deployment?
+
+
 
 ## "Ready For Review" checklist
 
-* [ ] Fixes #...
+These checklists are to help the author ensure the code review basics are covered. Feel free to remove to reduce noise on the PR.
+
 * [ ] PR title accurately summarizes changes
 * [ ] New tests were added for isolated methods or new endpoints
 * [ ] I opened an issue for any logical followups
+* [ ] If this fixes a bug, "Fixes #XXX" is either the very first or very last line of the description.
 
-
-## For review, as well as after each subsequent commit
+## Before code review *and after additional commits* during review.
 
 * [ ] All tests green
-* [ ] I booted up the branch locally, exercised any new code
+* [ ] Booted up the branch locally, exercised any new code
 * [ ] Percy changes are purposeful or explained
-* [ ] I verified css changes are happy on mobile (via Percy is ok)
+* [ ] Css changes are happy on mobile (via Percy is ok)

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -13,7 +13,7 @@
 
 ## "Ready For Review" checklist
 
-These checklists are to help the author ensure the code review basics are covered. Feel free to remove to reduce noise on the PR.
+These checklists are to help ensure the code review basics are covered. Consider removing to reduce noise.
 
 * [ ] PR title accurately summarizes changes
 * [ ] New tests were added for isolated methods or new endpoints
@@ -22,6 +22,7 @@ These checklists are to help the author ensure the code review basics are covere
 
 ## Before code review *and after additional commits* during review.
 
+* [ ] Update title and description to account for additional changes
 * [ ] All tests green
 * [ ] Booted up the branch locally, exercised any new code
 * [ ] Percy changes are purposeful or explained

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,18 +1,17 @@
+### [Bug] Provide step by step console or UI reproduction steps. When and how did the problem begin?
+### What changes are in this PR and why did you implement it this way?
 
+### Is there anything reviewers need to pay attention to? Anything difficult or tricky that should be explained?
+
+### Does anything special need to happen for deployment?
 
 ## "Ready For Review" checklist
 
 * [ ] PR title accurately summarizes changes
-* [ ] PR description
-  * Does this fix any open issues?
-  * What changes are you making?
-  * Why did you implement it this way?
-  * Is there anything reviewers need to know or pay attention to?
-  * Does anything special need to happen for deployment?
 * [ ] Optional: Inline github PR comments explaining context of tricky / complicated / unexpected lines so reviewers can follow along.
 * [ ] If appropriate, new tests were added for isolated methods or new endpoints
 * [ ] All tests green
 * [ ] Percy changes are purposeful or explained
-* [ ] I booted up the branch locally, exercised any new code I wrote.
+* [ ] I booted up the branch locally, exercised any new code I wrote
 * [ ] If css was touched, I verified changes are happy on mobile (via Percy is ok)
 * [ ] I opened an issue for any logical followups


### PR DESCRIPTION
### What changes are in this PR? Why did you implement them this way?

This PR adjusts the PR template to move away from a "checklist-only" description by 

1) Adding a few prose prompts
2) Adding a prompt for bug reproduction  
3) Reducing the length of the checklist and splitting it into 2 parts
4) Asking PR author to remove the checklists to reduce noise

We want to upgrade our PR descriptions from "a list of things the code does" to more of a first class representative of the changes taking place in the PR. 

Longer descriptions with the rationale and process included encourages deeper thinking. Writing them typically helps bubble up additional concerns that might otherwise not come up until code review. It also communicates more context to the reviewer.

### Was anything tried that didn't work? Is there anything reviewers need to pay attention to? Anything difficult or tricky that should be explained?

I looked into how we could create 2 different templates: bug and feature — that looks possible, but you can only actually switch between them by passing the `template` url variable and not via the UI (this is possible with issue templates, however). So for now I included the prose prompt for bug reproduction up top and it will have to be manually deleted when not applicable to the PR.

Another open issue is "noise" — for example, on this PR, almost none of the checklist is relevant. The "bug reproduction" prompt is also not relevant. To increase readability, I'd like to manually curate what is put in the PR description vs. including it all by default. 

Another concern is part of the checklist should actually happen after every commit (tests/percy/etc). It's somewhat confusing to see PRs with ✅ that tests passed, and then a red X on the actual tests. We should let the tests/percy/etc speak for themselves and have the checklist be a "reminder" that gets removed when a PR is opened.