### PR TITLE
CSS fixes and improvements for sitewide mobile issues/shortcomings

### DIFF
--- a/app/assets/stylesheets/white_theme/comments.scss
+++ b/app/assets/stylesheets/white_theme/comments.scss
@@ -22,6 +22,12 @@
   .comments_area {
     margin-bottom: 0;
   }
+  #left {
+    @media #{$one-column} {
+      margin-bottom: $baseline * 2;
+    }
+  }
+
 }
 
 /* ADDING COMMENTS */

--- a/app/assets/stylesheets/white_theme/comments.scss
+++ b/app/assets/stylesheets/white_theme/comments.scss
@@ -27,7 +27,6 @@
       margin-bottom: $baseline * 2;
     }
   }
-
 }
 
 /* ADDING COMMENTS */
@@ -64,7 +63,6 @@
       justify-content: flex-end;
       margin-left: 110px;
     }
-
   }
 }
 

--- a/app/assets/stylesheets/white_theme/edit_profile.scss
+++ b/app/assets/stylesheets/white_theme/edit_profile.scss
@@ -23,6 +23,7 @@ form#reset-password {
   }
   select {
     margin-top: 6px;
+    max-width: 100%;
   }
 }
 
@@ -34,6 +35,9 @@ form#reset-password {
     }
     input[type="text"] {
       width: 190px;
+    }
+    select {
+      max-width: 100%;
     }
   }
 }

--- a/app/assets/stylesheets/white_theme/history.scss
+++ b/app/assets/stylesheets/white_theme/history.scss
@@ -38,11 +38,16 @@
       }
     }
   }
+  #left {
+    @media #{$one-column} {
+      margin-bottom: $baseline * 2;
+    }
+  }
   #right {
     .box {
       overflow: hidden;
       margin-bottom: 0;
-      :last-child {
+      > :last-child {
         margin-bottom: 10px;
       }
     }

--- a/app/assets/stylesheets/white_theme/playlist_edit.scss
+++ b/app/assets/stylesheets/white_theme/playlist_edit.scss
@@ -181,6 +181,10 @@
     padding-left: 60px;
     padding-right: 60px;
     padding-top: 20px;
+    @media #{$mobile} {
+      padding-left: 12px;
+      padding-right: 12px;
+    }
     input {
       float: right;
       @include default-button();

--- a/app/assets/stylesheets/white_theme/playlist_edit.scss
+++ b/app/assets/stylesheets/white_theme/playlist_edit.scss
@@ -17,6 +17,9 @@
     font-family: $medium-sans-font;
     overflow: hidden;
     text-overflow: ellipsis;
+    @media #{$mobile} {
+      padding-left: 12px;
+    }
   }
   form p {
     font-size: 14px;
@@ -34,11 +37,15 @@
     @media #{$mobile} {
       padding-left: $baseline / 2;
       padding-right: $baseline / 2;
+      flex-direction: column-reverse;
     }
     flex-wrap: wrap;
     .edit_playlist_info_left_column {
       min-width: 220px;
       width: 20%;
+      @media #{$mobile} {
+        width: 100%;
+      }
       .cover {
         display: block;
         border: 1px dashed $samo-light-gray;

--- a/app/assets/stylesheets/white_theme/playlist_edit.scss
+++ b/app/assets/stylesheets/white_theme/playlist_edit.scss
@@ -45,6 +45,7 @@
       width: 20%;
       @media #{$mobile} {
         width: 100%;
+        margin-top: $baseline;
       }
       .cover {
         display: block;
@@ -86,6 +87,10 @@
       display: flex;
       flex-wrap: wrap;
       width: 75%;
+      @media #{$mobile} {
+        width: 100%;
+      }
+
       div.input {
         width: 100%;
       }
@@ -93,12 +98,18 @@
         display: flex;
         flex-direction: row;
         width: 100%;
+        @media #{$mobile} {
+          flex-direction: column;
+        }
         > :nth-child(1) {
           flex: 1;
           input {
             width: 100%;
           }
           margin-right: 30px;
+          @media #{$mobile} {
+            margin-right: 0;
+          }
         }
         > :nth-child(2) {
           width: 140px;
@@ -111,12 +122,18 @@
         display: flex;
         flex-direction: row;
         width: 100%;
+        @media #{$mobile} {
+          flex-direction: column;
+        }
         > :nth-child(1) {
           flex: 1;
           input {
             width: 100%;
           }
           margin-right: 30px;
+          @media #{$mobile} {
+            margin-right: 0px;
+          }
         }
         > :nth-child(2) {
           flex: 1;
@@ -140,6 +157,9 @@
         font-size: 12px;
         position: relative;
         height: 54px;
+        @media #{$mobile} {
+          flex-direction: column;
+        }
         div.input {
           width: auto;
         }

--- a/app/assets/stylesheets/white_theme/playlists.scss
+++ b/app/assets/stylesheets/white_theme/playlists.scss
@@ -115,13 +115,24 @@ ul.playlists {
     color: $samo-orange;
     margin-top: 0;
     margin-bottom: 16px;
+    @media #{$mobile} {
+      padding-left: 2.5%;
+    }
   }
   max-width: 1032px;
   padding: 0 $baseline * 1.5;
   box-sizing: border-box;
   margin-left: auto;
   margin-right: auto;
+  @media #{$mobile} {
+    padding-left: 0;
+    padding-right: 0;
+  }
   ul.playlists {
+    @media #{$mobile} {
+      width: 100%;
+      margin-right: 0;
+    }
     margin-right: -36px;
     li {
       margin-bottom: 30px;

--- a/app/assets/stylesheets/white_theme/playlists.scss
+++ b/app/assets/stylesheets/white_theme/playlists.scss
@@ -31,7 +31,6 @@ ul.playlists {
         position: relative;
       }
     }
-
     font-size: 11px;
     width: 220px;
     margin-right: 26.66px;

--- a/app/assets/stylesheets/white_theme/playlists.scss
+++ b/app/assets/stylesheets/white_theme/playlists.scss
@@ -70,6 +70,12 @@ ul.playlists {
     a.small_playlist_user {
       color: $black;
       font-size: 10px;
+      overflow-wrap: break-word;
+      word-wrap: break-word;
+      -webkit-hyphens: auto;
+      -ms-hyphens: auto;
+      -moz-hyphens: auto;
+      hyphens: auto;
     }
     a:last-child {
       font-weight: normal;

--- a/app/assets/stylesheets/white_theme/user.scss
+++ b/app/assets/stylesheets/white_theme/user.scss
@@ -490,8 +490,14 @@ main {
 
       background-color: #efefef;
       @include samo-shadow-and-radius();
-      padding: 16px;
+      padding: 12px 16px 4px 16px;
       box-sizing: border-box;
+      
+      > a {
+        margin-top: 0px;
+        margin-bottom: 8px;
+        margin-right: 4px;
+      }
 
       a.edit_profile {
         @include default-button("admin");

--- a/app/assets/stylesheets/white_theme/user_playlists.scss
+++ b/app/assets/stylesheets/white_theme/user_playlists.scss
@@ -6,13 +6,29 @@ main {
     max-width: 1032px;
     padding: 0 $baseline * 1.5;
     box-sizing: border-box;
+    @media #{$mobile} {
+      padding-left: 0;
+      padding-right: 0;
+    }
+    h1 {
+      @media #{$mobile} {
+        padding-left: 2.5%;
+      }
+    }
     .sort_instructions {
       color: #868686;
       margin: 8px 0;
+      @media #{$mobile} {
+        padding-left: 2.5%;
+      }
+
     }
-    
     ul.playlists {
       margin-right: -36px;
+      @media #{$mobile} {
+        width: 100%;
+        margin-right: 0;
+      }
       li {
 
         &.sortable-ghost {

--- a/app/assets/stylesheets/white_theme/user_playlists.scss
+++ b/app/assets/stylesheets/white_theme/user_playlists.scss
@@ -30,7 +30,6 @@ main {
         margin-right: 0;
       }
       li {
-
         &.sortable-ghost {
           opacity: .2;
         }

--- a/app/assets/stylesheets/white_theme/user_tracks.scss
+++ b/app/assets/stylesheets/white_theme/user_tracks.scss
@@ -1,7 +1,10 @@
 .user_tracks {
-  #left{
+  #left {
     .box {
       margin-bottom: 0;
+    }
+    @media #{$mobile} {
+      margin-bottom: $baseline * 2;
     }
   }
   h2 {

--- a/app/assets/stylesheets/white_theme/user_tracks.scss
+++ b/app/assets/stylesheets/white_theme/user_tracks.scss
@@ -3,7 +3,7 @@
     .box {
       margin-bottom: 0;
     }
-    @media #{$mobile} {
+    @media #{$one-column} {
       margin-bottom: $baseline * 2;
     }
   }

--- a/app/assets/stylesheets/white_theme/users_index.scss
+++ b/app/assets/stylesheets/white_theme/users_index.scss
@@ -8,7 +8,10 @@
   padding: 0 $baseline * 1.5;
   margin-left: auto;
   margin-right: auto;
-
+  @media #{$mobile} {
+    padding-left: 0;
+    padding-right: 0;
+  }
   .users_menu {
     box-shadow: none;
     width: 25%;
@@ -16,6 +19,9 @@
     margin-right: 5%;
     padding-left: 0;
     overflow: hidden;
+    @media #{$mobile} {
+      margin-right: 0;
+    }
     h2 {
       color: $samo-orange;
       margin-bottom: 0;
@@ -61,6 +67,10 @@
     @media #{$one-column} {
       width: 100%;
     }
+    @media #{$mobile} {
+      justify-content: space-around;
+    }
+
     div.clear {
       display: none;
     }
@@ -70,6 +80,12 @@
       margin-bottom: 30px;
       text-align: center;
       margin-right: 18px;
+      @media #{$mobile} {
+        display: block !important;
+        width: 45%;
+        margin: 0;
+        margin-bottom: 18px;
+      }
       img.cover {
         width: 125px;
         height: 125px;


### PR DESCRIPTION
✔ Edit Profile: Country input on is too wide on 320px phone
✔ Choose file for profile picture has an odd hidden and too wide input
✔ /playlists are unneccessarily narrow compared to /home and /user
✔ user/playlists are unneccessarily narrow compared to /home and /user
✔ browse artists too narrow and only 1 column
✔ /user/history columns collapse awkardly
✔ /user/comments columns collapse awkardly
✔ User Profile, Admin> Spam User, Delete User collapse poorly
✔ Edit/Playlist Heading has extra padding
✔ Edit/Playlist Title, Year, Links should have their own lines
✔ Edit/Playlist Private message wraps akwardly
✔ Edit/Playlist Delete playlist and save playlist
✔ MinnesotaCoffeeTable as a long artist name needs to link break on tiny /playlists view


### Iterate through the changes in this PR. Why did you implement them this way?

I mostly just added mobile rules to address a local list of mobile audits. I don't expect any would be controversial.

### Was anything tried that didn't work? Anything that reviewers should pay attention to or difficult or tricky that should be explained? Does anything special need to happen for deployment?

Most every line of CSS code was added within a #{$mobile} rule so I expect no universal changes or breakages.


## "Ready For Review" checklist

* [x] PR title accurately summarizes changes

## Before code review *and after additional commits* during review.

* [ ] Update title and description to account for additional changes
* [ ] All tests green
* [ ] Booted up the branch locally, exercised any new code
* [ ] Percy changes are purposeful or explained
* [ ] Css changes are happy on mobile (via Percy is ok)