### PR TITLE
Remove references to source_files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,6 @@
 /public/packs-test
 /public/pics
 /public/sitemap.xml
-/public/source_files
 /public/system
 /stats.json
 /storage

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -149,7 +149,6 @@ Alonetone::Application.routes.draw do
         get :sudo
       end
       resource 'profile'
-      resources 'source_files' #:path_prefix => ':login'
       resources 'tracks', controller: :assets do
         member do
           get :share


### PR DESCRIPTION
Looks like a bot is hitting resource route that was deprecated a while back.

[Bugsnag](https://app.bugsnag.com/alonetone/alonetone/errors/5d5d5644e2a0f6001986e1a8?event_id=5d5d5644004d676bddb20000&i=em&m=nw) - looks like a bot, but good to cleanup unused `resource` in `routes.rb`
```	
https://alonetone.com/sudara/source_files/13
# Error
ActionController::RoutingErrorGET /sudara/source_files/13
uninitialized constant SourceFilesController
```

Also, found something I don't think we have in `.gitignore`.
