### PR TITLE
Remove a 2nd minimal style for ajax feedback, break lines for comment posting feedback instead

### DIFF
--- a/app/assets/stylesheets/white_theme/ajax.scss
+++ b/app/assets/stylesheets/white_theme/ajax.scss
@@ -9,6 +9,7 @@
   margin-right: 12px;
   font-weight: bold;
   border: 1px solid transparent;
+  height: 0;
   &.ajax_fail {
     height: 22px;
     border: 1px solid #ff1f75;

--- a/app/assets/stylesheets/white_theme/ajax.scss
+++ b/app/assets/stylesheets/white_theme/ajax.scss
@@ -61,9 +61,11 @@
   box-shadow: 0px 2px 6px rgba(0, 0, 0, 0.30);
   &.ajax_success {
     border: 1px solid #67c906!important;
+    height: 33px;
   }
   &.ajax_fail {
     border: 1px solid #ff1f75!important;
+    height: 33px;
   }
   &.ajax_success > div  {
     padding-top: 9.75px;

--- a/app/assets/stylesheets/white_theme/ajax.scss
+++ b/app/assets/stylesheets/white_theme/ajax.scss
@@ -7,31 +7,16 @@
   top: 1px;
   border-radius: 2px;
   margin-right: 12px;
-  height: 22px;
+  // height: 22px;
   font-weight: bold;
   border: 1px solid transparent;
   &.ajax_fail {
+    height: 22px;
     border: 1px solid #ff1f75;
-    @media #{$mobile} {
-      border: 0;
-    }
-    @media #{$two-column-narrow} {
-      border: 0;
-    }
     > div {
       padding-right: 2px;
       color: #b20035;
       padding-top: 6.5px;
-      @media #{$mobile} {
-        span {
-          display: none;
-        }
-      }
-      @media #{$two-column-narrow} {
-        span {
-          display: none;
-        }
-      }
       &::after {
         position: absolute;
         top: 7.5px;
@@ -41,27 +26,12 @@
     }
   }
   &.ajax_success {
+    height: 22px;
     border: 1px solid #67c906;
-    @media #{$mobile} {
-      border: 0;
-    }
-    @media #{$two-column-narrow} {
-      border: 0;
-    }
     > div {
       padding-right: 2px;
       color: #2b8800;
       padding-top: 6.5px;
-      @media #{$mobile} {
-        span {
-          display: none;
-        }
-      }
-      @media #{$two-column-narrow} {
-        span {
-          display: none;
-        }
-      }
       &::after {
         position: absolute;
         top: 7px;
@@ -110,16 +80,6 @@ div.small_spinner {
   &.ajax_success > div  {
     padding-top: 9.75px;
     padding-right: 3px;
-    @media #{$mobile} {
-      span {
-        display: inline;
-      }
-    }
-    @media #{$two-column-narrow} {
-      span {
-        display: inline;
-      }
-    }
     &::after {
       position: absolute;
       top: 7.5px;
@@ -135,16 +95,6 @@ div.small_spinner {
   &.ajax_fail > div {
     padding-top: 9.75px;
     padding-right: 3px;
-    @media #{$mobile} {
-      span {
-        display: inline;
-      }
-    }
-    @media #{$two-column-narrow} {
-      span {
-        display: inline;
-      }
-    }
     &::after {
       position: absolute;
       top: 7.5px;

--- a/app/assets/stylesheets/white_theme/ajax.scss
+++ b/app/assets/stylesheets/white_theme/ajax.scss
@@ -7,7 +7,6 @@
   top: 1px;
   border-radius: 2px;
   margin-right: 12px;
-  // height: 22px;
   font-weight: bold;
   border: 1px solid transparent;
   &.ajax_fail {
@@ -42,16 +41,6 @@
   }
 }
 
-div.small_spinner {
-  display: none;
-  background: image-url("svg/icon_spinner.svg") no-repeat center center;
-  height: 20px;
-  width: 20px;
-  background-size: 100%;
-  position: relative;
-  top: 3px;
-}
-
 .floating_feedback {
   opacity: 0;
   visibility: hidden;
@@ -76,7 +65,6 @@ div.small_spinner {
   &.ajax_fail {
     border: 1px solid #ff1f75!important;
   }
-
   &.ajax_success > div  {
     padding-top: 9.75px;
     padding-right: 3px;
@@ -107,4 +95,14 @@ div.small_spinner {
       background-repeat: no-repeat;
     }
   }
+}
+
+div.small_spinner {
+  display: none;
+  background: image-url("svg/icon_spinner.svg") no-repeat center center;
+  height: 20px;
+  width: 20px;
+  background-size: 100%;
+  position: relative;
+  top: 3px;
 }

--- a/app/assets/stylesheets/white_theme/comments.scss
+++ b/app/assets/stylesheets/white_theme/comments.scss
@@ -64,7 +64,7 @@
       margin-left: 110px;
       @media #{$mobile} {
         display: block;
-        top: -2px;
+        top: -20px;
         .ajax_waiting {
           margin-right: 0;
           float: right;
@@ -75,7 +75,7 @@
       }
       @media #{$two-column-narrow} {
         display: block;
-        top: -2px;
+        top: -20px;
         .ajax_waiting {
           margin-right: 0;
           float: right;

--- a/app/assets/stylesheets/white_theme/comments.scss
+++ b/app/assets/stylesheets/white_theme/comments.scss
@@ -64,6 +64,7 @@
       margin-left: 110px;
       @media #{$mobile} {
         display: block;
+        top: -2px;
         .ajax_waiting {
           margin-right: 0;
           float: right;
@@ -74,6 +75,7 @@
       }
       @media #{$two-column-narrow} {
         display: block;
+        top: -2px;
         .ajax_waiting {
           margin-right: 0;
           float: right;

--- a/app/assets/stylesheets/white_theme/comments.scss
+++ b/app/assets/stylesheets/white_theme/comments.scss
@@ -67,7 +67,7 @@
         .ajax_waiting {
           margin-right: 0;
           float: right;
-          border: 0
+          border: 0;
           &.ajax_fail, &.ajax_success {
             margin-bottom: 12px;
           }
@@ -78,7 +78,7 @@
         .ajax_waiting {
           margin-right: 0;
           float: right;
-          border: 0
+          border: 0;
           &.ajax_fail, &.ajax_success {
             margin-bottom: 12px;
           }

--- a/app/assets/stylesheets/white_theme/comments.scss
+++ b/app/assets/stylesheets/white_theme/comments.scss
@@ -115,6 +115,7 @@
         .ajax_waiting {
           margin-right: 0;
           float: right;
+          border: 0;
           &.ajax_fail, &.ajax_success {
             margin-bottom: 12px;
           }

--- a/app/assets/stylesheets/white_theme/comments.scss
+++ b/app/assets/stylesheets/white_theme/comments.scss
@@ -57,8 +57,27 @@
       clear: both;
       justify-content: flex-end;
       margin-left: 110px;
+      @media #{$mobile} {
+        display: block;
+        .ajax_waiting {
+          margin-right: 0;
+          float: right;
+          &.ajax_fail, &.ajax_success {
+            margin-bottom: 12px;
+          }
+        }
+      }
+      @media #{$two-column-narrow} {
+        display: block;
+        .ajax_waiting {
+          margin-right: 0;
+          float: right;
+          &.ajax_fail, &.ajax_success {
+            margin-bottom: 12px;
+          }
+        }
+      }
     }
-
   }
 }
 
@@ -84,6 +103,16 @@
       clear: both;
       justify-content: flex-end;
       margin-left: 110px;
+      @media #{$one-column} {
+        display: block;
+        .ajax_waiting {
+          margin-right: 0;
+          float: right;
+          &.ajax_fail, &.ajax_success {
+            margin-bottom: 12px;
+          }
+        }
+      }
     }
   }
 }
@@ -184,6 +213,7 @@
       input.comment_submit {
         margin-bottom: 0;
         float: right;
+        clear: right;
         @include default_button();
       }
     }

--- a/app/assets/stylesheets/white_theme/comments.scss
+++ b/app/assets/stylesheets/white_theme/comments.scss
@@ -64,10 +64,10 @@
       margin-left: 110px;
       @media #{$mobile} {
         display: block;
-        top: -20px;
         .ajax_waiting {
           margin-right: 0;
           float: right;
+          border: 0
           &.ajax_fail, &.ajax_success {
             margin-bottom: 12px;
           }
@@ -75,10 +75,10 @@
       }
       @media #{$two-column-narrow} {
         display: block;
-        top: -20px;
         .ajax_waiting {
           margin-right: 0;
           float: right;
+          border: 0
           &.ajax_fail, &.ajax_success {
             margin-bottom: 12px;
           }

--- a/app/assets/stylesheets/white_theme/variables.scss
+++ b/app/assets/stylesheets/white_theme/variables.scss
@@ -26,7 +26,7 @@ $baseline: 24px; // used for various layout spacing
 // media tiers
 
 $mobile: 'only screen and (max-width: 420px)';
-$two-column-narrow: 'only screen and (min-width: 749px) and (max-width: 920px)';
+$two-column-narrow: 'only screen and (min-width: 749px) and (max-width: 952px)';
 $one-column: 'only screen and (max-width: 748px)';
 
 // fonts

--- a/app/javascript/controllers/comment_controller.js
+++ b/app/javascript/controllers/comment_controller.js
@@ -14,13 +14,15 @@ export default class extends Controller {
   success() {
     this.textareaTarget.value = ''
     this.responseTarget.innerHTML = '<div><span>Submitted, thanks!</span></div>'
-    this.responseTarget.classList.toggle('ajax_success')
+    this.responseTarget.classList.add('ajax_success')
+    this.responseTarget.classList.remove('ajax_fail')
     this.spinnerTarget.style.display = 'none'
   }
 
   error() {
     this.responseTarget.innerHTML = '<div><span>That didn\'t work!</span></div>'
-    this.responseTarget.classList.toggle('ajax_fail')
+    this.responseTarget.classList.add('ajax_fail')
+    this.responseTarget.classList.remove('ajax_success')
     this.spinnerTarget.style.display = 'none'
   }
 

--- a/app/javascript/controllers/comment_controller.js
+++ b/app/javascript/controllers/comment_controller.js
@@ -19,7 +19,7 @@ export default class extends Controller {
   }
 
   error() {
-    this.responseTarget.innerHTML = '<div><span>Sorry, that didn\'t work</span></div>'
+    this.responseTarget.innerHTML = '<div><span>That didn\'t work!</span></div>'
     this.responseTarget.classList.toggle('ajax_fail')
     this.spinnerTarget.style.display = 'none'
   }


### PR DESCRIPTION
This is to simplify the logic of the ajax feedback styles, fixes a display error on mass_edit feedback in certain screen widths, and reduces the complexity of code in ajax.scss

The compromise is that in a certain few screen widths, the comments feedback appear on a different line from the buttons. But before that, this scenario would show just a less useful green check mark.

<img width="244" alt="Screenshot 2019-08-26 15 58 38" src="https://user-images.githubusercontent.com/407724/63726690-3a579000-c81b-11e9-81e0-5fb297493d53.png">

I also added explicit add() and remove() classes for ajax_fail and success to avoid erroneous intermediate states.

## "Ready For Review" checklist

These checklists are to help ensure the code review basics are covered. Consider removing to reduce noise.

* [x] PR title accurately summarizes changes
* [ ] New tests were added for isolated methods or new endpoints
* [ ] I opened an issue for any logical followups
* [ ] If this fixes a bug, "Fixes #XXX" is either the very first or very last line of the description.

## Before code review *and after additional commits* during review.

* [x] Update title and description to account for additional changes
* [x] All tests green
* [x] Booted up the branch locally, exercised any new code
* [x] Percy changes are purposeful or explained
* [x] Css changes are happy on mobile (via Percy is ok)