### PR TITLE
Add styles to thredded pagination scss to fix unwanted cascading. Fixes #616 

### DIFF
--- a/app/assets/stylesheets/white_theme_thredded.scss
+++ b/app/assets/stylesheets/white_theme_thredded.scss
@@ -242,6 +242,21 @@ form.button_to > .thredded--post--dropdown--actions--item {
   }
 }
 
+.thredded--pagination {
+  float: none;
+  border-top: 0;
+  span {
+    font-size: 12px;
+    line-height: inherit;
+    display: block;
+    float: left;
+    height: auto;
+    padding: 0;
+    color: inherit;
+  }
+
+}
+
 .thredded--post-moderation-record--moderation-state-notice a, .thredded--post-moderation-record--content-changed-notice a, .thredded--link, .thredded--messageboard, .thredded--post--user a, .thredded--post--topic a, .thredded--post--user-and-topic a, .thredded--post--content a, .thredded--post--content--spoiler--summary, .thredded--topic-header--participants--participant > a, .thredded--topic-header--started-by a, .thredded--topic-header--edit-topic, .thredded--topic-header--follow-info form input[type=submit], .thredded--topic-header--follow-info form button, .thredded--topics--title a, .thredded--topics--updated-by a, .thredded--topics--messageboard a {
   transition: 0;
 }


### PR DESCRIPTION

Fixes the glaring misalignments shown in #616 screen shot, returns thredded pagination to a default state.

<img width="359" alt="Screenshot 2019-08-29 15 24 06" src="https://user-images.githubusercontent.com/407724/63977735-bfd47d80-ca71-11e9-8cf0-a9d83f78137e.png">

I imagine in the upcoming forum redesign branch these paginations may be updated to match the pagy bars we have elsewhere, but this will fix the issue.


### Iterate through the changes in this PR. Why did you implement them this way?

Only added some lines of css to thredded.scss

### Does anything special need to happen for deployment?

No, this won't conflict with any other code.

## "Ready For Review" checklist

These checklists are to help ensure the code review basics are covered. Consider removing to reduce noise.

* [x] PR title accurately summarizes changes
* [x] If this fixes a bug, "Fixes #XXX" is either the very first or very last line of the description.

## Before code review *and after additional commits* during review.

* [x] Update title and description to account for additional changes
* [x] All tests green
* [x] Css changes are happy on mobile (via Percy is ok)