### PR TITLE
Add a span and overflow rules to last line of .listens. Fixes #703 

### DIFF
--- a/app/assets/stylesheets/white_theme/history.scss
+++ b/app/assets/stylesheets/white_theme/history.scss
@@ -36,6 +36,12 @@
         font-size: 10px;
         font-weight: bold;
       }
+      span {
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        display: block;
+      }
     }
   }
   #left {

--- a/app/assets/stylesheets/white_theme/user.scss
+++ b/app/assets/stylesheets/white_theme/user.scss
@@ -614,6 +614,12 @@ main {
               font-size: 10px;
               font-weight: bold;
             }
+            span {
+              white-space: nowrap;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              display: block;
+            }
           }
         }
       }

--- a/app/views/users/_track_play.html.erb
+++ b/app/views/users/_track_play.html.erb
@@ -9,7 +9,7 @@
     <%= local_time_ago(track_play.created_at) %>
     by <%= track_play.listener ? (link_to (h track_play.listener.name), user_home_path(track_play.listener)) :
     "Guest #{track_play.ip.present? ? '('+track_play.ip+')': ''}" %> <br>
-    via <%= link_source(track_play.source) %>
+    <span>via <%= link_source(track_play.source) %></span>
   </div>
   <div class="listen_flag">
     <%= flag_for track_play.country %>


### PR DESCRIPTION
### [Bug] Step by step walkthrough of how to reproduce (console/UI/etc). When and how did the problem begin?

See #703 


### Iterate through the changes in this PR. Why did you implement them this way?

I added some CSS to truncate that last line if the URL listened from is very long, now instead of breaking to a 4th line that doesn't fit, a ellipses is added and it's truncated before the flag.

<img width="243" alt="Screenshot 2019-08-29 15 47 56" src="https://user-images.githubusercontent.com/407724/63978885-be588480-ca74-11e9-91d7-889d8582e7fc.png">


### Does anything special need to happen for deployment?

No


## "Ready For Review" checklist

These checklists are to help ensure the code review basics are covered. Consider removing to reduce noise.

* [x] PR title accurately summarizes changes
* [x] If this fixes a bug, "Fixes #XXX" is either the very first or very last line of the description.

## Before code review *and after additional commits* during review.

* [ ] All tests green
* [ ] Booted up the branch locally, exercised any new code
* [ ] Percy changes are purposeful or explained
* [x] Css changes are happy on mobile (via Percy is ok)