### PR TITLE
Fixes #582 safari view all and box-shadow overlap bug

### DIFF
--- a/app/assets/stylesheets/white_theme/alonetone.scss
+++ b/app/assets/stylesheets/white_theme/alonetone.scss
@@ -71,7 +71,7 @@ ul {
       vertical-align: top;
       display: inline;
       i.icon_caret {
-        margin-left: -4px;
+        margin-left: -3px;
         position: relative;
         top: 5px;
         svg {

--- a/app/assets/stylesheets/white_theme/alonetone.scss
+++ b/app/assets/stylesheets/white_theme/alonetone.scss
@@ -66,7 +66,6 @@ ul {
     @include samo-shadow-and-radius();
     background-color: $white;
     box-shadow: none;
-    text-align: right;
     font-size: 15px;
     font-family: $medium-sans-font;
     display: inline-block;
@@ -75,7 +74,6 @@ ul {
       vertical-align: top;
       display: inline;
       i.icon_caret {
-        margin-left: -2px;
         position: relative;
         top: 5px;
         svg {

--- a/app/assets/stylesheets/white_theme/alonetone.scss
+++ b/app/assets/stylesheets/white_theme/alonetone.scss
@@ -74,7 +74,7 @@ ul {
       i.icon_caret {
         position: relative;
         top: 5px;
-        margin-left: -3px;
+        margin-left: -3.5px;
         svg {
           height: 20px;
           .icon_caret_path {

--- a/app/assets/stylesheets/white_theme/alonetone.scss
+++ b/app/assets/stylesheets/white_theme/alonetone.scss
@@ -53,12 +53,11 @@ ul {
   text-align: right;
   a.view_all {
     font-size: 15px;
-    font-weight: normal;
     font-family: $medium-sans-font;
+    display: inline-block;
     color: #868686;
     border: 0;
     margin-right: 4px;
-    display: inline-block;
     margin-top: 12px;
     text-align: right;
     padding-left: 20px;
@@ -70,27 +69,22 @@ ul {
     box-shadow: none;
     span {
       vertical-align: top;
-      display: inline-flex;
-    }
-    i.icon_caret {
-      position: relative;
-      top: 5px;
-      svg {
-        height: 20px;
+      display: inline;
+      i.icon_caret {
+        margin-left: -4px;
+        position: relative;
+        top: 5px;
+        svg {
+          height: 20px;
+          .icon_caret_path {
+            stroke: $samo-orange;
+          }
+        }
       }
-    }
-    .icon_caret_path {
-      stroke: $samo-orange;
     }
     &:hover {
       text-decoration: none;
-      span {
-        color: $samo-orange;
-        text-decoration: none;
-        .icon_caret_path {
-          stroke: $samo-orange;
-        }
-      }
+      color: $samo-orange;
     }
   }
 }

--- a/app/assets/stylesheets/white_theme/alonetone.scss
+++ b/app/assets/stylesheets/white_theme/alonetone.scss
@@ -71,11 +71,10 @@ ul {
     display: inline-block;
     color: #868686;
     span {
-      vertical-align: top;
-      display: inline;
       i.icon_caret {
         position: relative;
         top: 5px;
+        margin-left: 6px;
         svg {
           height: 20px;
           .icon_caret_path {

--- a/app/assets/stylesheets/white_theme/alonetone.scss
+++ b/app/assets/stylesheets/white_theme/alonetone.scss
@@ -52,14 +52,9 @@ ul {
 .below_box {
   text-align: right;
   a.view_all {
-    font-size: 15px;
-    font-family: $medium-sans-font;
-    display: inline-block;
-    color: #868686;
     border: 0;
     margin-right: 4px;
     margin-top: 12px;
-    text-align: right;
     padding-left: 20px;
     padding-right: 6px;
     height: 32px;
@@ -67,6 +62,11 @@ ul {
     @include samo-shadow-and-radius();
     background-color: #fff;
     box-shadow: none;
+    text-align: right;
+    font-size: 15px;
+    font-family: $medium-sans-font;
+    display: inline-block;
+    color: #868686;
     span {
       vertical-align: top;
       display: inline;

--- a/app/assets/stylesheets/white_theme/alonetone.scss
+++ b/app/assets/stylesheets/white_theme/alonetone.scss
@@ -74,7 +74,7 @@ ul {
       i.icon_caret {
         position: relative;
         top: 5px;
-        margin-left: 6px;
+        margin-left: -3px;
         svg {
           height: 20px;
           .icon_caret_path {


### PR DESCRIPTION
### Iterate through the changes in this PR. Why did you implement them this way?

See strange artifacts in #582 

Safari only bug, but could have been related to that being maybe the only place I was using display: inline-flex.

Fixed it by rewriting that structure with an inline and some adjustments.

Also, Cleaned up some extra lines and un-needed rules within this view_all button.

### Does anything special need to happen for deployment?

No, just css changes within one button in one file and within Percy's gaze.

## "Ready For Review" checklist

These checklists are to help ensure the code review basics are covered. Consider removing to reduce noise.

* [x] PR title accurately summarizes changes
* [x] If this fixes a bug, "Fixes #XXX" is either the very first or very last line of the description.

## Before code review *and after additional commits* during review.

* [x] Update title and description to account for additional changes
* [x] All tests green
* [x] Booted up the branch locally, exercised any new code
* [x] Percy changes are purposeful or explained
* [x] Css changes are happy on mobile (via Percy is ok)