### PR TITLE
Add styles for ul and ol in thredded post content

### DIFF
--- a/app/assets/stylesheets/white_theme_thredded.scss
+++ b/app/assets/stylesheets/white_theme_thredded.scss
@@ -97,7 +97,7 @@ aside.thredded--currently-online {
         }
       }
     }
-    
+
     margin-bottom: $baseline;
     padding-top: $baseline * 0.5;
     border-top: 1px solid $thredded-base-border-color;
@@ -140,6 +140,40 @@ aside.thredded--currently-online {
       }
       .thredded--post--content {
         font-size: 1rem;
+        line-height: 1.5rem;
+        font-size: 1rem;
+        h1,
+        h2,
+        h3 {
+          margin-bottom: 0;
+        }
+        h2 {
+          color: $dark-gray;
+          margin-top: 2rem;
+          margin-bottom: 0.25rem;
+          line-height: 1.5rem;
+        }
+        ul {
+          padding-left: 24px;
+          li {
+            list-style-type: disc;
+          }
+        }
+        ol {
+          counter-reset: listNumbering;
+          padding-left: 6px;
+          li {
+            list-style: none;
+            counter-increment: listNumbering;
+            &:before {
+              content: counter(listNumbering) ".";
+              font-variant-numeric: tabular-nums;
+              font-size: 14px;
+              color: $black;
+              margin-right: 6px;
+            }
+          }
+        }
       }
     }
     article.thredded--topics--topic {
@@ -158,21 +192,6 @@ aside.thredded--currently-online {
     }
     .thredded--post-form--wrapper {
       border-top: 0;
-    }
-  }
-  .thredded--post--content {
-    line-height: 1.5rem;
-    font-size: 1rem;
-    h1,
-    h2,
-    h3 {
-      margin-bottom: 0;
-    }
-    h2 {
-      color: $dark-gray;
-      margin-top: 2rem;
-      margin-bottom: 0.25rem;
-      line-height: 1.5rem;
     }
   }
   [type="checkbox"]:not(:checked),
@@ -254,9 +273,24 @@ form.button_to > .thredded--post--dropdown--actions--item {
     padding: 0;
     color: inherit;
   }
-
 }
 
-.thredded--post-moderation-record--moderation-state-notice a, .thredded--post-moderation-record--content-changed-notice a, .thredded--link, .thredded--messageboard, .thredded--post--user a, .thredded--post--topic a, .thredded--post--user-and-topic a, .thredded--post--content a, .thredded--post--content--spoiler--summary, .thredded--topic-header--participants--participant > a, .thredded--topic-header--started-by a, .thredded--topic-header--edit-topic, .thredded--topic-header--follow-info form input[type=submit], .thredded--topic-header--follow-info form button, .thredded--topics--title a, .thredded--topics--updated-by a, .thredded--topics--messageboard a {
+.thredded--post-moderation-record--moderation-state-notice a,
+.thredded--post-moderation-record--content-changed-notice a,
+.thredded--link,
+.thredded--messageboard,
+.thredded--post--user a,
+.thredded--post--topic a,
+.thredded--post--user-and-topic a,
+.thredded--post--content a,
+.thredded--post--content--spoiler--summary,
+.thredded--topic-header--participants--participant > a,
+.thredded--topic-header--started-by a,
+.thredded--topic-header--edit-topic,
+.thredded--topic-header--follow-info form input[type="submit"],
+.thredded--topic-header--follow-info form button,
+.thredded--topics--title a,
+.thredded--topics--updated-by a,
+.thredded--topics--messageboard a {
   transition: 0;
 }


### PR DESCRIPTION
Fixes #727 
 
<img width="992" alt="Screenshot 2019-09-06 19 00 51" src="https://user-images.githubusercontent.com/407724/64467766-27757300-d0d9-11e9-8359-69486e17fa06.png">

### Iterate through the changes in this PR. Why did you implement them this way?

I guess sometimes these elements are more fancily designed, color bullets, etc. I tried to come up with a basic solution for now.

A max-width of 100% for an <img> within a post exists. The image in my screenshot is 4000px wide.

### Does anything special need to happen for deployment?

No, just adding some styles in one SASS file.

## "Ready For Review" checklist

These checklists are to help ensure the code review basics are covered. Consider removing to reduce noise.

* [x] PR title accurately summarizes changes
* [x] If this fixes a bug, "Fixes #XXX" is either the very first or very last line of the description.

## Before code review *and after additional commits* during review.

* [x] Update title and description to account for additional changes
* [ ] All tests green
* [ ] Booted up the branch locally, exercised any new code
* [ ] Percy changes are purposeful or explained
* [ ] Css changes are happy on mobile (via Percy is ok)