### PR TITLE
Fixes #715 Add CSS styles to Password Reset page

### DIFF
--- a/app/assets/stylesheets/white_theme.scss
+++ b/app/assets/stylesheets/white_theme.scss
@@ -22,6 +22,7 @@
 @import 'white_theme/radio';
 
 @import 'white_theme/login_signup';
+@import 'white_theme/password_reset';
 
 @import 'white_theme/user';
 @import 'white_theme/about_stats'; 

--- a/app/assets/stylesheets/white_theme/password_reset.scss
+++ b/app/assets/stylesheets/white_theme/password_reset.scss
@@ -1,0 +1,14 @@
+.password_reset {
+  margin-right: auto;
+  margin-left: auto;
+  max-width: 720px;
+  .static_content {
+    padding: $baseline $baseline / 2;
+  }
+  br {
+    display: block;
+  }
+  input[type=submit] {
+    margin-bottom: 0;
+  }
+}

--- a/app/views/password_resets/edit.html.erb
+++ b/app/views/password_resets/edit.html.erb
@@ -1,9 +1,9 @@
-<div class="box">
-  <h2 class="box">Alright, pick a new password</h2>
-  <div id="login" class="static_content box">
+<div class="box password_reset">
+  <h2>Alright, pick a new password</h2>
+  <div id="login" class="static_content">
     <%= form_with model: @user, url: password_reset_path, method: :put do |f| %>
-      <%= f.password_field :password %><br/>
-      <%= f.password_field :password_confirmation %>
+      <%= f.password_field :password, placeholder: "Enter New Password" %><br/>
+      <%= f.password_field :password_confirmation, placeholder: "Confirm New Password" %><br>
       <%= f.submit "Come on in..." %>
     <% end %>
   </div>


### PR DESCRIPTION
### [Bug] Step by step walkthrough of how to reproduce (console/UI/etc). When and how did the problem begin?

I think when simple form was removed, this page lost its default styles that kept things somewhat orderly.

### Iterate through the changes in this PR. Why did you implement them this way?

I made a separate .scss file for this page, since that seems to work as a way to organize styling.

<img width="815" alt="Screenshot 2019-09-10 12 59 24" src="https://user-images.githubusercontent.com/407724/64643275-4cb1fc00-d3cd-11e9-9228-27f6acaddadb.png">

### Does anything special need to happen for deployment?

No, these changes are all compartmentalized from other code.

## "Ready For Review" checklist

These checklists are to help ensure the code review basics are covered. Consider removing to reduce noise.

* [ ] PR title accurately summarizes changes
* [ ] New tests were added for isolated methods or new endpoints
* [ ] I opened an issue for any logical followups
* [ ] If this fixes a bug, "Fixes #XXX" is either the very first or very last line of the description.

## Before code review *and after additional commits* during review.

* [ ] Update title and description to account for additional changes
* [ ] All tests green
* [ ] Booted up the branch locally, exercised any new code
* [ ] Percy changes are purposeful or explained
* [ ] Css changes are happy on mobile (via Percy is ok)