### PR TITLE
Fixes #726 Change textarea font in the single track editor back to normal

### DIFF
--- a/app/assets/stylesheets/white_theme/single_and_playlists_player/track_content.scss
+++ b/app/assets/stylesheets/white_theme/single_and_playlists_player/track_content.scss
@@ -214,6 +214,7 @@
       }
     }
     textarea {
+      font-family: $sans-font;
       font-size: 16px;
       line-height: 23px;
       position: relative;


### PR DESCRIPTION
### [Bug] Step by step walkthrough of how to reproduce (console/UI/etc). When and how did the problem begin?

At one point of standardizing CSS, where all other inputs on the site use a medium weight for their inputs, this textarea got switched over.

But it was intended to match the display of its associated /view so it should be normal in the editor too.

<img width="512" alt="Screen Shot 2019-09-10 at 1 33 13 PM" src="https://user-images.githubusercontent.com/407724/64644291-8e43a680-d3cf-11e9-86b5-e69ab2ade667.png">


### Does anything special need to happen for deployment?

No, I changed one line of CSS in one file.

## "Ready For Review" checklist

These checklists are to help ensure the code review basics are covered. Consider removing to reduce noise.

* [x] PR title accurately summarizes changes
* [x] If this fixes a bug, "Fixes #XXX" is either the very first or very last line of the description.

## Before code review *and after additional commits* during review.

* [x] Update title and description to account for additional changes
* [x] All tests green
* [x] Booted up the branch locally, exercised any new code
* [x] Percy changes are purposeful or explained
* [x] Css changes are happy on mobile (via Percy is ok)