### PR TITLE
Misc stats and lists fixes

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -145,7 +145,7 @@ class UsersController < ApplicationController
     @popular_tracks = @user.assets.includes(user: :pic).limit(5).reorder('assets.listens_count DESC')
     @assets = @user.assets.includes(user: :pic).limit(5)
     @playlists = @user.playlists.include_private.includes(:user, :pic)
-    @listens = @user.listened_to_tracks.preload(:user).limit(5)
+    @listens = @user.listened_to_tracks.preload(:user).group(:asset_id).limit(5)
     @track_plays = @user.track_plays.from_user.limit(10)
     @favorites = @user.tracks.favorites.recent.includes(asset: { user: :pic }).limit(5).collect(&:asset)
     @comments = @user.comments.public_or_private(display_private_comments?)

--- a/spec/fixtures/listens.yml
+++ b/spec/fixtures/listens.yml
@@ -1,7 +1,7 @@
 valid_listen:
   listener: sudara
   asset: valid_mp3
-  track_owner: arthur
+  track_owner: sudara
 another_valid_listen:
   listener: arthur
   asset: valid_mp3
@@ -13,4 +13,8 @@ listens_on_soft_deleted_asset:
 listens_on_soft_deleted_asset2:
   listener: sudara
   asset: asset_with_relations_for_soft_delete
+  track_owner: jamie_kiesl
+listens_to_test_recently_listened:
+  listener: sudara
+  asset: another_valid_asset_to_test_on_latest
   track_owner: jamie_kiesl

--- a/spec/request/users_controller_spec.rb
+++ b/spec/request/users_controller_spec.rb
@@ -24,6 +24,24 @@ RSpec.describe UsersController, type: :request do
         end
       end
     end
+
+    # it should display 5 unique titles for assets of latest listens
+    it "displays only unique listens on Recently Listened To" do
+      # create 5 of the same listen and one extra
+      # ensure it definitely shows the other listens
+      5.times do |t|
+        Listen.create(asset: assets(:valid_arthur_mp3), listener: users(:sudara), track_owner: users(:arthur))
+      end
+
+      get "/#{users(:sudara).login}"
+
+      # from assets(:valid_arthur_mp3)
+      expect(response.body).to match(/arthur\/tracks\/song1.mp3/)
+      # from listens(:another_valid_asset_to_test_on_latest)
+      expect(response.body).to match(/Second hottest asset to test latest/)
+      # from assets(:asset_with_relations_for_soft_delete)
+      expect(response.body).to match(/Asset to test soft deletion of relations/)
+    end
   end
 
   context "POST create" do


### PR DESCRIPTION
### Fixes #794 
Only display unique recent listens. I do too sometimes put my favorite song on loop, but I just don't want to be reminded at just how MANY times I listened to it :)

#### [Bug] To reproduce
If you actually have any of the files locally, listen to a song a bunch of times and observe before and after in `/you_user` -> Recently Listened To
Another way is to do it in `RAILS_ENV=test rails s`. 
```
5.times do
   Listen.create(asset: asset, listener: user, track_owner: user)
end
```
<img width="441" alt="sudara_s_Music___alonetone" src="https://user-images.githubusercontent.com/2320322/65825906-af6b1a80-e24a-11e9-86ed-917a37f60cf0.png">

<img width="426" alt="Fullscreen_9_28_19__11_44_PM" src="https://user-images.githubusercontent.com/2320322/65825901-aa0dd000-e24a-11e9-84db-8f2661962f42.png">

#### "Ready For Review" checklist

* [x] PR title accurately summarizes changes
* [x] New tests were added for isolated methods or new endpoints
* [x] If this fixes a bug, "Fixes #XXX" is either the very first or very last line of the description.

## Before code review *and after additional commits* during review.

* [ ] Update title and description to account for additional changes
* [ ] All tests green
* [ ] Booted up the branch locally, exercised any new code
* [ ] Percy changes are purposeful or explained
* [ ] Css changes are happy on mobile (via Percy is ok)
