### PR TITLE
Add some styles to make errorExplanation at least halfway sane

### DIFF
--- a/app/assets/stylesheets/components/notifications.scss
+++ b/app/assets/stylesheets/components/notifications.scss
@@ -115,14 +115,29 @@ div.small_spinner {
   padding: 20px 30px;
   background-color: $background-color-one;
   width: 100%;
+  max-width: 960px;
+  padding: 0 $baseline * 1.5;
+  box-sizing: border-box;
   margin-right: auto;
   margin-left: auto;
+  padding-top: $baseline * 2;
+  padding-bottom: $baseline * 2;
+  @include samo-shadow-and-radius();
   @media #{$mobile} {
     width: 96%;
   }
+  h2 {
+    color: $accent;
+  }
+  ul {
+    li {
+      margin-bottom: $baseline / 4;
+    }
+  }
+  
+  
 }
 
-.errorExplanation p,
 .notice h2 {
   font-size: 20px;
   font-weight: bold;


### PR DESCRIPTION
Fixes #790

I imagine this might be temporary. I think these form requirements should be handled with Javascript next to the form itself. ( also, related issue is you can have a 0 length password and pass the validation #772 ) 

I don't know if this errorExplanation/notice paradigm has a future.

Before:

<img width="741" alt="Screenshot 2019-09-30 13 24 09" src="https://user-images.githubusercontent.com/407724/65909972-f78f5780-e386-11e9-84f9-3624615363fc.png">

After:

<img width="672" alt="Screenshot 2019-09-30 13 31 33" src="https://user-images.githubusercontent.com/407724/65909975-fbbb7500-e386-11e9-99e8-f7fa1f6e31bf.png">


### Does anything special need to happen for deployment?

I don't think so. Just adding some css rules to those specific divs.


## "Ready For Review" checklist

These checklists are to help ensure the code review basics are covered. Consider removing to reduce noise.

* [ ] PR title accurately summarizes changes
* [ ] New tests were added for isolated methods or new endpoints
* [ ] I opened an issue for any logical followups
* [ ] If this fixes a bug, "Fixes #XXX" is either the very first or very last line of the description.

## Before code review *and after additional commits* during review.

* [ ] Update title and description to account for additional changes
* [ ] All tests green
* [ ] Booted up the branch locally, exercised any new code
* [ ] Percy changes are purposeful or explained
* [ ] Css changes are happy on mobile (via Percy is ok)
