### PR TITLE
Fix mobile dropdown search reveal to not show on desktop views

### DIFF
--- a/app/assets/stylesheets/components/site_header.scss
+++ b/app/assets/stylesheets/components/site_header.scss
@@ -104,7 +104,7 @@ header#site_header {
         
       }
       #mobile_search_reveal_button {
-        display: block;
+        display: none;
         width: 36px;
         height: 36px;
         background-color: $background-color-four;
@@ -112,6 +112,10 @@ header#site_header {
         background-image: $site-header-search-magnifying-glass-image;
         background-position: center;
         background-repeat: no-repeat;
+        @media #{$mobile} {
+          display: block; 
+        }
+
       }
     }
     .login_button {

--- a/app/assets/stylesheets/components/site_header.scss
+++ b/app/assets/stylesheets/components/site_header.scss
@@ -50,7 +50,6 @@ header#site_header {
         margin-right: $baseline / 2;
         padding-left: $baseline / 2;
       }
-
       #search_form {
         display: block;
         height: 100%;
@@ -84,7 +83,6 @@ header#site_header {
               width: 100%;
             }
           }
-
         }
       }
       #search_button {
@@ -101,7 +99,6 @@ header#site_header {
         @media #{$mobile} {
           display: none; 
         }
-        
       }
       #mobile_search_reveal_button {
         display: none;
@@ -115,7 +112,6 @@ header#site_header {
         @media #{$mobile} {
           display: block; 
         }
-
       }
     }
     .login_button {


### PR DESCRIPTION

Please merge this before deploying! The mobile search reveal button ( square with magnifying glass) shouldn't appear on desktop views, only when the site goes to mobile widths.


### Iterate through the changes in this PR. Why did you implement them this way?

Added a couple lines of CSS to only show this special button on mobile widths, when clicking on it will then reveal the full header search field.


## "Ready For Review" checklist

These checklists are to help ensure the code review basics are covered. Consider removing to reduce noise.

* [ ] PR title accurately summarizes changes
* [ ] New tests were added for isolated methods or new endpoints
* [ ] I opened an issue for any logical followups
* [ ] If this fixes a bug, "Fixes #XXX" is either the very first or very last line of the description.

## Before code review *and after additional commits* during review.

* [ ] Update title and description to account for additional changes
* [ ] All tests green
* [ ] Booted up the branch locally, exercised any new code
* [ ] Percy changes are purposeful or explained
* [ ] Css changes are happy on mobile (via Percy is ok)
