### PR TITLE
Fix two vertical alignment issues, add shadow to back to artist's profile link

### DIFF
--- a/app/assets/stylesheets/components/shared.scss
+++ b/app/assets/stylesheets/components/shared.scss
@@ -97,6 +97,7 @@ ul {
   color: $font-color-three;
   display: inline-flex;
   margin-bottom: $baseline;
+  @include shadow-one();
   .caret {
     background-color: $accent;
     display: block;
@@ -116,11 +117,9 @@ ul {
   }
   .text {
     font-family: $medium-sans-font;
-    padding: 6px 12px 0 12px;
-    padding-left: 12px;
-    padding-right: 12px;
+    padding: 8px 12px 0 12px;
     font-size: 12px;
-    line-height: 1.6;
+    line-height: 1;
   }
   span {
     color: $accent;

--- a/app/assets/stylesheets/components/site_header.scss
+++ b/app/assets/stylesheets/components/site_header.scss
@@ -67,7 +67,7 @@ header#site_header {
           border: 0;
           border-radius: 3px;
           transition: width .4s, background-color .4s, border-width .4s;
-          line-height: 1;
+          line-height: normal;
           &:focus {
             border-width: 0px;
             width: 256px;

--- a/app/assets/stylesheets/components/site_header.scss
+++ b/app/assets/stylesheets/components/site_header.scss
@@ -67,6 +67,7 @@ header#site_header {
           border: 0;
           border-radius: 3px;
           transition: width .4s, background-color .4s, border-width .4s;
+          line-height: 1;
           &:focus {
             border-width: 0px;
             width: 256px;

--- a/app/assets/stylesheets/components/variables.scss
+++ b/app/assets/stylesheets/components/variables.scss
@@ -80,3 +80,11 @@ $black-font: 'Alright-v2-Normal-Black', sans-serif;
   }
 
 }
+
+@mixin shadow-one() {
+  box-shadow: 0px 1px 2px rgba(53, 53, 53, 0.15);
+}
+
+@mixin shadow-one-inner {
+  box-shadow: inset 0px .5px 1.5px rgba(0, 0, 0, 0.33);
+}


### PR DESCRIPTION
Fixes #785 

The other issue, in Safari, the placeholder text was oddly aligned compared to the actual input.
I think setting line-height: normal is the solution. Was found on google to be a fix for such things.

![Screenshot 2019-10-01 14 56 35](https://user-images.githubusercontent.com/407724/65999944-adc47100-e45b-11e9-9eab-7c0f5f3950f8.png)

I also added a shadow-one to the Back to Artist's Profile Link

### Was anything tried that didn't work? Anything that reviewers should pay attention to or difficult or tricky that should be explained?

### Does anything special need to happen for deployment?

I don't think so! 


## "Ready For Review" checklist

These checklists are to help ensure the code review basics are covered. Consider removing to reduce noise.

* [x] PR title accurately summarizes changes
* [ ] New tests were added for isolated methods or new endpoints
* [ ] I opened an issue for any logical followups
* [x] If this fixes a bug, "Fixes #XXX" is either the very first or very last line of the description.

## Before code review *and after additional commits* during review.

* [ ] Update title and description to account for additional changes
* [ ] All tests green
* [ ] Booted up the branch locally, exercised any new code
* [ ] Percy changes are purposeful or explained
* [ ] Css changes are happy on mobile (via Percy is ok)
