### PR TITLE
Prevent analyzer and previewer jobs from running after upload

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -33,6 +33,10 @@ module Alonetone
     config.active_storage.service = config.alonetone.storage_service
     config.active_storage.variant_processor = :vips
 
+    # Turn off previewers and analysers because we don't use them.
+    config.active_storage.analyzers = []
+    config.active_storage.previewers = []
+
     def fastly_enabled?
       config.alonetone.fastly_base_url.present?
     end

--- a/config/initializers/storage.rb
+++ b/config/initializers/storage.rb
@@ -1,0 +1,8 @@
+# Prevent Rails from even scheduling ActiveStorage::AnalyzeJob by overriding
+# the method that schedules it.
+
+Rails.application.config.after_initialize do
+  ActiveStorage::Blob::Analyzable.module_eval do
+    def analyze_later; end
+  end
+end


### PR DESCRIPTION
Active Storage normally schedules a job to analyze uploaded files. We are not interested in the metadata resulting from this action. This PR turns those off.

Closes #814.