### PR TITLE
Change vertical waveform alignment to be handled by flexbox rather than top padding

### DIFF
--- a/app/assets/stylesheets/components/single_and_playlists_player/playlist.scss
+++ b/app/assets/stylesheets/components/single_and_playlists_player/playlist.scss
@@ -55,7 +55,4 @@
       margin-right: auto;
     }
   }
-  .player .waveform {
-    padding-top: 14px;
-  }
 }

--- a/app/assets/stylesheets/components/single_and_playlists_player/track_player.scss
+++ b/app/assets/stylesheets/components/single_and_playlists_player/track_player.scss
@@ -29,6 +29,9 @@
     flex-grow: 1;
     user-select: none;
     position: relative;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
     svg {
       width: 100%;
       height: 54px;

--- a/app/assets/stylesheets/components/single_and_playlists_player/track_player.scss
+++ b/app/assets/stylesheets/components/single_and_playlists_player/track_player.scss
@@ -26,7 +26,6 @@
   .waveform {
     top: 0;
     right: 0;
-    padding-top: 10px;
     flex-grow: 1;
     user-select: none;
     position: relative;


### PR DESCRIPTION
Fixes #800 

### [Bug] Step by step walkthrough of how to reproduce (console/UI/etc). When and how did the problem begin?

Padding tops were set to 10px and 14px for the single player and playlist player waveforms.

### Iterate through the changes in this PR. Why did you implement them this way?

I rewrote the vertical centering with flex box for both cases.

### Does anything special need to happen for deployment?

I don't think so.


## "Ready For Review" checklist

These checklists are to help ensure the code review basics are covered. Consider removing to reduce noise.

* [x] PR title accurately summarizes changes
* [ ] New tests were added for isolated methods or new endpoints
* [ ] I opened an issue for any logical followups
* [x] If this fixes a bug, "Fixes #XXX" is either the very first or very last line of the description.

## Before code review *and after additional commits* during review.

* [ ] Update title and description to account for additional changes
* [ ] All tests green
* [ ] Booted up the branch locally, exercised any new code
* [ ] Percy changes are purposeful or explained
* [ ] Css changes are happy on mobile (via Percy is ok)
