### PR TITLE
Silence logging for requests to Active Storage controllers in development

### DIFF
--- a/lib/filtered_rack_logger.rb
+++ b/lib/filtered_rack_logger.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# Works just like the regular Rails Rack request logger, but silences all requests to the
+# configured silenced request paths.
+#
+#   config.middleware.use(
+#     FilteredRackLogger,
+#     silenced: %w(/rails/active_storage)
+#   )
+class FilteredRackLogger < Rails::Rack::Logger
+  def initialize(app, silenced:)
+    super(app)
+    @silenced = silenced
+  end
+
+  def call(env)
+    if @silenced.any? { |path_prefix| env['PATH_INFO'].start_with?(path_prefix) }
+      Rails.logger.silence { @app.call(env) }
+    else
+      super
+    end
+  end
+end


### PR DESCRIPTION
When Active Storage is using the `filesystem` storage variant and running in development mode we silence all requests to the Active Storage controllers because they make it hard to read the relevant output during development.

References #834.