### PR TITLE
783-Admin users should search "display_name"

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -278,7 +278,7 @@ class User < ApplicationRecord
     when "not_spam"
       with_deleted.where(is_spam: false).recent
     when String
-      with_deleted.where("email like '%#{filter}%' or login like '%#{filter}%'").recent
+      with_deleted.where("email like '%#{filter}%' or login like '%#{filter}%' or display_name like '%#{filter}%'").recent
     else
       with_deleted.recent
     end

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -34,7 +34,7 @@
                 <%= user_image(user, variant: :large) %>
               </div>
               <div>
-                <div><%= user.soft_deleted? ? user.login : link_to(user.login + " (#{user.display_name})", user_home_path(user.login)) %></div>
+                <div><%= user.soft_deleted? ? user.display_name : link_to(user.display_name, user_home_path(user.login)) %></div>
                 <div><%= user.email %></div>
                 <% unless user.soft_deleted? %>
                 <div><%= user.current_login_ip %>

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -8,7 +8,7 @@
   <div class="admin_column_right">
    <div class="admin_search_field">
     <%= form_for 'filter_by', method: :get do |f| %>
-      <%= text_field_tag 'filter_by',nil, placeholder: 'Search by login or email' %>
+      <%= text_field_tag 'filter_by', nil, placeholder: 'Search by login or email' %>
     <% end %>
     </div>
     <div class="mini_paginator top_paginator">
@@ -34,7 +34,7 @@
                 <%= user_image(user, variant: :large) %>
               </div>
               <div>
-                <div><%= user.soft_deleted? ? user.login : link_to(user.login, user_home_path(user.login)) %></div>
+                <div><%= user.soft_deleted? ? user.login : link_to(user.login + " (#{user.display_name})", user_home_path(user.login)) %></div>
                 <div><%= user.email %></div>
                 <% unless user.soft_deleted? %>
                 <div><%= user.current_login_ip %>


### PR DESCRIPTION
Fixes #783 

### Iterate through the changes in this PR. Why did you implement them this way?

* Add a condition to also search column `display_name`
* Show `user.display_name` on the `admin#users#index#`

## "Ready For Review" checklist

* [x] PR title accurately summarizes changes
