### PR TITLE
Remove listens_average method and mention. 

### DIFF
--- a/app/models/user/statistics.rb
+++ b/app/models/user/statistics.rb
@@ -36,14 +36,6 @@ class User < ApplicationRecord
       # )
     end
 
-    def listens_average
-      first_created_at = assets.limit(1).order('created_at').first.created_at
-
-      x = ((Time.now - first_created_at) / 60 / 60 / 24).ceil
-
-      (listens_count.to_f / x).ceil
-    end
-
     def number_of_tracks_listened_to
       Listen.count(:all,
         order: 'count_all DESC',

--- a/app/views/users/_track_plays.html.erb
+++ b/app/views/users/_track_plays.html.erb
@@ -1,9 +1,10 @@
+<!-- ToDo: used in old theme. Please remove me when time -->
 <% cache([@track_plays, theme_name]) do %>
   <div id="user_track_plays" class="box">
   	<h2 class="box">Latest listens to your music</h2>
       <div class="static_content">
         <strong><%= @user.track_plays.today %></strong> new plays &amp; downloads today <br/>
-  		  <%= @user.listens_count %> total plays and downloads (<strong><%= @user.listens_average %></strong> per/day)
+  		  <%= @user.listens_count %> total plays and downloads
       </div>
   	<%= render partial: 'users/track_play', collection: @track_plays %>
   </div>

--- a/app/views/users/show_white.html.erb
+++ b/app/views/users/show_white.html.erb
@@ -105,7 +105,7 @@
 
             <div class="static_content">
               <strong><%= @user.track_plays.today %></strong> new plays &amp; downloads today <br/>
-              <%= @user.listens_count %> total plays and downloads (<strong><%= @user.listens_average %></strong> per/day)
+              <%= @user.listens_count %> total plays and downloads
             </div>
             <%= render partial: 'users/track_play', collection: @track_plays %>
           </div>


### PR DESCRIPTION
Closes #273 
I was not able to reproduce the bug locally. With or without cache enabled it seems to work as expected. Per suggestion, I'm removing the logic altogether. 

However, it might be a good idea to revisit the concept with a more complex algorithm (something like `if user recently active, what are the stats since latest album was added` or make it more specific like `daily listens in the last month`.

## Before code review *and after additional commits* during review.

* [x] Update title and description to account for additional changes
* [x] All tests green
* [x] Booted up the branch locally, exercised any new code
* [ ] Percy changes are purposeful or explained
* [ ] Css changes are happy on mobile (via Percy is ok)
