### PR TITLE
Remove unwanted bottom margin from artwork thumbnail on playlist edit

### DIFF
--- a/app/assets/stylesheets/components/playlist_edit.scss
+++ b/app/assets/stylesheets/components/playlist_edit.scss
@@ -58,7 +58,7 @@
           img {
             width: 150px;
             border-radius: 6px;
-            display: inline-block;
+            display: block;
           }
           .no_pic {
             display: block;


### PR DESCRIPTION
Fixes #862 

Before:

<img width="242" alt="Screenshot 2019-10-22 12 53 08" src="https://user-images.githubusercontent.com/407724/67320366-5b5ef900-f4cb-11e9-98f9-15b333049653.png">

Fixed:

<img width="229" alt="Screenshot 2019-10-22 12 55 17" src="https://user-images.githubusercontent.com/407724/67320374-5f8b1680-f4cb-11e9-8c48-1fed2a736639.png">

### Does anything special need to happen for deployment?

No, one line of isolated code was changed


## "Ready For Review" checklist

These checklists are to help ensure the code review basics are covered. Consider removing to reduce noise.

* [ ] PR title accurately summarizes changes
* [ ] New tests were added for isolated methods or new endpoints
* [ ] I opened an issue for any logical followups
* [ ] If this fixes a bug, "Fixes #XXX" is either the very first or very last line of the description.

## Before code review *and after additional commits* during review.

* [ ] Update title and description to account for additional changes
* [ ] All tests green
* [ ] Booted up the branch locally, exercised any new code
* [ ] Percy changes are purposeful or explained
* [ ] Css changes are happy on mobile (via Percy is ok)
