### PR TITLE
I627 fix user/tracks order in tracks lists

### DIFF
--- a/app/assets/stylesheets/application/tracks.scss
+++ b/app/assets/stylesheets/application/tracks.scss
@@ -207,12 +207,6 @@
       -webkit-box-sizing: border-box;
     }
   }
-
-  &.descriptionless {
-    .seekbar {
-      background-color: $tab_box_silver;
-    }
-  }
 }
 
 div.track_options {

--- a/app/controllers/assets_controller.rb
+++ b/app/controllers/assets_controller.rb
@@ -26,10 +26,10 @@ class AssetsController < ApplicationController
 
   def set_related_user_variables
     all_user_tracks = @user.assets
-    @hot_tracks_this_week = all_user_tracks.hottest.limit(10)
-    @most_fav_tracks = all_user_tracks.favorited.limit(10)
-    @most_commented_tracks = all_user_tracks.most_commented.limit(10)
-    @most_listened_to_tracks = all_user_tracks.most_listened.limit(10)
+    @hot_tracks_this_week = all_user_tracks.hottest.limit(5)
+    @most_fav_tracks = all_user_tracks.favorited.limit(5)
+    @most_commented_tracks = all_user_tracks.most_commented.limit(5)
+    @most_listened_to_tracks = all_user_tracks.most_listened.limit(5)
   end
 
   # user's home page

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -16,16 +16,16 @@ class Asset < ApplicationRecord
   serialize :waveform, Array
 
   scope :published,       -> { where(private: false) }
-  scope :recent,          -> { order('assets.id DESC').includes(:user) }
-  scope :last_updated,    -> { order('updated_at DESC').first }
   scope :descriptionless, -> { where('description = "" OR description IS NULL').order('created_at DESC').limit(10) }
-  scope :random_order,    -> { order(Arel.sql('RAND()')) }
-  scope :favorited,       -> { select('distinct assets.*').includes(:tracks).where('tracks.is_favorite = (?)', true).order('tracks.id DESC') }
+  scope :recent,          -> { reorder('assets.id DESC').includes(:user) }
+  scope :last_updated,    -> { reorder('updated_at DESC').first }
+  scope :random_order,    -> { reorder(Arel.sql('RAND()')) }
+  scope :favorited,       -> { select('distinct assets.*').includes(:tracks).where('tracks.is_favorite = (?)', true).reorder('tracks.id DESC') }
   scope :not_current,     ->(id) { where('id != ?', id) }
   scope :for_user,        ->(user_id) { where(user_id: user_id) }
-  scope :hottest,         -> { where('hotness > 0').order('hotness DESC') }
-  scope :most_commented,  -> { where('comments_count > 0').order('comments_count DESC') }
-  scope :most_listened,   -> { where('listens_count > 0').order('listens_count DESC') }
+  scope :hottest,         -> { where('hotness > 0').reorder(hotness: :desc) }
+  scope :most_commented,  -> { where('comments_count > 0').reorder('comments_count DESC') }
+  scope :most_listened,   -> { where('listens_count > 0').reorder('listens_count DESC') }
   scope :with_preloads,   -> { includes(user: { avatar_image_attachment: :blob }) }
 
   belongs_to :user, counter_cache: true

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -16,7 +16,6 @@ class Asset < ApplicationRecord
   serialize :waveform, Array
 
   scope :published,       -> { where(private: false) }
-  scope :descriptionless, -> { where('description = "" OR description IS NULL').order('created_at DESC').limit(10) }
   scope :recent,          -> { reorder('assets.id DESC').includes(:user) }
   scope :last_updated,    -> { reorder('updated_at DESC').first }
   scope :random_order,    -> { reorder(Arel.sql('RAND()')) }

--- a/spec/fixtures/assets.yml
+++ b/spec/fixtures/assets.yml
@@ -140,7 +140,7 @@ asset_with_relations_for_soft_delete:
   permalink: delete-me-softly
   mp3_content_type: audio/mpeg
   mp3_file_size: <%= 3.megabytes %>
-  listens_count: 2
+  listens_count: 5
   created_at: 2010-04-08 13:00:03
   user: jamie_kiesl
   length: 55
@@ -152,6 +152,7 @@ valid_asset_to_test_on_latest:
   mp3_content_type: audio/mpeg
   mp3_file_size: <%= 3.megabytes %>
   listens_count: 2
+  comments_count: 4
   created_at: 2019-09-08 13:00:03
   user: jamie_kiesl
   hotness: 111
@@ -163,7 +164,8 @@ another_valid_asset_to_test_on_latest:
   permalink: valid-but-manually-spammed-asset
   mp3_content_type: audio/mpeg
   mp3_file_size: <%= 3.megabytes %>
-  listens_count: 2
+  listens_count: 3
+  comments_count: 6
   created_at: 2019-08-07 13:00:03
   user: jamie_kiesl
   hotness: 101

--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -25,6 +25,33 @@ RSpec.describe Asset, type: :model do
         end
       end.to perform_queries(count: 4)
     end
+
+    context "user's assets" do
+      let(:user) { users(:jamie_kiesl) }
+
+      it "should order user's hottest tracks" do
+        track_111 = assets(:valid_asset_to_test_on_latest)
+        track_101 = assets(:another_valid_asset_to_test_on_latest)
+
+        assert_equal [track_111, track_101], user.assets.hottest
+      end
+
+      it "should order user's most listened to tracks" do
+        track_listen_5 = assets(:asset_with_relations_for_soft_delete)
+        track_listen_2 = assets(:valid_asset_to_test_on_latest)
+        track_listen_3 = assets(:another_valid_asset_to_test_on_latest)
+        # 0 listens is not included
+        track_listen_0 = assets(:jamie_kiesl_the_duck)
+
+        assert_equal [track_listen_5, track_listen_3, track_listen_2], user.assets.most_listened
+      end
+
+      it "should order user's most commented tracks" do
+        track_comment_4 = assets(:valid_asset_to_test_on_latest)
+        track_comment_6 = assets(:another_valid_asset_to_test_on_latest)
+        assert_equal [track_comment_6, track_comment_4], user.assets.most_commented
+      end
+    end
   end
 
   context "validation" do


### PR DESCRIPTION
### [Bug] #627 

If we chain `order` method in Rails, it will order by first value and then order by second value what's available. So since for associations first order is by`id` and it's always unique, it does not (EVER) actually order by the second value :/ So none of user's assets get ordered in their lists.

I decided to add at least some specs (on a `model` since we can't really test for order of assets as part of a controller spec) to have at least SOME check on those lists.

* [x] PR title accurately summarizes changes
* [x] New tests were added for isolated methods or new endpoints
* [x] If this fixes a bug, "Fixes #XXX" is either the very first or very last line of the description.

## Before code review *and after additional commits* during review.

* [x] Update title and description to account for additional changes
* [x] All tests green
* [x] Booted up the branch locally, exercised any new code
* [ ] Percy changes are purposeful or explained
* [ ] Css changes are happy on mobile (via Percy is ok)
