### PR TITLE
Ignore nonsense content-types reported by `file`.

### DIFF
--- a/spec/models/upload_spec.rb
+++ b/spec/models/upload_spec.rb
@@ -23,6 +23,20 @@ RSpec.describe Upload, type: :model do
     )
   end
 
+  it 'determines the content-type' do
+    content_type = Upload.resolve_content_type(
+      uploaded_file, uploaded_file.path => 'nonsense/content-type'
+    )
+    expect(content_type).to eq('application/zip')
+  end
+
+  it 'prefers the detected over the reported content-type' do
+    content_type = Upload.resolve_content_type(
+      uploaded_file, uploaded_file.path => 'audio/mp3'
+    )
+    expect(content_type).to eq('audio/mp3')
+  end
+
   it 'processes' do
     expect(
       Upload.process(


### PR DESCRIPTION
The `file` command was updated in macOS recently and is now reporting different mime-types for various files. This appears to be causing issues in development and might start causing problems in production too.

In this PR we change the code to ignore the mime-type reported by the `file` command when it's not something we support. We fall back to the browser reported content-type in that case.

This may solve #890 and other upload related spec suite failures.