### PR TITLE
Skip validation on unattached blob.

### DIFF
--- a/app/validators/attached_validator.rb
+++ b/app/validators/attached_validator.rb
@@ -10,6 +10,7 @@
 class AttachedValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
     return if value.nil?
+    return unless value.attached?
 
     validate_content_type(record, attribute, value) if options.key?(:content_type)
     validate_byte_size(record, attribute, value) if options.key?(:byte_size)

--- a/spec/validators/attached_validator_spec.rb
+++ b/spec/validators/attached_validator_spec.rb
@@ -28,19 +28,28 @@ RSpec.describe AttachedValidator do
     expect(record).to be_valid
   end
 
-  it 'allows valid attachement' do
+  it 'allows valid attachment' do
     record = AttachedValidatorModel.new(
       double(
         content_type: 'audio/mpeg',
-        byte_size: 30.kilobytes.to_i
+        byte_size: 30.kilobytes.to_i,
+        attached?: true
       ),
       nil
     )
     expect(record).to be_valid
   end
 
+  it 'allows an unattached attachment' do
+    record = AttachedValidatorModel.new(
+      double(attached?: false),
+      nil
+    )
+    expect(record).to be_valid
+  end
+
   it 'allows empty attachment when configured to do so' do
-    record = AttachedValidatorModel.new(nil, double(byte_size: 0))
+    record = AttachedValidatorModel.new(nil, double(byte_size: 0, attached?: true))
     expect(record).to be_valid
   end
 
@@ -48,7 +57,8 @@ RSpec.describe AttachedValidator do
     record = AttachedValidatorModel.new(
       double(
         content_type: 'application/octet-stream',
-        byte_size: 30.kilobytes.to_i
+        byte_size: 30.kilobytes.to_i,
+        attached?: true
       ),
       nil
     )
@@ -67,7 +77,8 @@ RSpec.describe AttachedValidator do
     record = AttachedValidatorModel.new(
       double(
         content_type: 'audio/mpeg',
-        byte_size: 0
+        byte_size: 0,
+        attached?: true
       ),
       nil
     )
@@ -80,7 +91,7 @@ RSpec.describe AttachedValidator do
   it 'does not allow attachment that is too small' do
     record = AttachedValidatorModel.new(
       nil,
-      double(byte_size: 30.kilobytes)
+      double(byte_size: 30.kilobytes, attached?: true)
     )
     expect(record).to_not be_valid
     expect(record.errors.details[:video_file]).to eq(
@@ -97,7 +108,8 @@ RSpec.describe AttachedValidator do
     record = AttachedValidatorModel.new(
       double(
         content_type: 'audio/mpeg',
-        byte_size: 2.gigabytes.to_i
+        byte_size: 2.gigabytes.to_i,
+        attached?: true
       ),
       nil
     )


### PR DESCRIPTION
A record can have an Active Storage attachment that (no longer) points to a blob. When we attempt to validate the content-type and size of the blob we get a delegation error.

The solution in this PR is to skip validation when the attachment is not attached.

This may solve #890 and other upload related spec suite failures.