### PR TITLE
Replace has_permalink with a few lines of slug code

### DIFF
--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -49,7 +49,6 @@ class Asset < ApplicationRecord
     source: :user,
     through: :tracks
 
-  before_save :ensure_unique_permalink, if: :permalink_changed?
   after_commit :create_waveform, on: :create
 
   # We have to define attachments last to make the Active Record callbacks
@@ -70,6 +69,18 @@ class Asset < ApplicationRecord
     byte_size: { less_than: 60.megabytes }
   }
 
+  include Slugs
+  has_slug(
+    :permalink,
+    from_attribute: :title,
+    scope: :user_id,
+    default: 'untitled'
+  )
+
+  def to_param
+    permalink
+  end
+
   # @deprecated Please use asset.audio_file.filename.
   def mp3_file_name
     if filename = audio_file&.filename
@@ -85,16 +96,6 @@ class Asset < ApplicationRecord
   # @deprecated Please use asset.audio_file.content_type.
   def mp3_content_type
     audio_file.attached? ? audio_file.content_type : nil
-  end
-
-  def title=(title)
-    super
-    rename
-  end
-
-  def audio_file=(audio_file)
-    super
-    rename
   end
 
   def self.latest(limit = 10)
@@ -187,10 +188,6 @@ class Asset < ApplicationRecord
     "https://#{hostname}/#{user.login}/tracks/#{permalink}"
   end
 
-  def to_param
-    permalink
-  end
-
   def notify_followers
     user.followers.select(&:wants_email?).each do |user|
       AssetNotificationJob.set(wait: 10.minutes).perform_later(asset_ids: id, user_id: user.id)
@@ -232,23 +229,6 @@ class Asset < ApplicationRecord
     else
       with_deleted.recent
     end
-  end
-
-  private
-
-  include HasPermalink::InstanceMethods
-
-  # Required when calling fix_duplication.
-  def auto_fix_duplication
-    true
-  end
-
-  def rename
-    self.permalink = normalize(name).presence || 'untitled'
-  end
-
-  def ensure_unique_permalink
-    self.permalink = fix_duplication(permalink)
   end
 end
 

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -131,7 +131,7 @@ class Asset < ApplicationRecord
   def name
     return title.strip if title.present?
 
-    name = audio_file.attached? ? audio_file.filename.base.humanize : nil
+    name = audio_file.attached? ? audio_file.filename.base : nil
     name.presence || 'untitled'
   end
 

--- a/app/models/concerns/slugs.rb
+++ b/app/models/concerns/slugs.rb
@@ -42,7 +42,8 @@ module Slugs
       define_method("#{from_attribute}=") do |value|
         result = super(value)
         if changes.key?(from_attribute.to_s)
-          send("#{column}=", Slug.generate(result).presence || default)
+          slug = Slug.generate(result).presence || default
+          send("#{column}=", slug)
         end
         result
       end

--- a/app/models/concerns/slugs.rb
+++ b/app/models/concerns/slugs.rb
@@ -18,7 +18,7 @@ module Slugs
 
   # Increments slugs when they changed and conflict with another slug.
   def make_slugs_unique
-    slugs.each do |column, (from_attribute, scope_column)|
+    slugs.each do |column, (_, scope_column)|
       next unless changes.key?(column.to_s)
 
       current_slug = send(column)

--- a/app/models/concerns/slugs.rb
+++ b/app/models/concerns/slugs.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require 'slug'
+
+# Provides functionality to automatically set and update slugs for an Active
+# Record model.
+module Slugs
+  extend ActiveSupport::Concern
+
+  included do
+    # Keeps a mapping between a slug column and its configuration.
+    class_attribute :slugs, default: {}
+
+    before_save :make_slugs_unique
+  end
+
+  private
+
+  # Increments slugs when they changed and conflict with another slug.
+  def make_slugs_unique
+    slugs.each do |column, (from_attribute, scope_column)|
+      next unless changes.key?(column.to_s)
+
+      current_slug = send(column)
+      scope_value = scope_column ? send(scope_column) : nil
+      while self.class.slug_taken?(column, current_slug, scope_column, scope_value)
+        current_slug = Slug.increment(current_slug)
+        send("#{column}=", current_slug)
+      end
+    end
+  end
+
+  class_methods do
+    # Configures a column so its value is set based on the from_attribute. The slug value will
+    # be made unique within the defined scope. If the from_attribute does not have a value it
+    # will get the default value.
+    def has_slug(column, from_attribute:, scope: nil, default: nil)
+      slugs[column] = [from_attribute, scope]
+
+      attribute(column, default: default) if default
+
+      define_method("#{from_attribute}=") do |value|
+        result = super(value)
+        if changes.key?(from_attribute.to_s)
+          send("#{column}=", Slug.generate(result).presence || default)
+        end
+        result
+      end
+    end
+
+    # Returns true when another record with the specified column value exists in the given scope
+    # with the scope value.
+    #
+    #   Author.slug_taken?(:slug, 'bob-writer', nil, nil)
+    #   Book.slug_taken?(:slug, 'wonderful-life', :author_id, 54)
+    def slug_taken?(column, value, scope_column, scope_value)
+      conditions = { column => value }
+      conditions[scope_column] = scope_value if scope_column
+      exists?(conditions)
+    end
+  end
+end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -5,7 +5,8 @@ class Group < ActiveRecord::Base
   validates_presence_of :name
   validates_presence_of :description
 
-  has_permalink :name
+  include Slugs
+  has_slug :permalink, from_attribute: :name
 
   def to_param
     permalink

--- a/app/models/playlist.rb
+++ b/app/models/playlist.rb
@@ -25,10 +25,13 @@ class Playlist < ActiveRecord::Base
   validates_length_of   :title, within: 3..100
   validates_length_of   :year, within: 2..4, allow_blank: true
 
-  has_permalink :title
-  before_validation :name_favorites_and_set_permalink, on: :create
-  before_update :set_mix_or_album, :check_for_new_permalink, :ensure_private_if_less_than_two_tracks,
-    :set_published_at, :notify_followers_if_publishing_album
+  before_validation :name_favorites, on: :create
+  before_update(
+    :set_mix_or_album,
+    :ensure_private_if_less_than_two_tracks,
+    :set_published_at,
+    :notify_followers_if_publishing_album
+  )
 
   # We have to define attachments last to make the Active Record callbacks
   # fire in the right order.
@@ -43,8 +46,16 @@ class Playlist < ActiveRecord::Base
     _suffix: true
   )
 
+  include Slugs
+  has_slug(
+    :permalink,
+    from_attribute: :title,
+    scope: :user_id,
+    default: 'untitled'
+  )
+
   def to_param
-    permalink.to_s
+    permalink
   end
 
   def type
@@ -138,13 +149,8 @@ class Playlist < ActiveRecord::Base
   end
 
   # if this is a "favorites" playlist, give it a name/description to match
-  def name_favorites_and_set_permalink
+  def name_favorites
     self.title = user.name + "'s favorite tracks" if is_favorite?
-    generate_permalink!
-  end
-
-  def check_for_new_permalink
-    generate_permalink! if title_changed?
   end
 end
 

--- a/app/models/upload/metadata.rb
+++ b/app/models/upload/metadata.rb
@@ -41,7 +41,7 @@ class Upload
         ATTRIBUTE_TO_ID3_TAG_NAME.each_with_object({}) do |(name, tag_name), attributes|
           value = info.respond_to?(tag_name) ? info.public_send(tag_name) : info.tag[tag_name]
           attributes[name] = self.class.sanitize_encoding(value)
-        end.compact
+        end.reject { |_, value| value.blank? }
       end
     rescue Mp3InfoError
       {}

--- a/app/models/upload/metadata.rb
+++ b/app/models/upload/metadata.rb
@@ -36,15 +36,19 @@ class Upload
 
     private
 
-    def extract_attributes
+    def mp3info_attributes
       Mp3Info.open(file.path) do |info|
         ATTRIBUTE_TO_ID3_TAG_NAME.each_with_object({}) do |(name, tag_name), attributes|
           value = info.respond_to?(tag_name) ? info.public_send(tag_name) : info.tag[tag_name]
           attributes[name] = self.class.sanitize_encoding(value)
-        end.reject { |_, value| value.blank? }
+        end
       end
     rescue Mp3InfoError
       {}
+    end
+
+    def extract_attributes
+      mp3info_attributes.reject { |_, value| value.blank? }
     end
   end
 end

--- a/app/models/upload/mp3_file.rb
+++ b/app/models/upload/mp3_file.rb
@@ -52,12 +52,17 @@ class Upload
 
     private
 
+    def title_from_filename
+      File.basename(filename, '.*').humanize
+    end
+
     def metadata
       @metadata ||= Upload::Metadata.new(file)
     end
 
     def combined_attributes
       asset_attributes
+        .merge(title: title_from_filename)
         .merge(metadata.attributes)
         .merge(
           user: user,

--- a/app/models/upload/mp3_file.rb
+++ b/app/models/upload/mp3_file.rb
@@ -53,7 +53,7 @@ class Upload
     private
 
     def title_from_filename
-      File.basename(filename, '.*').humanize
+      File.basename(filename, '.*').strip
     end
 
     def metadata

--- a/lib/slug.rb
+++ b/lib/slug.rb
@@ -2,13 +2,10 @@
 
 # Helper class to generate slugs out of names or titles.
 class Slug
-  CONTROL_CHARACTERS_RE = /[\x00-\x1F\x7F]/
+  CONTROL_CHARACTERS_RE = /[\x00-\x1F\x7F]/.freeze
 
   def self.generate(string)
-    raise(
-      ArgumentError,
-      "Can't generate a slug from a nil value."
-    ) if string.nil?
+    raise(ArgumentError, "Can't generate a slug from a nil value.") if string.nil?
 
     string.unicode_normalize.downcase(:fold)
           .gsub(CONTROL_CHARACTERS_RE, '')
@@ -17,7 +14,7 @@ class Slug
           .gsub(%r{[[:space:]]+}, '-')
   end
 
-  DEDUPED_RE = %r{\A(.*)-(\d+)\Z}
+  DEDUPED_RE = %r{\A(.*)-(\d+)\Z}.freeze
 
   def self.increment(slug)
     if match = DEDUPED_RE.match(slug)

--- a/lib/slug.rb
+++ b/lib/slug.rb
@@ -11,10 +11,10 @@ class Slug
     ) if string.nil?
 
     string.unicode_normalize.downcase(:fold)
-      .gsub(CONTROL_CHARACTERS_RE, '')
-      .gsub(%r{\A([[:space:]]+)}, '')
-      .gsub(%r{([[:space:]]+)\Z}, '')
-      .gsub(%r{[[:space:]]+}, '-')
+          .gsub(CONTROL_CHARACTERS_RE, '')
+          .gsub(%r{\A([[:space:]]+)}, '')
+          .gsub(%r{([[:space:]]+)\Z}, '')
+          .gsub(%r{[[:space:]]+}, '-')
   end
 
   DEDUPED_RE = %r{\A(.*)-(\d+)\Z}

--- a/lib/slug.rb
+++ b/lib/slug.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+# Helper class to generate slugs out of names or titles.
+class Slug
+  CONTROL_CHARACTERS_RE = /[\x00-\x1F\x7F]/
+
+  def self.generate(string)
+    raise(
+      ArgumentError,
+      "Can't generate a slug from a nil value."
+    ) if string.nil?
+
+    string.unicode_normalize.downcase(:fold).
+      gsub(CONTROL_CHARACTERS_RE, '').
+      gsub(%r{\A([[:space:]]+)}, '').
+      gsub(%r{([[:space:]]+)\Z}, '').
+      gsub(%r{[[:space:]]+}, '-')
+  end
+end

--- a/lib/slug.rb
+++ b/lib/slug.rb
@@ -10,11 +10,11 @@ class Slug
       "Can't generate a slug from a nil value."
     ) if string.nil?
 
-    string.unicode_normalize.downcase(:fold).
-      gsub(CONTROL_CHARACTERS_RE, '').
-      gsub(%r{\A([[:space:]]+)}, '').
-      gsub(%r{([[:space:]]+)\Z}, '').
-      gsub(%r{[[:space:]]+}, '-')
+    string.unicode_normalize.downcase(:fold)
+      .gsub(CONTROL_CHARACTERS_RE, '')
+      .gsub(%r{\A([[:space:]]+)}, '')
+      .gsub(%r{([[:space:]]+)\Z}, '')
+      .gsub(%r{[[:space:]]+}, '-')
   end
 
   DEDUPED_RE = %r{\A(.*)-(\d+)\Z}

--- a/lib/slug.rb
+++ b/lib/slug.rb
@@ -16,4 +16,14 @@ class Slug
       gsub(%r{([[:space:]]+)\Z}, '').
       gsub(%r{[[:space:]]+}, '-')
   end
+
+  DEDUPED_RE = %r{\A(.*)-(\d+)\Z}
+
+  def self.increment(slug)
+    if match = DEDUPED_RE.match(slug)
+      "#{match[1]}-#{match[2].to_i + 1}"
+    else
+      "#{slug}-2"
+    end
+  end
 end

--- a/spec/fixtures/assets.yml
+++ b/spec/fixtures/assets.yml
@@ -86,7 +86,7 @@ will_studd_rockfort_white_wild_tangy:
   created_at: 2019-04-08 13:00:03
 will_studd_magnificent_lacaune:
   user: will_studd
-  title: Magnificent Lacuane
+  title: Magnificent Lacaune
   permalink: magnificent-lacaune
   mp3_file_name: mixs for will 3.mp3
   mp3_content_type: audio/mpeg

--- a/spec/fixtures/groups.yml
+++ b/spec/fixtures/groups.yml
@@ -1,0 +1,4 @@
+microwave:
+  name: Microwave
+  permalink: microwave
+  description: Microwave is the leading vaporwave label in the world.

--- a/spec/fixtures/groups.yml
+++ b/spec/fixtures/groups.yml
@@ -2,3 +2,9 @@ microwave:
   name: Microwave
   permalink: microwave
   description: Microwave is the leading vaporwave label in the world.
+kliek:
+  name: Spaarndammerbuurtkliek
+  # The permalink deliberately doesn't match the name so we can construct a test case that ensures
+  # it's not overwritten.
+  permalink: dekliek
+  description: De kliek, de kliek!

--- a/spec/lib/slug_spec.rb
+++ b/spec/lib/slug_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'slug'
+
+RSpec.describe Slug do
+  it 'raises an exception generating a slug out of nil' do
+    expect do
+      Slug.generate(nil)
+    end.to raise_error(ArgumentError)
+  end
+
+  it 'normalizes Unicode characters' do
+    string = 'Càfé'
+    expect(
+      Slug.generate(string.unicode_normalize(:nfd))
+    ).to eq('càfé'.unicode_normalize(:nfkc))
+  end
+
+  it 'folds ASCII characters down' do
+    expect(Slug.generate('HELLO')).to eq('hello')
+  end
+
+  it 'folds Unicode characters down' do
+    expect(Slug.generate('ĲLAND')).to eq('ĳland')
+    expect(Slug.generate('Århüs')).to eq('århüs')
+  end
+
+  it 'removes control characters' do
+    expect(Slug.generate("\x00\x1fbel")).to eq('bel')
+  end
+
+  it 'strips ASCII space from the front' do
+    expect(Slug.generate("  \tbel")).to eq('bel')
+  end
+
+  it 'strips ASCII space from the end' do
+    expect(Slug.generate("bel\n  ")).to eq('bel')
+  end
+
+  it 'strips Unicode space from the front' do
+    expect(Slug.generate("#{unicode_whitespace}bel")).to eq('bel')
+  end
+
+  it 'strips Unicode space from the end' do
+    expect(Slug.generate("bel#{unicode_whitespace}")).to eq('bel')
+  end
+
+  it 'replaces ASCII space characters with a single dash' do
+    expect(Slug.generate("Tubular Bells")).to eq('tubular-bells')
+    expect(Slug.generate("Tubular  Bells")).to eq('tubular-bells')
+  end
+
+  it 'replaces Unicode space characters with a single dash' do
+    expect(
+      Slug.generate("Tubular#{unicode_whitespace}Bells")
+    ).to eq('tubular-bells')
+  end
+
+  it 'works' do
+    [
+      ['All Things Fall Apart', 'all-things-fall-apart'],
+      [
+        "It's Always Raining in Connecticut",
+        "it's-always-raining-in-connecticut"
+      ],
+      ['NeoTokyo', 'neotokyo'],
+      ['مرحبا', 'مرحبا'],
+      ['नमस्कार', 'नमस्कार'],
+      ['Привет дженя', 'привет-дженя']
+    ].each do |example, expected|
+      expect(Slug.generate(example)).to eq(expected)
+    end
+  end
+
+  def unicode_whitespace
+    [0x2002, 0x2009].pack('U*')
+  end
+end

--- a/spec/lib/slug_spec.rb
+++ b/spec/lib/slug_spec.rb
@@ -10,6 +10,10 @@ RSpec.describe Slug do
     end.to raise_error(ArgumentError)
   end
 
+  it 'does not swallow user input when generating a slug' do
+    expect(Slug.generate('-')).to eq('-')
+  end
+
   it 'normalizes Unicode characters' do
     string = 'Càfé'
     expect(
@@ -71,6 +75,21 @@ RSpec.describe Slug do
     ].each do |example, expected|
       expect(Slug.generate(example)).to eq(expected)
     end
+  end
+
+  it 'increments the initial version of a slug' do
+    expect(Slug.increment('demo')).to eq('demo-2')
+  end
+
+  it 'increments a previously versioned slug' do
+    expect(Slug.increment('demo-2')).to eq('demo-3')
+    expect(Slug.increment('नमस्कार-2')).to eq('नमस्कार-3')
+    expect(Slug.increment('مرحبا-2')).to eq('مرحبا-3')
+    expect(Slug.increment('-2')).to eq('-3')
+  end
+
+  it 'does not swallow user input when incrementing a slug' do
+    expect(Slug.increment('-')).to eq('--2')
   end
 
   def unicode_whitespace

--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -123,12 +123,14 @@ RSpec.describe Asset, type: :model do
 
     it "should still work even when tags are empty and the name is weird" do
       asset = file_fixture_asset('_ .mp3', content_type: 'audio/mpeg')
-      expect(asset.permalink).to eq('untitled')
-      expect(asset.name).to eq('untitled')
+      expect(asset.permalink).to eq('_')
+      expect(asset.title).to eq('_')
+      expect(asset.name).to eq('_')
     end
 
     it "should handle strange charsets / characters in title tags" do
       asset = file_fixture_asset('japanese-characters.mp3', content_type: 'audio/mpeg')
+      expect(asset.title).to eq('01-¶ÔμÄÈË') # name is still 01-\266Ե??\313"
       expect(asset.name).to eq('01-¶ÔμÄÈË') # name is still 01-\266Ե??\313"
       expect(asset.mp3_file_name).to eq('japanese-characters.mp3')
     end
@@ -165,7 +167,7 @@ RSpec.describe Asset, type: :model do
 
     it "should use the filename as name if no tags are present" do
       asset = file_fixture_asset('titleless.mp3', content_type: 'audio/mpeg')
-      expect(asset.name).to eq('Titleless')
+      expect(asset.name).to eq('titleless')
     end
 
     it "should generate a permalink from tags" do

--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -7,6 +7,12 @@ RSpec.describe Asset, type: :model do
     expect(Asset.new(title: '👍').title).to eq('👍')
   end
 
+  it 'should use its permalink as param' do
+    expect(assets(:will_studd_rockfort_combalou).permalink).to eq(
+      assets(:will_studd_rockfort_combalou).to_param
+    )
+  end
+
   context "asset with audio file" do
     let(:asset) { assets(:will_studd_rockfort_combalou) }
 
@@ -129,7 +135,7 @@ RSpec.describe Asset, type: :model do
 
     it "should handle empty name in mp3 tag" do
       asset = file_fixture_asset('japanese-characters.mp3', content_type: 'audio/mpeg')
-      expect(asset.permalink).to eq("01-oaee") # name is 01-\266Ե??\313"
+      expect(asset.permalink).to eq("01-¶ôμäèë") # name is 01-\266Ե??\313"
       asset.title = 'bee'
       asset.save
       expect(asset.permalink).to eq('bee')
@@ -177,7 +183,7 @@ RSpec.describe Asset, type: :model do
     it "should generate unique permalinks" do
       asset = file_fixture_asset('tag2.mp3', content_type: 'audio/mpeg')
       asset2 = file_fixture_asset('tag2.mp3', content_type: 'audio/mpeg')
-      expect(asset2.permalink).to eq('put-a-nickel-on-my-door-1')
+      expect(asset2.permalink).to eq('put-a-nickel-on-my-door-2')
     end
 
     it "should make sure to grab bitrate and length in seconds" do
@@ -276,6 +282,33 @@ RSpec.describe Asset, type: :model do
       expect(asset.soft_deleted?).to eq(true)
       expect(asset.user).to be_nil
       expect(asset.possibly_deleted_user).not_to be_nil
+    end
+  end
+
+  describe 'slug' do
+    let(:title) { 'Music for the Masses' }
+    let(:slug) { Slug.generate(title) }
+
+    it 'updates when the name changes' do
+      asset = Asset.new(title: title)
+      expect(asset.permalink).to eq(slug)
+    end
+
+    it 'saves the permalink after creation' do
+      asset = Asset.create!(user: users(:henri_willig), title: title)
+      expect(asset.reload.permalink).to eq(slug)
+    end
+
+    it 'updates after title update' do
+      asset = assets(:henri_willig_finest_cheese)
+      asset.update(title: title)
+      expect(asset.reload.permalink).to eq(slug)
+    end
+
+    it 'increments the slug in case of a collision' do
+      existing = assets(:henri_willig_finest_cheese)
+      asset = Asset.create!(user: users(:henri_willig), title: existing.title)
+      expect(asset.reload.permalink).to eq('manufacturer-of-the-finest-cheese-2')
     end
   end
 end

--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -149,12 +149,13 @@ RSpec.describe Asset, type: :model do
       expect(asset.mp3_file_name).to eq(filename)
     end
 
-    it "should handle permalink with ???? as tags, default to untitled" do
+    it 'creates an asset with a Chinese title in the ID3 tags' do
       asset = file_fixture_asset('中文測試.mp3', content_type: 'audio/mpeg')
       expect(asset).to be_persisted
       expect(asset.name).to eq("中文測試")
+      expect(asset.title).to eq("中文測試")
       expect(asset.permalink).not_to be_blank
-      expect(asset.permalink).to eq("untitled")
+      expect(asset.permalink).to eq("中文測試")
     end
 
     it "should use the mp3 tag1 title as name if present" do

--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -133,14 +133,6 @@ RSpec.describe Asset, type: :model do
       expect(asset.mp3_file_name).to eq('japanese-characters.mp3')
     end
 
-    it "should handle empty name in mp3 tag" do
-      asset = file_fixture_asset('japanese-characters.mp3', content_type: 'audio/mpeg')
-      expect(asset.permalink).to eq("01-¶ôμäèë") # name is 01-\266Ե??\313"
-      asset.title = 'bee'
-      asset.save
-      expect(asset.permalink).to eq('bee')
-    end
-
     it "should cope with non-english filenames" do
       asset = file_fixture_asset('中文測試.mp3', content_type: 'audio/mpeg')
       expect(asset.save).to eq(true)

--- a/spec/models/concerns/slugs_spec.rb
+++ b/spec/models/concerns/slugs_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Slugs do
+  context 'a slug' do
+    let(:record) { Group.new }
+
+    it 'returns all the configured slugs for the class' do
+      expect(record.class.slugs).to eq(
+        permalink: [:name, nil]
+      )
+    end
+
+    it 'does not have a slug' do
+      expect(record.permalink).to be_nil
+    end
+
+    it 'sets the slug when the source attribute changes' do
+      record.name = 'The Bob Marshall Trio Experience'
+      expect(record.permalink).to eq('the-bob-marshall-trio-experience')
+    end
+
+    it 'increments the slug when it already exists before save' do
+      existing = groups(:microwave)
+      record.name = existing.name
+      record.description = 'Not blank'
+
+      expect(record.permalink).to eq('microwave')
+      record.save!
+      expect(record.reload.permalink).to eq('microwave-2')
+    end
+  end
+
+  context 'a slug with a scope and default value' do
+    let(:record) { Asset.new }
+
+    it 'returns all the configured slugs for the class' do
+      expect(record.class.slugs).to eq(
+        permalink: [:title, :user_id]
+      )
+    end
+
+    it 'has the default slug' do
+      expect(record.permalink).to eq('untitled')
+    end
+
+    it 'sets the slug when the source attribute changes' do
+      record.title = 'The Bob Marshall Trio Experience'
+      expect(record.permalink).to eq('the-bob-marshall-trio-experience')
+    end
+
+    it 'increments the slug when it already exists before save' do
+      existing = assets(:henri_willig_finest_cheese)
+      record.title = existing.title
+      record.user = users(:henri_willig)
+
+      expect(record.permalink).to eq('manufacturer-of-the-finest-cheese')
+      record.save!
+      expect(record.reload.permalink).to eq('manufacturer-of-the-finest-cheese-2')
+    end
+
+    it 'does not increments the slug when it already exists outside of scope' do
+      existing = assets(:henri_willig_finest_cheese)
+      record.title = existing.title
+      record.user = users(:william_shatner)
+
+      expect(record.permalink).to eq('manufacturer-of-the-finest-cheese')
+      record.save!
+      expect(record.reload.permalink).to eq('manufacturer-of-the-finest-cheese')
+    end
+
+    it 'keeps the default when the source attribute becomes blank' do
+      asset = assets(:henri_willig_finest_cheese)
+      asset.title = ''
+      expect(asset.permalink).to eq('untitled')
+    end
+  end
+end

--- a/spec/models/concerns/slugs_spec.rb
+++ b/spec/models/concerns/slugs_spec.rb
@@ -30,6 +30,12 @@ RSpec.describe Slugs do
       record.save!
       expect(record.reload.permalink).to eq('microwave-2')
     end
+
+    it 'does not change an existing slug when the source attribute does not change' do
+      group = groups(:kliek)
+      group.update(name: group.name)
+      expect(group.permalink).to eq('dekliek')
+    end
   end
 
   context 'a slug with a scope and default value' do

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Group do
+  it 'should use its permalink as param' do
+    expect(groups(:microwave).permalink).to eq(groups(:microwave).to_param)
+  end
+
+  describe 'slug' do
+    let(:name) { 'The Wellfair' }
+    let(:slug) { Slug.generate(name) }
+
+    it 'updates when the name changes' do
+      group = Group.new(name: name)
+      expect(group.permalink).to eq(slug)
+    end
+
+    it 'saves the permalink after creation' do
+      group = Group.create!(name: name, description: 'Not blank')
+      expect(group.reload.permalink).to eq(slug)
+    end
+
+    it 'updates after name update' do
+      group = groups(:microwave)
+      group.update(name: name)
+      expect(group.reload.permalink).to eq(slug)
+    end
+
+    it 'increments the slug in case of a collision' do
+      existing = groups(:microwave)
+      group = Group.create!(name: existing.name, description: 'Not blank')
+      expect(group.reload.permalink).to eq('microwave-2')
+    end
+  end
+end

--- a/spec/models/playlist_spec.rb
+++ b/spec/models/playlist_spec.rb
@@ -190,4 +190,31 @@ RSpec.describe Playlist, type: :model do
       end.to change { Playlist.count }.from(original_count).to(0)
     end
   end
+
+  describe 'slug' do
+    let(:title) { 'Music for the Masses' }
+    let(:slug) { Slug.generate(title) }
+
+    it 'updates when the name changes' do
+      playlist = Playlist.new(title: title)
+      expect(playlist.permalink).to eq(slug)
+    end
+
+    it 'saves the permalink after creation' do
+      playlist = Playlist.create!(user: users(:henri_willig), title: title)
+      expect(playlist.reload.permalink).to eq(slug)
+    end
+
+    it 'updates after title update' do
+      playlist = playlists(:jamie_kiesl_loves)
+      playlist.update(title: title)
+      expect(playlist.reload.permalink).to eq(slug)
+    end
+
+    it 'increments the slug in case of a collision' do
+      existing = playlists(:jamie_kiesl_loves)
+      playlist = Playlist.create!(user: users(:jamie_kiesl), title: existing.title)
+      expect(playlist.reload.permalink).to eq('jamie-loves-2')
+    end
+  end
 end

--- a/spec/models/upload/metadata_spec.rb
+++ b/spec/models/upload/metadata_spec.rb
@@ -24,6 +24,18 @@ RSpec.describe Upload::Metadata, type: :model do
     end
   end
 
+  context 'valid MP3 with a blank title and author in the ID3 tags' do
+    let(:filename) { '_ .mp3' }
+
+    it 'returns all non-blank attributes' do
+      expect(metadata.attributes).to eq(
+        bitrate: 128,
+        length: 213.4525,
+        samplerate: 44100
+      )
+    end
+  end
+
   context 'valid MP3 with ID3 tags with completely broken character encoding' do
     let(:filename) { 'japanese-characters.mp3' }
 

--- a/spec/models/upload/mp3_file_spec.rb
+++ b/spec/models/upload/mp3_file_spec.rb
@@ -48,6 +48,25 @@ RSpec.describe Upload::Mp3File, type: :model do
     end
   end
 
+  context 'processing file with some blank ID3 tags' do
+    let(:filename) { '_ .mp3' }
+    let(:fixture_filename) { filename }
+
+    it 'builds a valid single asset' do
+      expect(mp3_file.process).to eq(true)
+      expect(mp3_file.assets.length).to eq(1)
+
+      asset = mp3_file.assets.first
+      expect(asset.errors).to be_blank
+      expect(asset.user).to eq(user)
+      expect(asset.title).to eq('_')
+      expect(asset.mp3_content_type).to eq('audio/mpeg')
+      expect(asset.mp3_file_name).to eq(filename)
+      expect(asset.mp3_file_size).to eq(3415280)
+      expect(asset.private).to eq(false)
+    end
+  end
+
   context 'processing file with ID3 tags' do
     let(:fixture_filename) { 'piano.mp3' }
 
@@ -108,7 +127,7 @@ RSpec.describe Upload::Mp3File, type: :model do
 
   context 'processing an unsupported file' do
     let(:filename) { 'smallest.zip' }
-    let(:fixture_filename) { 'smallest.zip' }
+    let(:fixture_filename) { filename }
 
     it 'builds an invalid single asset' do
       expect(mp3_file.process).to eq(false)

--- a/spec/models/upload/mp3_file_spec.rb
+++ b/spec/models/upload/mp3_file_spec.rb
@@ -33,6 +33,7 @@ RSpec.describe Upload::Mp3File, type: :model do
       asset = mp3_file.assets.first
       expect(asset.errors).to be_blank
       expect(asset.user).to eq(user)
+      expect(asset.title).to eq('Smallest')
       expect(asset.mp3_content_type).to eq('audio/mpeg')
       expect(asset.mp3_file_name).to eq(mp3_file_filename)
       expect(asset.mp3_file_size).to eq(72)
@@ -82,6 +83,7 @@ RSpec.describe Upload::Mp3File, type: :model do
       asset = mp3_file.assets.first
       expect(asset.errors).to be_blank
       expect(asset.user).to eq(user)
+      expect(asset.title).to eq('🐬')
       expect(asset.name).to eq('🐬')
       expect(asset.mp3_file_name).to eq('🐬.mp3')
       expect(asset.private).to eq(false)

--- a/spec/models/upload/mp3_file_spec.rb
+++ b/spec/models/upload/mp3_file_spec.rb
@@ -5,12 +5,15 @@ require 'rails_helper'
 RSpec.describe Upload::Mp3File, type: :model do
   let(:user) { users(:will_studd) }
   let(:asset_attributes) { nil }
-  let(:mp3_file_filename) { 'smallest.mp3' }
+  let(:fixture_filename) { 'smallest.mp3' }
+  let(:filename) {
+    'op1 virtual III the 2nd when Times are hard %live% (prod. THE MAN).mp3'
+  }
   let(:mp3_file) do
     Upload::Mp3File.new(
       user: user,
-      file: file_fixture_tempfile(mp3_file_filename),
-      filename: mp3_file_filename,
+      file: file_fixture_tempfile(fixture_filename),
+      filename: filename,
       asset_attributes: asset_attributes
     )
   end
@@ -19,8 +22,8 @@ RSpec.describe Upload::Mp3File, type: :model do
     expect(
       Upload::Mp3File.process(
         user: user,
-        file: file_fixture_tempfile(mp3_file_filename),
-        filename: mp3_file_filename
+        file: file_fixture_tempfile(fixture_filename),
+        filename: filename
       )
     ).to be_kind_of(Upload::Mp3File)
   end
@@ -33,16 +36,20 @@ RSpec.describe Upload::Mp3File, type: :model do
       asset = mp3_file.assets.first
       expect(asset.errors).to be_blank
       expect(asset.user).to eq(user)
-      expect(asset.title).to eq('Smallest')
+      expect(asset.title).to eq(
+        'op1 virtual III the 2nd when Times are hard %live% (prod. THE MAN)'
+      )
       expect(asset.mp3_content_type).to eq('audio/mpeg')
-      expect(asset.mp3_file_name).to eq(mp3_file_filename)
+      expect(asset.mp3_file_name).to eq(
+        'op1 virtual III the 2nd when Times are hard -live- (prod. THE MAN).mp3'
+      )
       expect(asset.mp3_file_size).to eq(72)
       expect(asset.private).to eq(false)
     end
   end
 
   context 'processing file with ID3 tags' do
-    let(:mp3_file_filename) { 'piano.mp3' }
+    let(:fixture_filename) { 'piano.mp3' }
 
     it 'builds a valid single asset' do
       expect(mp3_file.process).to eq(true)
@@ -60,21 +67,16 @@ RSpec.describe Upload::Mp3File, type: :model do
       expect(asset.id3_track_num).to eq(2)
       expect(asset.genre).to eq('Rock')
       expect(asset.mp3_content_type).to eq('audio/mpeg')
-      expect(asset.mp3_file_name).to eq(mp3_file_filename)
+      expect(asset.mp3_file_name).to eq(
+        'op1 virtual III the 2nd when Times are hard -live- (prod. THE MAN).mp3'
+      )
       expect(asset.mp3_file_size).to eq(37352)
       expect(asset.private).to eq(false)
     end
   end
 
   context 'processing file with emoji in the filename' do
-    let(:mp3_file_filename) { '🐬.mp3' }
-    let(:mp3_file) do
-      Upload::Mp3File.new(
-        user: user,
-        file: file_fixture_tempfile('smallest.mp3'),
-        filename: mp3_file_filename
-      )
-    end
+    let(:filename) { '🐬.mp3' }
 
     it 'builds a valid single asset' do
       expect(mp3_file.process).to eq(true)
@@ -91,9 +93,9 @@ RSpec.describe Upload::Mp3File, type: :model do
   end
 
   context 'processing an empty file' do
-    let(:mp3_file_filename) { 'empty.mp3' }
+    let(:fixture_filename) { 'empty.mp3' }
 
-    it 'builds an invalid single asset' do
+    it 'builds an asset' do
       expect(mp3_file.process).to eq(false)
       expect(mp3_file.assets.length).to eq(1)
 
@@ -105,7 +107,8 @@ RSpec.describe Upload::Mp3File, type: :model do
   end
 
   context 'processing an unsupported file' do
-    let(:mp3_file_filename) { 'smallest.zip' }
+    let(:filename) { 'smallest.zip' }
+    let(:fixture_filename) { 'smallest.zip' }
 
     it 'builds an invalid single asset' do
       expect(mp3_file.process).to eq(false)
@@ -144,8 +147,8 @@ RSpec.describe Upload::Mp3File, type: :model do
     let(:mp3_file) do
       Upload::Mp3File.new(
         user: user,
-        file: file_fixture_tempfile(mp3_file_filename),
-        filename: mp3_file_filename,
+        file: file_fixture_tempfile(fixture_filename),
+        filename: filename,
         content_type: content_type
       )
     end
@@ -164,8 +167,8 @@ RSpec.describe Upload::Mp3File, type: :model do
     let(:mp3_file) do
       Upload::Mp3File.new(
         user: user,
-        file: file_fixture_tempfile(mp3_file_filename),
-        filename: mp3_file_filename,
+        file: file_fixture_tempfile(fixture_filename),
+        filename: filename,
         content_type: nil
       )
     end

--- a/spec/request/assets_controller_spec.rb
+++ b/spec/request/assets_controller_spec.rb
@@ -323,7 +323,7 @@ RSpec.describe AssetsController, type: :request do
           asset: { audio_file: fixture_file_upload('files/muppets.mp3', 'audio/mpeg') }
         }
       )
-      expect(response).to redirect_to('/willstudd/tracks/magnificent-lacuane')
+      expect(response).to redirect_to('/willstudd/tracks/magnificent-lacaune')
     end
 
     it "does not update the audio file for an asset when it's spam" do
@@ -334,7 +334,7 @@ RSpec.describe AssetsController, type: :request do
           asset: { audio_file: fixture_file_upload('files/muppets.mp3', 'audio/mpeg') }
         }
       )
-      expect(response).to redirect_to('/willstudd/tracks/magnificent-lacuane')
+      expect(response).to redirect_to('/willstudd/tracks/magnificent-lacaune')
       expect(asset.reload).to be_is_spam
     end
   end

--- a/spec/request/assets_controller_spec.rb
+++ b/spec/request/assets_controller_spec.rb
@@ -239,6 +239,11 @@ RSpec.describe AssetsController, type: :request do
       expect(response).to redirect_to('/arthur/tracks/old-muppet-men-booing/edit')
     end
 
+    it 'uses the filename as the asset title when the title ID3 tag is empty' do
+      post '/arthur/tracks', params: { asset_data: [fixture_file_upload('files/emptytags.mp3', 'audio/mpeg')] }
+      expect(response).to redirect_to('/arthur/tracks/emptytags/edit')
+    end
+
     it 'should accept an uploaded mp3 from chrome with audio/mp3 content type' do
       expect {
         post '/arthur/tracks', params: { asset_data: [fixture_file_upload('files/muppets.mp3', 'audio/mp3')] }


### PR DESCRIPTION
Replace `has_permalink` in `Asset`, `Group`, and `Playlist` models.

Closes #793. Closes #846