### PR TITLE
De-duplicate playlist permalinks

### DIFF
--- a/db/migrate/20191111153306_make_playlist_permalinks_unique_within_scope.rb
+++ b/db/migrate/20191111153306_make_playlist_permalinks_unique_within_scope.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'slug'
+
+class Playlist < ActiveRecord::Base
+end
+
+class MakePlaylistPermalinksUniqueWithinScope < ActiveRecord::Migration[6.0]
+  def up
+    Playlist.find_each do |playlist|
+      playlist.reload
+
+      duplicates = Playlist
+                   .where(permalink: playlist.permalink)
+                   .where(user_id: playlist.user_id)
+                   .where.not(id: playlist.id)
+                   .order(id: :asc).to_a
+      next if duplicates.empty?
+
+      slug = Slug.generate(playlist.title)
+      duplicates.each do |duplicate|
+        slug = Slug.increment(slug)
+        duplicate.update_column(:permalink, slug)
+      end
+    end
+  end
+
+  def down; end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_11_04_123633) do
+ActiveRecord::Schema.define(version: 2019_11_11_153306) do
 
   create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", null: false


### PR DESCRIPTION
Adds migration that loops through all playlists and de-dupes their permalink without relying on the model code.

References #660.