### PR TITLE
Add CSS style to prevent long URLs from breaking user card bio layout

### DIFF
--- a/app/assets/stylesheets/components/user.scss
+++ b/app/assets/stylesheets/components/user.scss
@@ -268,6 +268,9 @@ main {
           color: $font-color-two;
           padding: 36px;
           font-family: $medium-sans-font;
+          p {
+            overflow-wrap: break-word;
+          }
         }
         .user_card_content_divider {
           height: 1px;


### PR DESCRIPTION
Fixes #879

### Was anything tried that didn't work? Anything that reviewers should pay attention to or difficult or tricky that should be explained?

Added a single line of CSS to line break long URLS to fit them within a user bio card.

## "Ready For Review" checklist

These checklists are to help ensure the code review basics are covered. Consider removing to reduce noise.

* [ ] PR title accurately summarizes changes
* [ ] New tests were added for isolated methods or new endpoints
* [ ] I opened an issue for any logical followups
* [ ] If this fixes a bug, "Fixes #XXX" is either the very first or very last line of the description.

## Before code review *and after additional commits* during review.

* [ ] Update title and description to account for additional changes
* [ ] All tests green
* [ ] Booted up the branch locally, exercised any new code
* [ ] Percy changes are purposeful or explained
* [ ] Css changes are happy on mobile (via Percy is ok)
