### PR TITLE
Update to Sidekiq 6 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,7 +60,7 @@ gem 'turbolinks'
 gem 'bugsnag'
 gem 'newrelic_rpm'
 gem 'skylight', '< 4.2' # bug in 4.2.beta2
-gem 'sidekiq', '< 6'
+gem 'sidekiq'
 gem 'dalli'
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -408,11 +408,11 @@ GEM
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
     shellany (0.0.1)
-    sidekiq (5.2.7)
-      connection_pool (~> 2.2, >= 2.2.2)
-      rack (>= 1.5.0)
-      rack-protection (>= 1.5.0)
-      redis (>= 3.3.5, < 5)
+    sidekiq (6.0.3)
+      connection_pool (>= 2.2.2)
+      rack (>= 2.0.0)
+      rack-protection (>= 2.0.0)
+      redis (>= 4.1.0)
     sixarm_ruby_unaccent (1.2.0)
     skylight (4.1.2)
       skylight-core (= 4.1.2)
@@ -542,7 +542,7 @@ DEPENDENCIES
   sass-rails
   scrypt
   selenium-webdriver
-  sidekiq (< 6)
+  sidekiq
   skylight (< 4.2)
   sometimes
   soundmanager2-rails


### PR DESCRIPTION
Now that #287 is closed and we are running with systemctl on the server, we can update to sidekiq 6.

https://github.com/mperham/sidekiq/blob/master/6.0-Upgrade.md