### PR TITLE
Use HTTPS for gems with a GitHub source?

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,9 @@
 source 'https://rubygems.org'
 
+git_source(:github) do |repo_name|
+  "https://github.com/#{repo_name}.git"
+end
+
 gem 'rails'
 gem 'mysql2'
 gem 'puma', '< 4.1' # experiencing some issues with config on 4.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 GIT
-  remote: git://github.com/rails/coffee-rails.git
+  remote: https://github.com/rails/coffee-rails.git
   revision: 8160511a6f5ea201880c68a28b834a8cdf166ced
   specs:
     coffee-rails (5.0.0)


### PR DESCRIPTION
> The git source `git://github.com/rails/coffee-rails.git` uses the `git` protocol, which transmits data without encryption. Disable this warning with `bundle config git.allow_insecure true`, or switch to the `https` protocol to keep your data secure.

These changes silence that warning. Alternatively we can use SSH. We can even keep it as-is.