### PR TITLE
Change storage URL expiration from 5 minutes to 6 hours

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -33,6 +33,10 @@ module Alonetone
     config.active_storage.service = config.alonetone.storage_service
     config.active_storage.variant_processor = :vips
 
+    # Expiration for storage URLs should be at least as long as the maximum
+    # cache time for HTML pages. The default is 5 minutes.
+    config.active_storage.service_urls_expire_in = 6.hours
+
     # Turn off previewers and analysers because we don't use them.
     config.active_storage.analyzers = []
     config.active_storage.previewers = []


### PR DESCRIPTION
In development and without the Fastly mock all image variants URLs will be Active Storage service URLs. Just like other presigned URLs these URLs expire. Combined with HTML page caching this can lead to URLs expiring before the page cache expires, this leads to missing images.

This PR changes the expiration time from 5 minutes to 6 hours to make this happen less. We can't fix it completely because the URLs require an expiration time and some HTML is cached indefinitely when nothing changes to the database.

Closes #869.