### PR TITLE
Don't stub current user and user session accessors in spec suite

### DIFF
--- a/spec/controllers/notifications_controller_spec.rb
+++ b/spec/controllers/notifications_controller_spec.rb
@@ -1,19 +1,23 @@
 require "rails_helper"
 
 RSpec.describe NotificationsController, type: :controller do
+  let(:user) { users(:brand_new_user) }
+
+  before do
+    login(user)
+  end
+
   context 'subscribe' do
     it 'should mark email_new_tracks setting as true' do
-      login(:brand_new_user)
       get :subscribe
-      expect(users(:brand_new_user).settings[:email_new_tracks]).to eq(true)
+      expect(user.reload.settings[:email_new_tracks]).to eq(true)
     end
   end
 
   context 'unsubscribe' do
     it 'should mark email_new_tracks setting as false' do
-      login(:brand_new_user)
       get :unsubscribe
-      expect(users(:brand_new_user).settings[:email_new_tracks]).to eq(false)
+      expect(user.reload.settings[:email_new_tracks]).to eq(false)
     end
   end
 end

--- a/spec/controllers/password_resets_controller_spec.rb
+++ b/spec/controllers/password_resets_controller_spec.rb
@@ -13,8 +13,10 @@ RSpec.describe PasswordResetsController, type: :controller do
       post :create, params: { email: users(:arthur).email }
       expect(flash[:error]).not_to be_present
       expect(User.where(login: 'arthur').first.perishable_token).not_to be_nil
-      login(:arthur)
-      expect(controller.session["user_credentials"]).to eq(nil) # can't login
+
+      expect do
+        login(:arthur)
+      end.to raise_error(Authlogic::Session::Existence::SessionInvalidError)
     end
 
     it 'should send an email with link to reset pass' do

--- a/spec/controllers/password_resets_controller_spec.rb
+++ b/spec/controllers/password_resets_controller_spec.rb
@@ -9,7 +9,6 @@ RSpec.describe PasswordResetsController, type: :controller do
     end
 
     it "should disallow logins after resetting" do
-      activate_authlogic
       post :create, params: { email: users(:arthur).email }
       expect(flash[:error]).not_to be_present
       expect(User.where(login: 'arthur').first.perishable_token).not_to be_nil
@@ -38,7 +37,6 @@ RSpec.describe PasswordResetsController, type: :controller do
     end
 
     it 'should allow user to manually type in password and login user' do
-      activate_authlogic
       post :create, params: { email: users(:arthur).email }
       put :update, params: { id: User.where(login: 'arthur').first.perishable_token,
                              user: { password: '12345678', password_confirmation: '12345678' } }
@@ -48,7 +46,6 @@ RSpec.describe PasswordResetsController, type: :controller do
     end
 
     it 'should allow user to manually type in password and present edit again if passes do not match' do
-      activate_authlogic
       post :create, params: { email: users(:arthur).email }
       put :update, params: { id: User.where(login: 'arthur').first.perishable_token,
                              user: { password: '123456', password_confirmation: '1234567' } }

--- a/spec/controllers/user_sessions_controller_spec.rb
+++ b/spec/controllers/user_sessions_controller_spec.rb
@@ -48,10 +48,11 @@ RSpec.describe UserSessionsController, type: :controller do
 
   # this is in authlogic, needs testing since we modify it (see users_controller_spec)
   it "should update IP and last_request_at" do
+    user = users(:arthur)
     travel_to (1.hour.ago) do
       request.env['REMOTE_ADDR'] = '10.1.1.1'
-      login(:arthur)
-      expect(controller.session["user_credentials"]).to eq(users(:arthur).persistence_token)
+      login(user)
+      expect(controller.session["user_credentials"]).to eq(user.reload.persistence_token)
       expect(users(:arthur).current_login_ip).to eq('10.1.1.1')
       expect(users(:arthur).last_request_at).to be_within(1.minute).of(DateTime.now)
     end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -207,7 +207,6 @@ RSpec.describe UsersController, type: :controller do
     end
 
     it "should not let a logged out user edit" do
-      logout
       post :edit, params: { user_id: 'arthur' }
       expect(response).not_to be_successful
     end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -106,27 +106,27 @@ RSpec.describe UsersController, type: :controller do
     end
 
     it "should activate with a for reals perishable token" do
-      set_good_request_headers && activate_authlogic && create_user
+      set_good_request_headers && create_user
       get :activate, params: { perishable_token: User.last.perishable_token }
       expect(flash[:ok]).to be_present
       expect(response).to redirect_to(new_user_track_path(User.last.login))
     end
 
     it 'should log in user on activation' do
-      set_good_request_headers && activate_authlogic && create_user
+      set_good_request_headers && create_user
       # expect(UserSession).to receive(:create)
       get :activate, params: { perishable_token: User.last.perishable_token }
       expect(controller.session["user_credentials"]).to eq(User.last.persistence_token)
     end
 
     it 'should send out email on activation' do
-      set_good_request_headers && activate_authlogic && create_user
+      set_good_request_headers && create_user
       get :activate, params: { perishable_token: User.last.perishable_token }
       expect(last_email.to).to eq(["quire@example.com"])
     end
 
     it "should not activate with bullshit perishable token" do
-      set_good_request_headers && activate_authlogic
+      set_good_request_headers
       get :activate, params: { perishable_token: "abunchofbullshit" }
       expect(flash[:error]).to be_present
       expect(response).to redirect_to(new_user_path)

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -324,7 +324,8 @@ RSpec.describe UsersController, type: :controller do
   context "last request at" do
     it "should touch last_request_at when logging in" do
       # Authlogic does this by default, which fucks things up
-      expect { login(:arthur) }.to change { users(:arthur).last_request_at }
+      user = users(:arthur)
+      expect { login(user) }.to change { user.reload.last_request_at }
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -33,4 +33,7 @@ RSpec.configure do |config|
 
   # Limits the available syntax (e.g. forces expect(…).to)
   config.disable_monkey_patching!
+
+  # Useful in combination with fail-fast when refactoring specs.
+  config.register_ordering(:alphabet, &:sort)
 end

--- a/spec/support/login_helpers.rb
+++ b/spec/support/login_helpers.rb
@@ -15,10 +15,6 @@ module RSpec
         allow(controller).to receive(:current_user).and_return(login_as)
       end
 
-      def logout
-        UserSession.find.destroy if UserSession.find
-      end
-
       def create_user_session(user)
         post(
           '/user_sessions',

--- a/spec/support/login_helpers.rb
+++ b/spec/support/login_helpers.rb
@@ -5,16 +5,20 @@ require 'authlogic/test_case'
 module RSpec
   module Support
     module LoginHelpers
-      include Authlogic::TestCase
-
+      # Creates an authenticated session for the user by changing the current
+      # test request. User passed to this method can either be a users fixture
+      # label or a User instance.
+      #
+      # Can be used in controller and view specs.
       def login(user)
-        login_as = user.is_a?(User) ? user : users(user)
-
-        expect(session = UserSession.create(login_as)).to be_truthy
-        allow(controller).to receive(:current_user_session).and_return(session)
-        allow(controller).to receive(:current_user).and_return(login_as)
+        user = user.is_a?(User) ? user : users(user)
+        UserSession.create!(login: user.login, password: 'test', remember_me: true)
       end
 
+      # Creates an authenticated session for the user by interacting with the
+      # current integration session.
+      #
+      # Should be used in request specs.
       def create_user_session(user)
         post(
           '/user_sessions',


### PR DESCRIPTION
By stubbing `current_user_session` and `current_user` on the controller object you lose the difference between the controller instance variable and the example local variable space. Does that sentence make sense?

* Remove duplicate inclusion of `Authlogic::TestCase` in controller and request specs.
* No longer includes `Authlogic::TestCase` in model and other specs.
* Allows `UserSession` and the `AuthLogic` controller integration to work as intended.
* Adds `alphabetic` rspec order: `rspec --order alphabet`.
* Stop activating Authlogic test integration all over the spec suite.
