### PR TITLE
Reload Rails in seeds when User doesn't have password

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,3 +1,10 @@
+# frozen_string_literal: true
+
+# Authlogic does not initialize when the database wasn't created when the
+# Rails process starts. We need to force a User reload at this point to
+# have full access to all the Authlogic methods.
+Rails.application.reloader.reload! unless User.new.respond_to?(:password)
+
 # Tell Raskimet we're in testing mode is it doesn't attempt to train based on
 # any API requests from the seeds.
 Rails.application.config.rakismet.test = true


### PR DESCRIPTION
Reload Rails when User is not properly initialized at the start of the seeds.

Closes #833.