### PR TITLE
Disallow permalinks with dots and migrate existing permalinks

### DIFF
--- a/db/migrate/20191114185637_undot_permalinks.rb
+++ b/db/migrate/20191114185637_undot_permalinks.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class UndotPermalinks < ActiveRecord::Migration[6.0]
+  def up
+    Asset.select(:id, :permalink).where("permalink LIKE '%.%'").each do |asset|
+      # Replace a dot with a dash and multiple dashes with one dash.
+      permalink = asset.permalink.gsub('.', '-').gsub(%r{-+}, '-')
+      asset.update_columns(permalink: permalink, updated_at: Time.zone.now)
+    end
+  end
+
+  def down
+  end
+end

--- a/db/migrate/20191114185637_undot_permalinks.rb
+++ b/db/migrate/20191114185637_undot_permalinks.rb
@@ -4,11 +4,10 @@ class UndotPermalinks < ActiveRecord::Migration[6.0]
   def up
     Asset.select(:id, :permalink).where("permalink LIKE '%.%'").each do |asset|
       # Replace a dot with a dash and multiple dashes with one dash.
-      permalink = asset.permalink.gsub('.', '-').gsub(%r{-+}, '-')
+      permalink = asset.permalink.tr('.', '-').gsub(%r{-+}, '-')
       asset.update_columns(permalink: permalink, updated_at: Time.zone.now)
     end
   end
 
-  def down
-  end
+  def down; end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_11_14_162609) do
+ActiveRecord::Schema.define(version: 2019_11_14_185637) do
 
   create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", null: false

--- a/lib/slug.rb
+++ b/lib/slug.rb
@@ -11,6 +11,7 @@ class Slug
           .gsub(CONTROL_CHARACTERS_RE, '')
           .gsub(%r{\A([[:space:]]+)}, '')
           .gsub(%r{([[:space:]]+)\Z}, '')
+          .gsub(%r{\.}, ' ')
           .gsub(%r{[[:space:]]+}, '-')
   end
 

--- a/lib/slug.rb
+++ b/lib/slug.rb
@@ -11,7 +11,7 @@ class Slug
           .gsub(CONTROL_CHARACTERS_RE, '')
           .gsub(%r{\A([[:space:]]+)}, '')
           .gsub(%r{([[:space:]]+)\Z}, '')
-          .gsub(%r{\.}, ' ')
+          .tr('.', ' ')
           .gsub(%r{[[:space:]]+}, '-')
   end
 

--- a/spec/lib/slug_spec.rb
+++ b/spec/lib/slug_spec.rb
@@ -55,6 +55,11 @@ RSpec.describe Slug do
     expect(Slug.generate("Tubular  Bells")).to eq('tubular-bells')
   end
 
+  it 'replaces ASCII dot characters with a single dash' do
+    expect(Slug.generate("Tubular . Bells")).to eq('tubular-bells')
+    expect(Slug.generate("Tubular.Bells")).to eq('tubular-bells')
+  end
+
   it 'replaces Unicode space characters with a single dash' do
     expect(
       Slug.generate("Tubular#{unicode_whitespace}Bells")


### PR DESCRIPTION
Some permalinks of recent assets caused a 404 on Alonetone. It turns out that Rails routing parses anything after a dot as the request format (eg. `mp3`) so we can't allow dots in path segments.

```
/sudara/tracks/i-love-marshmellows.com
 ^---          ^---                ^---
 user-id       track-id            format (`com`)
```

The alternative solution is to take dots out of the slugs.

Closes #924.