### PR TITLE
Check if audio file is attached to asset

### DIFF
--- a/app/controllers/assets_controller.rb
+++ b/app/controllers/assets_controller.rb
@@ -56,6 +56,7 @@ class AssetsController < ApplicationController
   def show
     respond_to do |format|
       format.html do
+        check_for_missing_attachment
         lazily_create_waveform_if_needed
         @assets = [@asset]
         set_related_show_variables
@@ -103,6 +104,7 @@ class AssetsController < ApplicationController
   end
 
   def edit
+    check_for_missing_attachment
     @allow_reupload = true
   end
 
@@ -205,6 +207,13 @@ class AssetsController < ApplicationController
       :user_id,
       :youtube_embed
     )
+  end
+
+  def check_for_missing_attachment
+    unless @asset.audio_file.attached?
+      flash.now[:error] = "Uh oh, there's no longer an mp3 attached to this track.<br/>
+        Please edit it and click 'upload a new version' to add the mp3"
+    end
   end
 
   def track_not_found

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -99,7 +99,7 @@ class Asset < ApplicationRecord
   end
 
   def self.latest(limit = 10)
-    with_preloads.limit(limit).order('assets.id DESC')
+    with_preloads.limit(limit).order('assets.created_at DESC')
   end
 
   def self.id_not_in(asset_ids)

--- a/app/views/shared/_asset.html.erb
+++ b/app/views/shared/_asset.html.erb
@@ -25,9 +25,11 @@
       </div>
     <% end %>
 
-    <div class="download_link">
-      <a href="<%= media_url(@asset) %>" download="<%= @asset.audio_file.filename %>"></a>
-    </div>
+    <% if @asset.audio_file.attached? %>
+      <div class="download_link">
+        <a href="<%= media_url(@asset) %>" download="<%= @asset.audio_file.filename %>"></a>
+      </div>
+    <% end %>
  </div>
 
   <div class="track_post">

--- a/spec/fixtures/assets.yml
+++ b/spec/fixtures/assets.yml
@@ -127,13 +127,13 @@ henri_willig_the_goat:
 # is no record in active_storage_attachments.
 henri_willig_lost_boy:
   user: henri_willig
-  title: Lost Boys
-  permalink: lost-boys
+  title: This track has no mp3
+  permalink: this-track-has-no-mp3
   mp3_file_name: track-4.mp3
   mp3_content_type: audio/mpeg
   mp3_file_size: <%= 6.5.megabytes %>
   length: 3566
-  created_at: 2019-02-08 13:00:03
+  created_at: 2019-01-08 13:00:03
 
 jamie_kiesl_the_duck:
   user: jamie_kiesl

--- a/spec/fixtures/assets.yml
+++ b/spec/fixtures/assets.yml
@@ -17,6 +17,7 @@ valid_zip:
   user: sudara
 invalid_file:
   mp3_file_name: Somefile.png
+  title: song1
   permalink: song1
   mp3_content_type: image/png
   mp3_file_size: <%= 1.megabyte %>

--- a/spec/fixtures/assets.yml
+++ b/spec/fixtures/assets.yml
@@ -123,6 +123,17 @@ henri_willig_the_goat:
   mp3_file_size: <%= 2.3.megabytes %>
   length: 140
   created_at: 2019-02-08 13:00:03
+# This track does not have an asset because we lost it! That means there
+# is no record in active_storage_attachments.
+henri_willig_lost_boy:
+  user: henri_willig
+  title: Lost Boys
+  permalink: lost-boys
+  mp3_file_name: track-4.mp3
+  mp3_content_type: audio/mpeg
+  mp3_file_size: <%= 6.5.megabytes %>
+  length: 3566
+  created_at: 2019-02-08 13:00:03
 
 jamie_kiesl_the_duck:
   user: jamie_kiesl

--- a/spec/fixtures/assets.yml
+++ b/spec/fixtures/assets.yml
@@ -133,7 +133,7 @@ henri_willig_lost_boy:
   mp3_content_type: audio/mpeg
   mp3_file_size: <%= 6.5.megabytes %>
   length: 3566
-  created_at: 2019-01-08 13:00:03
+  created_at: 2018-01-08 13:00:03
 
 jamie_kiesl_the_duck:
   user: jamie_kiesl

--- a/spec/fixtures/assets.yml
+++ b/spec/fixtures/assets.yml
@@ -17,8 +17,8 @@ valid_zip:
   user: sudara
 invalid_file:
   mp3_file_name: Somefile.png
-  title: song1
-  permalink: song1
+  title: Somefile
+  permalink: somefile
   mp3_content_type: image/png
   mp3_file_size: <%= 1.megabyte %>
   created_at: <%= 1.day.ago.to_s :db %>

--- a/spec/fixtures/tracks.yml
+++ b/spec/fixtures/tracks.yml
@@ -78,6 +78,12 @@ henri_willig_polderkaas_2:
   asset: henri_willig_the_goat
   position: 2
   created_at: <%= 3.months.ago %>
+henri_willig_polderkaas_3:
+  playlist: henri_willig_polderkaas
+  user: henri_willig
+  asset: henri_willig_lost_boy
+  position: 3
+  created_at: <%= 3.months.ago %>
 
 # Bill's favorites.
 william_shatners_favorites_1:

--- a/spec/fixtures/tracks.yml
+++ b/spec/fixtures/tracks.yml
@@ -78,12 +78,7 @@ henri_willig_polderkaas_2:
   asset: henri_willig_the_goat
   position: 2
   created_at: <%= 3.months.ago %>
-henri_willig_polderkaas_3:
-  playlist: henri_willig_polderkaas
-  user: henri_willig
-  asset: henri_willig_lost_boy
-  position: 3
-  created_at: <%= 3.months.ago %>
+
 
 # Bill's favorites.
 william_shatners_favorites_1:

--- a/spec/request/assets_controller_spec.rb
+++ b/spec/request/assets_controller_spec.rb
@@ -83,6 +83,11 @@ RSpec.describe AssetsController, type: :request do
       get user_track_path('sudara', 'song1'), params: { white: true }
       expect(response).to be_successful
     end
+
+    it 'shows an assets without an attachment' do
+      get user_track_path('henriwillig', 'lost-boys')
+      expect(response).to be_successful
+    end
   end
 
   context "#show.mp3" do

--- a/spec/request/assets_controller_spec.rb
+++ b/spec/request/assets_controller_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe AssetsController, type: :request do
     end
 
     it 'shows an assets without an attachment' do
-      get user_track_path('henriwillig', 'lost-boys')
+      get user_track_path('henriwillig', 'this-track-has-no-mp3')
       expect(response).to be_successful
     end
   end


### PR DESCRIPTION
Change the asset partial to check for the existence of an attachment before calling any method on `audio_file`.

Closes #916.