### PR TITLE
Alternative controller implementation for authentication

### DIFF
--- a/app/controllers/authenticated_sessions_controller.rb
+++ b/app/controllers/authenticated_sessions_controller.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+class AuthenticatedSessionsController < ApplicationController
+  def new
+    @page_title = "Login"
+    @user = User.new
+    @authenticated_session = AuthenticatedSession.new
+  end
+
+  def create
+    @authenticated_session = AuthenticatedSession.new(authenticated_session_params)
+    if @authenticated_session.save
+      return redirect_back_or_default(user_home_path(@authenticated_session.user))
+    elsif @authenticated_session.correct_password?
+      flash.now[:error] = "It looks like your account is not active. <br/> Do you have an email from us with activation details?".html_safe
+    else
+      flash.now[:error] = "There was a problem logging you in! Please check your login and password."
+    end
+
+    render :new
+  end
+
+  def destroy
+    if authenticated_session.destroy
+      redirect_to login_path, notice: "We've logged you out. Your secrets are safe with us!"
+    else
+      redirect_to login_path, error: "You weren't logged in to begin with, old chap/dame!"
+    end
+  end
+
+  private
+
+  def authenticated_session_params
+    params.require(:authenticated_session).permit(:login, :password).merge(session: session)
+  end
+end

--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -2,16 +2,24 @@
 
 # Implements controller helper methods to deal with authentication.
 module Authentication
+  # Returns the current user session from Authlogic
   def current_user_session
     return @current_user_session if defined?(@current_user_session)
 
     @current_user_session = UserSession.find
   end
 
+  # Returns the current authenticated session from Alonetone's own implementation.
+  def authenticated_session
+    return @authenticated_session if defined?(@authenticated_session)
+
+    @authenticated_session = AuthenticatedSession.new(session: session)
+  end
+
   def current_user
     return @current_user if defined?(@current_user)
 
-    @current_user = current_user_session&.user
+    @current_user = current_user_session&.user || authenticated_session&.user
   end
 
   def logged_in?

--- a/app/models/authenticated_session.rb
+++ b/app/models/authenticated_session.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+# Deals with session data related to an authenticated session.
+class AuthenticatedSession
+  SESSION_KEY = 'authenticated_session'
+
+  include ActiveModel::Model
+
+  # The Rails session object used to retrieve and store the authenticated
+  # session.
+  attr_accessor :session
+  # User's login when creating a new session.
+  attr_accessor :login
+  # User's password when creating a new session.
+  attr_accessor :password
+
+  # Returns the user for the session or credentials. Note that this does NOT
+  # mean the user is authenticated!
+  def user
+    @user ||= find_with_session || find_by_login
+  end
+
+  # A hash that can be used to represent the authenticated session.
+  def to_hash
+    { 'user_id' => user&.id }.compact
+  end
+
+  # Returns true if the password matches the user's password.
+  def correct_password?
+    !!user&.password?(password)
+  end
+
+  # Returns true if the user is present and active.
+  def user_active?
+    !!user&.active?
+  end
+
+  # Saves details to the Rails session. Return false when it fails.
+  def save
+    return false unless correct_password?
+    return false unless user_active?
+
+    session[SESSION_KEY] = to_hash
+    true
+  end
+
+  def destroy
+    return false unless session.key?(SESSION_KEY)
+
+    session.delete(SESSION_KEY)
+    true
+  end
+
+  private
+
+  def user_id
+    return nil unless session.key?(SESSION_KEY)
+    return nil unless session[SESSION_KEY]
+
+    session[SESSION_KEY]['user_id']
+  end
+
+  def find_with_session
+    return nil unless user_id
+
+    User.find_by(id: user_id)
+  end
+
+  def find_by_login
+    return nil unless login.present?
+
+    User.find_by(login: login)
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'scrypt'
+
 class User < ApplicationRecord
   include SoftDeletion
   include Rakismet::Model
@@ -142,6 +144,12 @@ class User < ApplicationRecord
   # We have to define attachments last to make the Active Record callbacks
   # fire in the right order.
   has_one_attached :avatar_image
+
+  def password?(password)
+    return false if [crypted_password, password, salt].any?(&:blank?)
+
+    SCrypt::Password.new(crypted_password) == password + salt
+  end
 
   # tokens and activation
   def clear_token!

--- a/app/views/authenticated_sessions/new.html.erb
+++ b/app/views/authenticated_sessions/new.html.erb
@@ -1,0 +1,40 @@
+<% content_for :left do %>
+  <div class="box">
+    <h2>Don't be shy, come on in</h2>
+    <div id="login" class="static_content box">
+      <%= form_with(
+        model: @authenticated_session,
+        url: authenticated_session_path,
+        local: true,
+        id: 'login_form'
+      ) do |f| %>
+        <%= f.label :login %>
+        <%= f.text_field :login %>
+
+        <%= f.label :password %>
+        <%= f.password_field :password %>
+
+        <div>
+          <%= f.submit "Come on in...", data: { turbolinks: "false" } %>
+        </div>
+      <% end %>
+
+      <p>
+        <%= link_to "Forgot Your Password?", "#reset-password", class: "slide_open_href" %>
+      </p>
+
+      <%= form_with url: password_resets_path, id: 'reset-password', style: 'display:none' do |f| %>
+        <label for="email">Enter the email address you signed up with</label>
+
+        <%= f.text_field 'email' %>
+        <div>
+          <%= f.submit 'Send Me An Email so I can login again!'%>
+        </div>
+      <% end %>
+    </div>
+  </div>
+<% end %>
+
+<% content_for :right do %>
+  <%= render partial: 'users/join' unless params[:already_joined] %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -70,6 +70,7 @@ Alonetone::Application.routes.draw do
   get 'rpmchallenge' => 'pages#rpm_challenge'
   get '24houralbum' =>  'pages#twentyfour'
 
+  resource :authenticated_session, only: %i[new create destroy]
   resources :password_resets, :comments, :user_sessions, :groups
 
   get 'about/' => 'pages#about'

--- a/spec/controllers/concerns/authentication_spec.rb
+++ b/spec/controllers/concerns/authentication_spec.rb
@@ -19,6 +19,10 @@ RSpec.describe Authentication, type: :controller do
     expect(controller).to_not be_logged_in
   end
 
+  it 'returns an authenticated session' do
+    expect(controller.authenticated_session).to_not be_nil
+  end
+
   context 'authenticated' do
     let(:user) { users(:henri_willig) }
 
@@ -28,6 +32,29 @@ RSpec.describe Authentication, type: :controller do
 
     it 'finds the current user session' do
       expect(controller.current_user_session).to_not be_nil
+    end
+
+    it 'finds the current user' do
+      expect(controller.current_user).to_not be_nil
+    end
+
+    it 'is logged in' do
+      expect(controller).to be_logged_in
+    end
+  end
+
+  context 'with authenticated session' do
+    let(:user) { users(:henri_willig) }
+    let(:authenticated_session) { AuthenticatedSession.new(session: session) }
+
+    before do
+      AuthenticatedSession.new(
+        session: session, login: user.login, password: 'test'
+      ).save
+    end
+
+    it 'returns an authenticated session' do
+      expect(controller.authenticated_session).to_not be_nil
     end
 
     it 'finds the current user' do

--- a/spec/models/authenticated_session_spec.rb
+++ b/spec/models/authenticated_session_spec.rb
@@ -1,0 +1,233 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.shared_examples 'does not return a user' do
+  it 'does not return a user' do
+    expect(authenticated_session.user).to be_nil
+  end
+
+  it 'coerces to an empty hash' do
+    expect(authenticated_session.to_hash).to be_empty
+  end
+
+  it 'does not match to the password from the credentials' do
+    expect(authenticated_session.correct_password?).to eq(false)
+  end
+
+  it 'does not think it has an active user' do
+    expect(authenticated_session.user_active?).to eq(false)
+  end
+
+  it 'does not save' do
+    before = session.dup
+    expect(authenticated_session.save).to eq(false)
+    expect(session).to eq(before)
+  end
+end
+
+RSpec.describe AuthenticatedSessionsController, type: :model do
+  context 'request with an empty session' do
+    let(:session) { {} }
+    let(:authenticated_session) do
+      AuthenticatedSession.new(session: session)
+    end
+
+    include_examples 'does not return a user'
+  end
+
+  context 'request authenticating with correct credentials' do
+    let(:session) { {} }
+    let(:user) { users(:will_studd) }
+    let(:authenticated_session) do
+      AuthenticatedSession.new(
+        session: session, login: user.login, password: 'test'
+      )
+    end
+
+    it 'returns the user' do
+      expect(authenticated_session.user).to eq(user)
+    end
+
+    it 'coerces to a proper hash' do
+      expect(authenticated_session.to_hash).to eq('user_id' => user.id)
+    end
+
+    it 'matches the password from the credentials' do
+      expect(authenticated_session.correct_password?).to eq(true)
+    end
+
+    it 'has an active user' do
+      expect(authenticated_session.user_active?).to eq(true)
+    end
+
+    it 'saves' do
+      expect(authenticated_session.save).to eq(true)
+      expect(session.keys).to eq(%w[authenticated_session])
+
+      values = session['authenticated_session']
+      expect(values.keys).to eq(%w[user_id])
+      expect(values['user_id']).to eq(user.id)
+    end
+  end
+
+  context 'request authenticating with correct credentials for inactive user' do
+    let(:session) { {} }
+    let(:user) { users(:not_activated) }
+    let(:authenticated_session) do
+      AuthenticatedSession.new(
+        session: session, login: user.login, password: 'test'
+      )
+    end
+
+    it 'returns the user' do
+      expect(authenticated_session.user).to eq(user)
+    end
+
+    it 'coerces to a proper hash' do
+      expect(authenticated_session.to_hash).to eq('user_id' => user.id)
+    end
+
+    it 'matches the password from the credentials' do
+      expect(authenticated_session.correct_password?).to eq(true)
+    end
+
+    it 'does not have an active user' do
+      expect(authenticated_session.user_active?).to eq(false)
+    end
+
+    it 'does not save' do
+      expect(authenticated_session.save).to eq(false)
+      expect(session).to be_empty
+    end
+  end
+
+  context 'request authenticating with incorrect credentials' do
+    let(:session) { {} }
+    let(:user) { users(:will_studd) }
+    let(:authenticated_session) do
+      AuthenticatedSession.new(
+        session: session, login: user.login, password: 'incorrect'
+      )
+    end
+
+    it 'returns the user' do
+      expect(authenticated_session.user).to eq(user)
+    end
+
+    it 'coerces to a proper hash' do
+      expect(authenticated_session.to_hash).to eq('user_id' => user.id)
+    end
+
+    it 'does not match to the password from the credentials' do
+      expect(authenticated_session.correct_password?).to eq(false)
+    end
+
+    it 'has an active user' do
+      expect(authenticated_session.user_active?).to eq(true)
+    end
+
+    it 'does not save' do
+      expect(authenticated_session.save).to eq(false)
+      expect(session).to be_empty
+    end
+  end
+
+  context 'request authenticating with unknown login' do
+    let(:session) { {} }
+    let(:user) { users(:will_studd) }
+    let(:authenticated_session) do
+      AuthenticatedSession.new(
+        session: session, login: 'unknown', password: 'test'
+      )
+    end
+
+    include_examples 'does not return a user'
+  end
+
+  context 'request authenticating with blank credentials' do
+    let(:session) { {} }
+    let(:user) { users(:will_studd) }
+    let(:authenticated_session) do
+      AuthenticatedSession.new(session: session, login: '', password: '')
+    end
+
+    include_examples 'does not return a user'
+  end
+
+  context 'request returning' do
+    let(:session) { {} }
+    let(:authenticated_session) { AuthenticatedSession.new(session: session) }
+
+    before do
+      AuthenticatedSession.new(
+        session: session, login: user.login, password: 'test'
+      ).save
+    end
+
+    context 'with valid session' do
+      let(:user) { users(:will_studd) }
+
+      it 'returns the user' do
+        expect(authenticated_session.user).to eq(user)
+      end
+
+      it 'coerces to a proper hash' do
+        expect(authenticated_session.to_hash).to eq('user_id' => user.id)
+      end
+
+      it 'does not match to the unset password' do
+        expect(authenticated_session.correct_password?).to eq(false)
+      end
+
+      it 'has an active user' do
+        expect(authenticated_session.user_active?).to eq(true)
+      end
+
+      it 'does not save' do
+        before = session.dup
+        expect(authenticated_session.save).to eq(false)
+        expect(session).to eq(before)
+      end
+
+      it 'destroys' do
+        expect(authenticated_session.destroy).to eq(true)
+        expect(session).to be_empty
+      end
+    end
+
+    context 'with a soft-deleted user' do
+      let(:user) { users(:deleted_yesterday) }
+
+      include_examples 'does not return a user'
+
+      it 'does not destroy' do
+        expect(authenticated_session.destroy).to eq(false)
+      end
+    end
+  end
+
+  context 'returning with a deleted user' do
+    let(:session) { { 'authenticated_session' => { 'user_id' => 65535 } } }
+    let(:authenticated_session) { AuthenticatedSession.new(session: session) }
+
+    include_examples 'does not return a user'
+
+    it 'destroys' do
+      expect(authenticated_session.destroy).to eq(true)
+      expect(session).to be_empty
+    end
+  end
+
+  context 'returning with a broken session' do
+    let(:session) { { 'authenticated_session' => {} } }
+    let(:authenticated_session) { AuthenticatedSession.new(session: session) }
+
+    include_examples 'does not return a user'
+
+    it 'destroys' do
+      expect(authenticated_session.destroy).to eq(true)
+      expect(session).to be_empty
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -74,6 +74,43 @@ RSpec.describe User, type: :model do
     end
   end
 
+  describe "password" do
+    it "matches the correct value" do
+      expect(users(:jamie_kiesl)).to be_password('test')
+    end
+
+    it "does not match the incorrect value" do
+      [
+        'incorrect',
+        ' test ',
+        '🛑'
+      ].each do |input|
+        expect(users(:jamie_kiesl)).to_not be_password(input)
+      end
+    end
+
+    it "does not match a blank password" do
+      [nil, ''].each do |blank_value|
+        user = User.new(password: blank_value, salt: SecureRandom.hex(64))
+        expect(user).to_not be_password(blank_value)
+      end
+    end
+
+    it "does not match the password when the crypted password is blank" do
+      [nil, ''].each do |blank_value|
+        user = User.new(crypted_password: blank_value, salt: SecureRandom.hex(64))
+        expect(user).to_not be_password(blank_value)
+      end
+    end
+
+    it "does not match the password when the salt is blank" do
+      [nil, ''].each do |blank_value|
+        user = User.new(crypted_password: 'flipper10', salt: blank_value)
+        expect(user).to_not be_password('flipper10')
+      end
+    end
+  end
+
   context "activation" do
     it "is considered active when persishble token doesn't exist" do
       expect(users(:arthur)).to be_active

--- a/spec/request/authenticated_sessions_controller_spec.rb
+++ b/spec/request/authenticated_sessions_controller_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe AuthenticatedSessionsController, type: :request do
+  context 'a visitor' do
+    it 'sees a login form' do
+      get '/authenticated_session/new'
+      expect(response).to be_successful
+    end
+
+    it 'starts an authenticated session with valid credentials' do
+      post(
+        '/authenticated_session',
+        params: {
+          authenticated_session: { login: 'Jamiek', password: 'test' }
+        }
+      )
+      expect(response).to be_redirect
+      uri = URI.parse(response.headers['Location'])
+      expect(uri.path).to start_with('/Jamiek')
+    end
+
+    it 'does not start an authenticated session with invalid credentials' do
+      post(
+        '/authenticated_session',
+        params: {
+          authenticated_session: { login: 'Jamiek', password: 'incorrect' }
+        }
+      )
+      expect(response).to be_successful
+      expect(response.body).to include('problem logging you in')
+    end
+
+    it 'does not start an authenticated session for an inactive user' do
+      post(
+        '/authenticated_session',
+        params: {
+          authenticated_session: { login: 'ben', password: 'test' }
+        }
+      )
+      expect(response).to be_successful
+      expect(response.body).to include('is not active')
+    end
+
+    it 'does not deletes their authenticated session' do
+      delete '/authenticated_session'
+      expect(response).to be_redirect
+      uri = URI.parse(response.headers['Location'])
+      get uri.path
+      expect(response.body).to include("weren't logged in")
+    end
+  end
+
+  context 'an authenticated user' do
+    before do
+      post(
+        '/authenticated_session',
+        params: {
+          authenticated_session: { login: 'Jamiek', password: 'test' }
+        }
+      )
+    end
+
+    it 'deletes their authenticated session' do
+      delete '/authenticated_session'
+      expect(response).to be_redirect
+      uri = URI.parse(response.headers['Location'])
+      get uri.path
+      expect(response.body).to include('logged you out')
+    end
+  end
+end


### PR DESCRIPTION
* Uses Rails session to store the authenticated session.
* Authenticated sessions don't expire.
* Authenticated sessions work with `current_user` so they are a drop-in replacement.

This PR does not replace any of the routes or login and logout links so it doesn't actually do anything at the moment. You can sign in with the new code by going to `/authenticated_session/new`. Sign out requires a delete request, so that's not very easy at the moment.

This is mostly a suggestion to see if this direction makes any sense.