### PR TITLE
Don't create tracks through a scoped association

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -243,7 +243,7 @@ class User < ApplicationRecord
     if existing_track
       existing_track.destroy && Asset.decrement_counter(:favorites_count, asset.id)
     else
-      tracks.favorites.create(asset_id: asset.id)
+      tracks.create(asset: asset, is_favorite: true)
       Asset.increment_counter(:favorites_count, asset.id, touch: true)
     end
   end


### PR DESCRIPTION
Rails 6.1 will starting performing the equivalent of `Track.unscoped.create` when creating through an association or relation. I'm guessing they don't want to apply attributes from a scope that is really meant for queries. This solves a deprecation warning.