### PR TITLE
Enable Dark Theme for all users

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -23,6 +23,10 @@ class ApplicationController < ActionController::Base
     :current_user_is_mod_or_owner?, :current_user?,
     :current_page, :moderator?, :welcome_back?, :user_setting, :latest_forum_topics
 
+  etag do
+    [current_user&.id, current_user&.dark_theme].join('/')
+  end
+
   # ability to tack these flash types on redirects/renders, access via flash.error
   add_flash_types(:error, :ok)
 
@@ -75,11 +79,12 @@ class ApplicationController < ActionController::Base
   end
 
   def set_theme
-    if logged_in? && current_user.dark_theme? # db is source of user truth, force set session
-      session[:theme] = 'dark'
-    else
-      session[:theme] ||= 'light' # whatever is in session, or light as the default
-    end
+    session[:theme] =
+      if current_user&.dark_theme? # db is source of user truth, force set session
+        'dark'
+      else
+        'light'
+      end
   end
 
   def not_found

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -75,10 +75,10 @@ class ApplicationController < ActionController::Base
   end
 
   def set_theme
-    if moderator? && current_user.dark_theme? # db is source of user truth, force set session
+    if logged_in? && current_user.dark_theme? # db is source of user truth, force set session
       session[:theme] = 'dark'
     else
-      session[:theme] = 'light' # roll with light as the default, or whatever is in session
+      session[:theme] ||= 'light' # whatever is in session, or light as the default
     end
   end
 

--- a/app/controllers/assets_controller.rb
+++ b/app/controllers/assets_controller.rb
@@ -9,8 +9,6 @@ class AssetsController < ApplicationController
   before_action :require_login, except: %i[index show latest radio listen_feed]
   before_action :check_new_user_abuse, only: %i[new create]
 
-  etag { current_user&.id }
-
   # home page
   def latest
     if stale?(Asset.last_updated)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -176,7 +176,7 @@ module ApplicationHelper
   end
 
   def theme_name
-    session[:theme] || 'light'
+    session[:theme]
   end
 
   def other_theme_name

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -31,7 +31,6 @@
           </ul>
 
           <div class="user_dropdown_menu_bottom_links">
-            <% if moderator? %>
             <a href="#" class="switch_to_theme switch_to_light"
               data-target="user-dropdown.switchToLight"
               data-action="click->user-dropdown#switchToLight"
@@ -46,8 +45,6 @@
               <div class="switcher_inner"></div>
               <div class="switcher_label">LIGHT</div>
             </a>
-            <% end %>
-
             <%= link_to 'Log Out', main_app.logout_path, class: 'logout_item', data: { turbolinks: "false" } %>
           </div>
 

--- a/spec/features/home_page_spec.rb
+++ b/spec/features/home_page_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe 'home page', type: :feature, js: true do
   end
 
   it 'renders logged in' do
-    logged_in(:sudara) do
+    logged_in(:arthur) do
       visit '/'
       expect(page).to have_selector('.profile_link')
       track_chunk = find(".asset", match: :first)

--- a/spec/features/playlist_spec.rb
+++ b/spec/features/playlist_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe 'playlists', type: :feature, js: true do
 
   it 'renders track and cover pages' do
-    logged_in(:sudara) do
+    logged_in(:arthur) do
       visit 'henriwillig/playlists/polderkaas'
       first_track = find('ul.tracklist li:first-child')
 
@@ -42,7 +42,7 @@ RSpec.describe 'playlists', type: :feature, js: true do
         # same position for the percy snap.
         Percy.snapshot(page,
           name: 'Playlist Track Play, Seek, Pause',
-            percy_css: '.progress_container_inner { left: 33% !important; }')
+          percy_css: '.progress_container_inner { left: 33% !important; }')
       end
     end
   end

--- a/spec/features/thredded_spec.rb
+++ b/spec/features/thredded_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe 'thredded', type: :feature, js: true do
   it 'renders' do
-    logged_in(:sudara) do
+    logged_in(:arthur) do
       visit '/forums'
       switch_themes
 

--- a/spec/fixtures/users.yml
+++ b/spec/fixtures/users.yml
@@ -8,6 +8,7 @@ sudara:
   created_at: <%= 5.days.ago.to_s :db %>
   updated_at: <%= 5.days.ago.to_s :db %>
   admin: true
+  dark_theme: true
   assets_count: 3
 
 # normal

--- a/spec/request/playlists_controller_spec.rb
+++ b/spec/request/playlists_controller_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "rails_helper"

--- a/spec/request/theme_spec.rb
+++ b/spec/request/theme_spec.rb
@@ -1,0 +1,65 @@
+require "rails_helper"
+
+RSpec.describe "Theme", type: :request do
+  it "should be light for guests" do
+    get "/"
+    expect(session[:theme]).to eql('light')
+  end
+
+  it "should be light for a user if they have nothing configured" do
+    create_user_session(users(:arthur))
+    get '/'
+    expect(session[:theme]).to eql('light')
+  end
+
+  it "should be dark for a user if they have dark configured" do
+    create_user_session(users(:sudara))
+    get '/'
+    expect(session[:theme]).to eql('dark')
+  end
+
+  it "should persist toggling themes from light to dark" do
+    create_user_session(users(:arthur))
+    get "/"
+    expect(session[:theme]).to eql('light')
+    put '/toggle_theme.js'
+    get '/users'
+    expect(session[:theme]).to eql('dark')
+  end
+
+  it "should persist toggling themes from dark to light" do
+    create_user_session(users(:sudara))
+    get "/"
+    expect(session[:theme]).to eql('dark')
+    put '/toggle_theme.js'
+    get '/users'
+    expect(session[:theme]).to eql('light')
+  end
+
+  context "with conditional GET caching" do
+     before do
+      create_user_session(users(:sudara))
+      get '/'
+      expect(response.code).to eql("200")
+      expect(response.headers['ETag']).to be_present
+      expect(response.headers['Last-Modified']).to be_present
+      @etag = response.headers['ETag']
+      @last_modified = response.headers['Last-Modified']
+    end
+
+    it "should return 304 not modified when theme doesn't change" do
+      get "/", headers: { 'HTTP_IF_NONE_MATCH': @etag, 'HTTP_IF_MODIFIED_SINCE': @last_modified }
+      expect(session[:theme]).to eql('dark')
+      expect(response).to have_http_status(304)
+    end
+
+    it "should not return 304 when theme changes because the etag will change" do
+      expect(session[:theme]).to eql('dark')
+      put '/toggle_theme.js'
+      get "/", headers: { 'HTTP_IF_NONE_MATCH': @etag, 'HTTP_IF_MODIFIED_SINCE': @last_modified }
+      expect(session[:theme]).to eql('light')
+      expect(response.headers['ETag']).to_not eql(@etag)
+      expect(response).to have_http_status(200)
+    end
+  end
+end


### PR DESCRIPTION
This enables the theme toggle for all users.

Current status:

* Guests see the light theme.
* Users see the light theme by default.
* Users can switch to the dark theme, it's set in the db and remembered across sessions and devices.

