### PR TITLE
Improve Markdown handling 

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,8 +8,7 @@ GIT
 
 GIT
   remote: https://github.com/thredded/thredded.git
-  revision: d8dc158dcf23b0f76daffff7f2fab225209ee446
-  branch: collection-cache
+  revision: 8aff13cdf97f21babc8f97f4607b8198ac9c1b6e
   specs:
     thredded (0.16.15)
       active_record_union (>= 1.3.0)
@@ -107,7 +106,7 @@ GEM
       activesupport (>= 5.2, < 6.1)
       request_store (~> 1.0)
       scrypt (>= 1.2, < 4.0)
-    autoprefixer-rails (9.7.3)
+    autoprefixer-rails (9.7.4)
       execjs
     awesome_print (1.8.0)
     aws-eventstream (1.0.3)
@@ -277,7 +276,8 @@ GEM
     notiffany (0.1.3)
       nenv (~> 0.1)
       shellany (~> 0.0)
-    onebox (1.9.24)
+    onebox (1.9.25)
+      addressable (~> 2.7.0)
       htmlentities (~> 4.3)
       multi_json (~> 1.11)
       mustache

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -81,7 +81,7 @@ module ApplicationHelper
 
   # https://en.wikipedia.org/wiki/Nofollow#rel="ugc"
   def nofollowize(markdown)
-    markdown.gsub('<a href','<a rel="nofollow ugc" href')
+    markdown.gsub('<a href', '<a rel="nofollow ugc" href')
   end
 
   def link_to_play(asset, referer = nil)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -64,18 +64,24 @@ module ApplicationHelper
     text.html_safe
   end
 
-  # comments, credits
+  # Comments are plaintext and don't use this helper
+  # credits/profile/playlist currently are markdowned without line breaks
   def markdown(text)
     return "" unless text
 
     CommonMarker.render_doc(text, :SMART).to_html([:NOBREAKS]).html_safe
   end
 
-  # full track description
-  def markdown_with_html(text)
+  # full track descriptions should have hard line breaks
+  def format_track_description(text)
     return "" unless text
 
-    CommonMarker.render_doc(text, :SMART).to_html(:HARDBREAKS).html_safe
+    nofollowize(CommonMarker.render_doc(text, :SMART, [:autolink]).to_html(:HARDBREAKS))
+  end
+
+  # https://en.wikipedia.org/wiki/Nofollow#rel="ugc"
+  def nofollowize(markdown)
+    markdown.gsub('<a href','<a rel="nofollow ugc" href')
   end
 
   def link_to_play(asset, referer = nil)

--- a/app/views/shared/_asset.html.erb
+++ b/app/views/shared/_asset.html.erb
@@ -24,7 +24,7 @@
 
     </div>
 
-    <%= markdown_with_html(@asset.description) %>
+    <%= format_track_description(@asset.description) %>
 
     <div>
       <%= markdown(@asset.credits) if @asset.credits.present? %>

--- a/app/views/shared/_comment.html.erb
+++ b/app/views/shared/_comment.html.erb
@@ -21,7 +21,7 @@
 
 		<div class="comment_body">
 			<p>
-				<%= strip_tags(markdown(comment.body)) %>
+				<%= strip_tags(comment.body) %>
 			</p>
 		<% if comment.private %>
 			<div class="private_message">private message</div>

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ApplicationHelper, type: :helper do
+
+  it "makes sure links are nofollow/ugc" do
+    expect(nofollowize('<a href="hey">')).to eql('<a rel="nofollow ugc" href="hey">')
+  end
+
+  it "converts track descriptions to markdown" do
+    expect(format_track_description("hey")).to eql("<p>hey</p>\n")
+  end
+
+  it "renders nofollow links in track descriptions" do
+    expect(format_track_description("https://alonetone.com")).to eql("<p><a rel=\"nofollow ugc\" href=\"https://alonetone.com\">https://alonetone.com</a></p>\n")
+  end
+
+  it "renders hard breaks in track descriptions" do
+    expect(format_track_description("this\nis\npoetry")).to eql("<p>this<br />\nis<br />\npoetry</p>\n")
+  end
+end


### PR DESCRIPTION
This fixes a few text display issues.

1. Fixes #972 by removing markdown processing on comments
2. Allows for links in track descriptions, rendering them with markdown and adding both the `nofollow` and `ugc` indications to them: https://support.google.com/webmasters/answer/96569?hl=en