### PR TITLE
Improve account requests

### DIFF
--- a/app/controllers/admin/account_requests_controller.rb
+++ b/app/controllers/admin/account_requests_controller.rb
@@ -13,7 +13,7 @@ module Admin
     end
 
     def deny
-      @account_request.denied!
+      @account_request.deny!(current_user)
       render plain: 'denied'
     end
 

--- a/app/controllers/password_resets_controller.rb
+++ b/app/controllers/password_resets_controller.rb
@@ -19,11 +19,12 @@ class PasswordResetsController < ApplicationController
   end
 
   def update
-    @newly_invited_user = !@user.last_login_at?
+    @newly_invited_user = @user.never_activated?
     @user.password = params[:user][:password]
     @user.password_confirmation = params[:user][:password_confirmation]
     if @user.save
       @user.clear_token!
+      @user.update_account_request!
       UserSession.create(@user, true)
       flash[:notice] = "Phew, we were worried about you. Welcome back." unless @newly_invited_user
       redirect_to @newly_invited_user ? upload_path : user_home_path(@user.login)

--- a/app/controllers/password_resets_controller.rb
+++ b/app/controllers/password_resets_controller.rb
@@ -24,7 +24,7 @@ class PasswordResetsController < ApplicationController
     @user.password_confirmation = params[:user][:password_confirmation]
     if @user.save
       @user.clear_token!
-      @user.update_account_request!
+      @user.update_account_request! if @newly_invited_user
       UserSession.create(@user, true)
       flash[:notice] = "Phew, we were worried about you. Welcome back." unless @newly_invited_user
       redirect_to @newly_invited_user ? upload_path : user_home_path(@user.login)

--- a/app/models/account_request.rb
+++ b/app/models/account_request.rb
@@ -27,7 +27,7 @@ class AccountRequest < ApplicationRecord
 
   validates :entity_type, inclusion: {
     in: entity_types,
-    message: "We'd like to know what sort of thing you want to upload!"
+    message: "We need to know what sort of thing you want to upload!"
   }
 
   validates :email,
@@ -47,7 +47,7 @@ class AccountRequest < ApplicationRecord
   validate :login_is_unique, on: :create
 
   validates :details, length: {
-    minimum: 5,
+    minimum: 20,
     too_short: "should link to your music/website or add some detail about what you make!"
   }
 

--- a/app/models/account_request.rb
+++ b/app/models/account_request.rb
@@ -77,7 +77,7 @@ class AccountRequest < ApplicationRecord
   end
 
   def create_user_account!(invited_by)
-    User.create!(login: login, email: email, invited_by: invited_by) do |u|
+    create_user!(login: login, email: email, invited_by: invited_by) do |u|
       u.reset_password
       u.reset_perishable_token
     end

--- a/app/models/account_request.rb
+++ b/app/models/account_request.rb
@@ -76,6 +76,14 @@ class AccountRequest < ApplicationRecord
     create_user_account!(approved_by)
   end
 
+  def deny!(denied_by)
+    return unless denied_by.moderator?
+
+    user&.soft_delete if approved?
+
+    denied! && update(moderated_by: denied_by)
+  end
+
   def create_user_account!(invited_by)
     create_user!(login: login, email: email, invited_by: invited_by) do |u|
       u.reset_password

--- a/app/models/account_request.rb
+++ b/app/models/account_request.rb
@@ -47,8 +47,8 @@ class AccountRequest < ApplicationRecord
   validate :login_is_unique, on: :create
 
   validates :details, length: {
-    minimum: 20,
-    too_short: "should link to your music/website or add some detail about what you make!"
+    minimum: 40,
+    too_short: "must be at least 40 characters: Please link to your music/website or add more info!"
   }
 
   def email_is_unique

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -152,6 +152,14 @@ class User < ApplicationRecord
     perishable_token.nil?
   end
 
+  def never_activated?
+    last_login_at.nil? && perishable_token.present?
+  end
+
+  def update_account_request!
+    account_request&.claimed!
+  end
+
   def moderator?
     self[:moderator] || self[:admin]
   end
@@ -199,7 +207,7 @@ class User < ApplicationRecord
   end
 
   def hasnt_been_here_in(hours)
-    ast_login_at &&
+    last_login_at &&
       last_login_at < hours.ago.utc
   end
 

--- a/app/views/account_requests/new.html.erb
+++ b/app/views/account_requests/new.html.erb
@@ -63,7 +63,7 @@
       </div>
       <div>
         <h3 class="form_heading">
-          Which best describes what you will host on alonetone:
+          Which best describes you?:
         </h3>
         <div class="form_radio_group">
           <div class="columns">
@@ -84,7 +84,7 @@
             <div class="right">
               <div class="form_radio_pair">
                 <%= f.radio_button(:entity_type, "blogger") %>
-                <%= f.label(:entity_type_blogger, "Blogger / Website") %>
+                <%= f.label(:entity_type_blogger, "Blogger / Website owner") %>
               </div>
               <div class="form_radio_pair">
                 <%= f.radio_button(:entity_type, "podcaster") %>
@@ -96,9 +96,9 @@
         </div>
       <div>
         <h3 class="form_heading">
-          Do you have music elsewhere (Bandcamp, Spotify, Soundcloud)?
+          Tell us something about your music — or better, link to it:
         </h3>
-        <%= f.label :details, "Give us a link. Or let us know what kind of thing you do. Don't worry, we don't care about genre, etc." %>
+        <%= f.label :details, "Don't worry, we don't care about genre or recording quality, etc. We just care that you are a music maker, not a spammer :)" %>
         <%= f.text_area :details %>
         <%= inline_form_error(@account_request.errors[:details]) %>
       </div>

--- a/app/views/admin/_navigation.html.erb
+++ b/app/views/admin/_navigation.html.erb
@@ -2,10 +2,11 @@
 
   <%= navigation_item "Account Requests <span>#{AccountRequest.count}</span>", admin_account_requests_path %>
   <ul>
-    <%= navigation_item "Waiting <span>#{AccountRequest.waiting.count }</span>", admin_account_requests_path({filter_by: :waiting}) %>
+    <%= navigation_item "Waiting Musicians <span>#{AccountRequest.candidates.count }</span>", admin_account_requests_path({filter_by: :candidates}) %>
+    <%= navigation_item "Waiting Spammers <span>#{AccountRequest.spammers.count }</span>", admin_account_requests_path({filter_by: :spammers}) %>
     <%= navigation_item "Approved <span>#{AccountRequest.approved.count }</span>", admin_account_requests_path({filter_by: :approved}) %>
     <%= navigation_item "Denied <span>#{AccountRequest.denied.count }</span>", admin_account_requests_path({filter_by: :denied}) %>
-    <%= navigation_item "Accepted <span>#{AccountRequest.accepted.count }</span>", admin_account_requests_path({filter_by: :accepted}) %>
+    <%= navigation_item "Claimed <span>#{AccountRequest.claimed.count }</span>", admin_account_requests_path({filter_by: :claimed}) %>
   </ul>
 
   <%= navigation_item "All Users <span>#{User.with_deleted.count}</span>", admin_users_path %>

--- a/app/views/admin/_navigation.html.erb
+++ b/app/views/admin/_navigation.html.erb
@@ -4,9 +4,9 @@
   <ul>
     <%= navigation_item "Waiting Musicians <span>#{AccountRequest.candidates.count }</span>", admin_account_requests_path({filter_by: :candidates}) %>
     <%= navigation_item "Waiting Spammers <span>#{AccountRequest.spammers.count }</span>", admin_account_requests_path({filter_by: :spammers}) %>
+    <%= navigation_item "Claimed <span>#{AccountRequest.claimed.count }</span>", admin_account_requests_path({filter_by: :claimed}) %>
     <%= navigation_item "Approved <span>#{AccountRequest.approved.count }</span>", admin_account_requests_path({filter_by: :approved}) %>
     <%= navigation_item "Denied <span>#{AccountRequest.denied.count }</span>", admin_account_requests_path({filter_by: :denied}) %>
-    <%= navigation_item "Claimed <span>#{AccountRequest.claimed.count }</span>", admin_account_requests_path({filter_by: :claimed}) %>
   </ul>
 
   <%= navigation_item "All Users <span>#{User.with_deleted.count}</span>", admin_users_path %>

--- a/app/views/admin/account_requests/_account_request.html.erb
+++ b/app/views/admin/account_requests/_account_request.html.erb
@@ -12,8 +12,9 @@
   </div>
   <div class="user_column">
     <div>
-      <div><%= account_request.approved? ? link_to(account_request.login, user_home_path(account_request.login)) : account_request.login %></div>
+      <div><%= account_request.claimed? ? link_to(account_request.login, user_home_path(account_request.login)) : account_request.login %></div>
       <div><%= account_request.email %></div>
+      <div><%= "#{account_request.submission_count} submissions!!" if account_request.submission_count > 1 %></div>
     </div>
   </div>
   <div class="bio_column">

--- a/app/views/invite_notification/approved_request.text.erb
+++ b/app/views/invite_notification/approved_request.text.erb
@@ -4,7 +4,7 @@ Your account has been approved. Welcome to alonetone!
 
 Just one step left, which is to pick a password:
 
-    <%= @password_url%>
+    <%= @password_url %>
 
 This is where your profile is. You probably want to add a picture and a bio to help people find you.
 

--- a/db/migrate/20200206161843_add_user_id_to_account_request.rb
+++ b/db/migrate/20200206161843_add_user_id_to_account_request.rb
@@ -1,0 +1,5 @@
+class AddUserIdToAccountRequest < ActiveRecord::Migration[6.0]
+  def change
+    add_reference :account_requests, :user
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_12_05_171852) do
+ActiveRecord::Schema.define(version: 2020_02_06_161843) do
 
   create_table "account_requests", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "email"
@@ -21,6 +21,8 @@ ActiveRecord::Schema.define(version: 2019_12_05_171852) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.integer "moderated_by_id"
+    t.bigint "user_id"
+    t.index ["user_id"], name: "index_account_requests_on_user_id"
   end
 
   create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|

--- a/spec/controllers/password_resets_controller_spec.rb
+++ b/spec/controllers/password_resets_controller_spec.rb
@@ -53,4 +53,12 @@ RSpec.describe PasswordResetsController, type: :controller do
       expect(controller.session["user_credentials"]).to eq(nil)
     end
   end
+
+  context "newly invited user" do
+    it "should redirect to upload_path after choosing a password" do
+      put :update, params: { id: users(:newly_approved).perishable_token,
+        user: { password: '12345678', password_confirmation: '12345678' }}
+      expect(response).to redirect_to('/upload')
+    end
+  end
 end

--- a/spec/features/account_requests_spec.rb
+++ b/spec/features/account_requests_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe 'Get An Account', type: :feature, js: true do
     visit '/get_an_account'
     page.fill_in 'Email', with: "someband@hotmail.com"
     page.fill_in 'account_request_login', with: 'someband456'
-    page.fill_in 'account_request_details', with: "This is a story of a very cool band"
+    page.fill_in 'account_request_details', with: "This is a story of a very cool band with 40 characters of story to tell"
     page.choose 'Musician'
     page.click_on 'Get On The List'
 

--- a/spec/fixtures/account_requests.yml
+++ b/spec/fixtures/account_requests.yml
@@ -11,3 +11,4 @@ approved:
   entity_type: musician
   details: I had something to say but I can't quite remember. Something something music.
   moderated_by: sudara
+  user: newly_approved

--- a/spec/fixtures/account_requests.yml
+++ b/spec/fixtures/account_requests.yml
@@ -3,4 +3,4 @@ waiting:
   login: newband
   email: mybandemail@domain.com
   entity_type: musician
-  details: I can't wait to get in, here's my link
+  details: I can't wait to get in, here's my link with some amount of detail

--- a/spec/fixtures/account_requests.yml
+++ b/spec/fixtures/account_requests.yml
@@ -4,3 +4,10 @@ waiting:
   email: mybandemail@domain.com
   entity_type: musician
   details: I can't wait to get in, here's my link with some amount of detail
+
+approved:
+  login: newmusician
+  email: newmusician@domain.com
+  entity_type: musician
+  details: I had something to say but I can't quite remember. Something something music.
+  moderated_by: sudara

--- a/spec/fixtures/profiles.yml
+++ b/spec/fixtures/profiles.yml
@@ -6,6 +6,7 @@
   not_activated
   sandbags
   joeblow
+  newly_approved
   brand_new_user
 ).each do |user| %>
 <%= user %>:

--- a/spec/fixtures/users.yml
+++ b/spec/fixtures/users.yml
@@ -32,10 +32,18 @@ aaron:
   created_at: <%= 1.days.ago.to_s :db %>
   updated_at: <%= 1.days.ago.to_s :db %>
 
-# not activated
 not_activated:
   login: ben
   email: ben@example.com
+  salt: <%= salt = SecureRandom.hex(64) %>
+  crypted_password: <%= scrypt("test" + salt) %>
+  created_at: <%= 1.days.ago.to_s :db %>
+  updated_at: <%= 1.days.ago.to_s :db %>
+  perishable_token: 8eou87daoeuhdtn
+
+newly_approved:
+  login: newmusician
+  email: newmusician@domain.com
   salt: <%= salt = SecureRandom.hex(64) %>
   crypted_password: <%= scrypt("test" + salt) %>
   created_at: <%= 1.days.ago.to_s :db %>

--- a/spec/fixtures/users.yml
+++ b/spec/fixtures/users.yml
@@ -1,3 +1,5 @@
+# Heads up: All users need a profile in profiles.yml
+
 # admin
 sudara:
   login: sudara

--- a/spec/models/account_request_spec.rb
+++ b/spec/models/account_request_spec.rb
@@ -74,6 +74,12 @@ RSpec.describe AccountRequest, type: :model do
       valid_account_request.approve!(users(:sudara))
       expect(valid_account_request.moderated_by.login).to eql(users(:sudara).login)
     end
+
+    it "should not have set last_login_at" do
+      login = valid_account_request.login
+      valid_account_request.approve!(users(:sudara))
+      expect(User.find_by_login(login).last_login_at).to be_nil
+    end
   end
 
   context "on denial" do
@@ -83,7 +89,7 @@ RSpec.describe AccountRequest, type: :model do
   end
 
   context "status" do
-    it "should change to accepted when user sets password" do
+    it "should change to claimed when user sets password" do
 
     end
   end

--- a/spec/models/account_request_spec.rb
+++ b/spec/models/account_request_spec.rb
@@ -55,6 +55,10 @@ RSpec.describe AccountRequest, type: :model do
       expect { valid_account_request.approve!(users(:sudara)) }.to change { User.count }.by(1)
     end
 
+    it "should store a reference to the created user account" do
+      expect { valid_account_request.approve!(users(:sudara)) }.to change { valid_account_request.user_id }
+    end
+
     it "should reset the perishable token and password for the user account" do
       login = valid_account_request.login
       valid_account_request.approve!(users(:sudara))

--- a/spec/models/account_request_spec.rb
+++ b/spec/models/account_request_spec.rb
@@ -87,8 +87,16 @@ RSpec.describe AccountRequest, type: :model do
   end
 
   context "on denial" do
-    it "should do nothing when denied" do
+    it "should populate moderated_by" do
+      valid_account_request.deny!(users(:sudara))
+      expect(valid_account_request.moderated_by.login).to eql(users(:sudara).login)
+    end
 
+    it "should soft delete any created user if the record was previously approved" do
+      expect {
+        valid_account_request.approve!(users(:sudara))
+        valid_account_request.deny!(users(:sudara))
+      }.not_to change { User.count }
     end
   end
 

--- a/spec/request/admin/account_requests_controller_spec.rb
+++ b/spec/request/admin/account_requests_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe Admin::AssetsController, type: :request do
+RSpec.describe Admin::AccountRequestsController, type: :request do
   before do
     create_user_session(users(:sudara))
   end


### PR DESCRIPTION
A few improvements to the account request system

* [x] Up the character minimum for account request details
* [x] Update copy to make it clearer we want text about what people do 
* [ ] Closes #954 
* [x] Show duplicate emails in the UI
* [x] Only show band/musician entries in "waiting"? Could have another category for waiting blogger/podcasters 