### PR TITLE
Give users in Search Results a responsive grid and the 'artist card' format

### DIFF
--- a/app/assets/stylesheets/components/search_results.scss
+++ b/app/assets/stylesheets/components/search_results.scss
@@ -35,7 +35,14 @@
 		width: 136px;
 		margin-bottom: 30px;
 		margin-right: 18px;
-		text-align: center;
+    text-align: center;
+    font-size: 11px;
+    padding-bottom: $baseline / 4;
+    text-align: center;
+    background-color: $user-card-background;
+    border-radius: 6px;
+    box-shadow: 0px 1.5px 2.75px rgba(0, 0, 0, 0.15);
+    overflow: hidden;
 		img.cover {
 			width: 125px;
 			height: 125px;

--- a/app/assets/stylesheets/components/search_results.scss
+++ b/app/assets/stylesheets/components/search_results.scss
@@ -32,9 +32,6 @@
 	}
 	div.user {
 		position: relative;
-		width: 136px;
-		margin-bottom: 30px;
-		margin-right: 18px;
     text-align: center;
     font-size: 11px;
     padding-bottom: $baseline / 4;
@@ -44,11 +41,11 @@
     box-shadow: 0px 1.5px 2.75px rgba(0, 0, 0, 0.15);
     overflow: hidden;
 		img.cover {
-			width: 125px;
-			height: 125px;
+			width: 100%;
+			// height: 125px;
 		}
 		.name {
-			margin-top: 4px;
+			margin-top: 8px;
 			font-size: 13px;
 			display: block;
 			&:hover {
@@ -56,4 +53,72 @@
 			}
 		}
 	}
+}
+
+
+$results-gutter-width: 18px;
+$results-three-column-cutoff: "only screen and (max-width: 2032px)";
+$results-two-column-cutoff: "only screen and (max-width: 550px)";
+
+ul.results_responsive_grid {
+  margin-bottom: 0;
+  li {
+    margin-bottom: $results-gutter-width;
+    width: calc(25% - 20px);
+    margin-right: $results-gutter-width;
+    &:nth-child(4n) {
+      margin-right: 0;
+    }
+    > a:first-child {
+      padding-top: 100%;
+      box-sizing: border-box;
+      position: relative;
+      img, svg {
+        position: absolute;
+        top: 0;
+        left: 0;
+      }
+    }
+  }
+  @media #{$results-three-column-cutoff} {
+    li {
+      width: calc(33.33333% - 17.77px);
+      &:nth-child(1n),
+      &:nth-child(2n),
+      &:nth-child(3n) {
+        display: block;
+      }
+      &:nth-child(3n) {
+        margin-right: 0 !important;
+      }
+      &:nth-child(4n) {
+        margin-right: $results-gutter-width;
+      }
+    }
+  }
+  @media #{$results-two-column-cutoff} {
+    li {
+      display: block !important;
+      width: calc(50% - 13.33px);
+      margin-bottom: $results-gutter-width!important;
+      margin-right: $results-gutter-width !important;
+      &:nth-child(3n) {
+        margin-right: $results-gutter-width !important;
+      }
+      &:nth-child(2n) {
+        margin-right: 0 !important;
+      }
+      img {
+        width: 100%;
+      }
+      svg {
+        width: 100%;
+      }
+    }
+  }
+  @media #{$mobile} {
+    width: calc(100% - 32px);
+    margin-left: auto;
+    margin-right: auto;
+  }
 }

--- a/app/assets/stylesheets/components/search_results.scss
+++ b/app/assets/stylesheets/components/search_results.scss
@@ -26,10 +26,6 @@
 	display: flex;
 	margin-top: 60px;
 	flex-wrap: wrap;
-	@media #{$mobile} {
-		padding-right: $baseline * 1.5;
-		padding-left: $baseline * 1.5;
-	}
 	div.user {
 		position: relative;
     text-align: center;
@@ -42,7 +38,6 @@
     overflow: hidden;
 		img.cover {
 			width: 100%;
-			// height: 125px;
 		}
 		.name {
 			margin-top: 8px;
@@ -55,51 +50,32 @@
 	}
 }
 
-
 $results-gutter-width: 18px;
-$results-three-column-cutoff: "only screen and (max-width: 2032px)";
 $results-two-column-cutoff: "only screen and (max-width: 550px)";
 
 ul.results_responsive_grid {
   margin-bottom: 0;
   li {
+    width: calc(33.33333% - 12px);
     margin-bottom: $results-gutter-width;
-    width: calc(25% - 20px);
     margin-right: $results-gutter-width;
+
+    &:nth-child(1n),
+    &:nth-child(2n),
+    &:nth-child(3n) {
+      display: block;
+    }
+    &:nth-child(3n) {
+      margin-right: 0 !important;
+    }
     &:nth-child(4n) {
-      margin-right: 0;
-    }
-    > a:first-child {
-      padding-top: 100%;
-      box-sizing: border-box;
-      position: relative;
-      img, svg {
-        position: absolute;
-        top: 0;
-        left: 0;
-      }
-    }
-  }
-  @media #{$results-three-column-cutoff} {
-    li {
-      width: calc(33.33333% - 17.77px);
-      &:nth-child(1n),
-      &:nth-child(2n),
-      &:nth-child(3n) {
-        display: block;
-      }
-      &:nth-child(3n) {
-        margin-right: 0 !important;
-      }
-      &:nth-child(4n) {
-        margin-right: $results-gutter-width;
-      }
+      margin-right: $results-gutter-width;
     }
   }
   @media #{$results-two-column-cutoff} {
     li {
       display: block !important;
-      width: calc(50% - 13.33px);
+      width: calc(50% - 9px);
       margin-bottom: $results-gutter-width!important;
       margin-right: $results-gutter-width !important;
       &:nth-child(3n) {

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -12,7 +12,7 @@
 <% if @users.present? %>
   <% content_for :left do %>
     <h2 class="user_search_results_heading">Artists that match "<%= @query %>"</h2>
-    <ul id="user_search_results" class="responsive_grid">
+    <ul id="user_search_results" class="results_responsive_grid">
       <%= render partial: 'shared/user', collection: @users, as: :user %>
     </ul>
   <% end %>

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -12,7 +12,7 @@
 <% if @users.present? %>
   <% content_for :left do %>
     <h2 class="user_search_results_heading">Artists that match "<%= @query %>"</h2>
-    <ul id="user_search_results">
+    <ul id="user_search_results" class="responsive_grid">
       <%= render partial: 'shared/user', collection: @users, as: :user %>
     </ul>
   <% end %>


### PR DESCRIPTION

<img width="770" alt="Screenshot 2020-02-12 14 46 33" src="https://user-images.githubusercontent.com/407724/74380410-ba13ef80-4da6-11ea-8efd-f45a2da7de4c.png">

I added a modified version of the responsive grid code to search_results to have these artists behave in a predictable grid at all widths.

### Does anything special need to happen for deployment?

No, this PR is localized to the search results.

## "Ready For Review" checklist

These checklists are to help ensure the code review basics are covered. Consider removing to reduce noise.

* [ ] PR title accurately summarizes changes
* [ ] New tests were added for isolated methods or new endpoints
* [ ] I opened an issue for any logical followups
* [ ] If this fixes a bug, "Fixes #XXX" is either the very first or very last line of the description.

## Before code review *and after additional commits* during review.

* [ ] Update title and description to account for additional changes
* [ ] All tests green
* [ ] Migrations were tested locally and do the right thing
* [ ] Booted up the branch locally, exercised any new code
* [ ] Percy changes are purposeful or explained
* [ ] Css changes are happy on mobile (via Percy is ok)
