### PR TITLE
Rework SVG animation js

### DIFF
--- a/app/assets/images/svg/animation_play.svg
+++ b/app/assets/images/svg/animation_play.svg
@@ -1,22 +1,22 @@
-   <svg id="playAnimationSVG"  xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 600">
-        <defs>
-            <mask id="iconMask">
-                <circle class="dotty" cx="300" cy="300" r="245" fill="#FFF" stroke="none" stroke-miterlimit="10" stroke-width="105" />
-                <circle class="dotty" cx="300" cy="300" r="245" fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="105" stroke-dasharray="167.94 51.98" />
-                <g class="spinballGroup">
-                    <circle class="spinball" cx="221" cy="300" r="55" fill="#000" stroke="none" stroke-miterlimit="10" stroke-width="0" />
-                    <circle class="spinball" cx="379" cy="300" r="55" fill="#000" stroke="none" stroke-miterlimit="10" stroke-width="0" />
-                </g>
-            </mask>
-        </defs>
-        <g>
-            <circle class="outline" cx="300" cy="300" r="245" fill="none" stroke="#999" stroke-miterlimit="10" stroke-width="0" />
-            <g class="iconGroup" mask="url(#iconMask)">
-                <path class="icon" d="M187,489.21l-.31-378.41a.77.77,0,0,1,1.15-.67l150.53,86.75L515.71,299.08a.76.76,0,0,1,0,1.31L188.14,489.87A.76.76,0,0,1,187,489.21Z" />
+<svg id="playAnimationSVG"  xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 600">
+    <defs>
+        <mask id="iconMask">
+            <circle class="dotty" cx="300" cy="300" r="245" fill="#FFF" stroke="none" stroke-miterlimit="10" stroke-width="105" />
+            <circle class="dotty" cx="300" cy="300" r="245" fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="105" stroke-dasharray="167.94 51.98" />
+            <g class="spinballGroup">
+                <circle class="spinball" cx="221" cy="300" r="55" fill="#000" stroke="none" stroke-miterlimit="10" stroke-width="0" />
+                <circle class="spinball" cx="379" cy="300" r="55" fill="#000" stroke="none" stroke-miterlimit="10" stroke-width="0" />
             </g>
-            <g id="pauseGroup" class="pauseGroup">
-                <line x1="235" y1="96" x2="235" y2="500" fill="none" stroke="#fff" stroke-miterlimit="10" stroke-width="64" />
-                <line x1="365" y1="96" x2="365" y2="500" fill="none" stroke="#fff" stroke-miterlimit="10" stroke-width="64" />
-            </g>
+        </mask>
+    </defs>
+    <g>
+        <circle class="outline" cx="300" cy="300" r="245" fill="none" stroke="#999" stroke-miterlimit="10" stroke-width="0" />
+        <g class="iconGroup" mask="url(#iconMask)">
+            <path class="icon" d="M187,489.21l-.31-378.41a.77.77,0,0,1,1.15-.67l150.53,86.75L515.71,299.08a.76.76,0,0,1,0,1.31L188.14,489.87A.76.76,0,0,1,187,489.21Z" />
         </g>
-    </svg>
+        <g id="pauseGroup" class="pauseGroup">
+            <line x1="235" y1="96" x2="235" y2="500" fill="none" stroke="#fff" stroke-miterlimit="10" stroke-width="64" />
+            <line x1="365" y1="96" x2="365" y2="500" fill="none" stroke="#fff" stroke-miterlimit="10" stroke-width="64" />
+        </g>
+    </g>
+</svg>

--- a/app/assets/stylesheets/components/markdown.scss
+++ b/app/assets/stylesheets/components/markdown.scss
@@ -1,0 +1,72 @@
+.markdown, .thredded--post--content {
+  > * {
+    color: inherit;
+  }
+  p {
+    margin-bottom: $baseline;
+    img {
+      max-width: 100%;
+    }
+  }
+  a {
+    color: $accent;
+    text-decoration: underline!important;
+    &:hover {
+      color: $accent!important;
+      text-decoration: underline!important;
+    }
+  }
+  h1 {
+    font-size: 28px;
+  }
+  h2 {
+    font-size: 22px;
+  }
+  h3 {
+    font-size: 18px;
+  }
+  pre {
+    overflow-x: auto;
+    white-space: pre-wrap;
+    word-wrap: break-word;
+    padding-left: 4%;
+    padding-right: 4%;
+  }
+  blockquote {
+    border-left: 4px solid $accent;
+    margin:0 10px;
+    padding: 0 10px;
+  }
+  ul {
+    padding-left: 24px;
+    li {
+      list-style-type: disc;
+    }
+  }
+  ol {
+    counter-reset: listNumbering;
+    padding-left: 6px;
+    li {
+      list-style: none;
+      counter-increment: listNumbering;
+      &:before {
+        content: counter(listNumbering) ".";
+        font-variant-numeric: tabular-nums;
+        font-size: 14px;
+        color: inherit;
+        margin-right: 6px;
+      }
+    }
+  }
+
+  hr {
+    width: 90%!important;
+    margin: ($baseline * 1.5) auto!important;
+    border: 0!important;
+    border-bottom: 1px solid $track-content-hr-background!important;
+  }
+  iframe {
+    margin-bottom: $baseline;
+    max-width: 100%;
+  }
+}

--- a/app/assets/stylesheets/components/single_and_playlists_player/track_player.scss
+++ b/app/assets/stylesheets/components/single_and_playlists_player/track_player.scss
@@ -20,7 +20,20 @@
       cursor: pointer;
       .largePlaySVG {
         path.icon.new {
-          fill: $track-player-play-button-triangle-background;
+          fill: $track-player-play-button-triangle-fill;
+        }
+        .outline {
+          opacity: .8;
+          stroke: $track-player-play-button-outline-stroke;
+        }
+        .dotty {
+          stroke: $track-player-dotty-stroke;
+        }
+        .pauseLoopGroup, .pauseGroup {
+          stroke: $track-player-pause-button-stroke;
+        }
+        .centerCircle {
+          fill: $track-player-pause-button-fill;
         }
       }
     }

--- a/app/assets/stylesheets/components/tracks.scss
+++ b/app/assets/stylesheets/components/tracks.scss
@@ -77,18 +77,17 @@
             margin-left: 8px;
             pointer-events: none;
             fill: $track-play-button-background;
-          }
-          .outline {
-            stroke: $track-play-button-background;
-          }
-          .icon {
-            fill: $track-play-button-background;
-          }
-          .pauseGroup {
-            line {
-              stroke: $track-pause-button-stroke;
-              
+            .outline {
+              stroke: $track-play-button-background;
             }
+            .icon {
+              fill: $track-play-button-background;
+            }
+            .pauseGroup {
+              line {
+                stroke: $track-pause-button-stroke;
+              }
+            }  
           }
         }
       }

--- a/app/assets/stylesheets/components/tracks.scss
+++ b/app/assets/stylesheets/components/tracks.scss
@@ -78,6 +78,18 @@
             pointer-events: none;
             fill: $track-play-button-background;
           }
+          .outline {
+            stroke: $track-play-button-background;
+          }
+          .icon {
+            fill: $track-play-button-background;
+          }
+          .pauseGroup {
+            line {
+              stroke: $track-pause-button-stroke;
+              
+            }
+          }
         }
       }
       div.title {

--- a/app/assets/stylesheets/themes/dark.scss
+++ b/app/assets/stylesheets/themes/dark.scss
@@ -317,7 +317,11 @@ $waveform-played-background: $grey100;
 $big-player-seekbar-background: $grey200;
 $track-player-background: $grey1150;
 $track-player-play-button-background: $grey1100;
-$track-player-play-button-triangle-background: $white;
+$track-player-play-button-triangle-fill: $white;
+$track-player-play-button-outline-stroke: $white;
+$track-player-dotty-stroke: $white;
+$track-player-pause-button-stroke: $black;
+$track-player-pause-button-fill: $white;
 $big-player-time-text: $black;
 $big-player-time-total-text: $grey800;
 

--- a/app/assets/stylesheets/themes/dark.scss
+++ b/app/assets/stylesheets/themes/dark.scss
@@ -111,7 +111,8 @@ $track-content-comment-textarea-text: $grey400;
 // tracks.scss
 $track-open-box-shadow: none;
 $track-background: $grey1100;
-$track-play-button-background: $accent;
+$track-play-button-background: $white;
+$track-pause-button-stroke: $black;
 $track-seekbar-loaded-background: $grey1000;
 $track-border-bottom: $grey1000;
 $track-time-text: $grey500;

--- a/app/assets/stylesheets/themes/white.scss
+++ b/app/assets/stylesheets/themes/white.scss
@@ -317,7 +317,11 @@ $waveform-played-background: $grey1000;
 $big-player-seekbar-background: $grey200;
 $track-player-background: $grey100;
 $track-player-play-button-background: $white;
-$track-player-play-button-triangle-background: $black;
+$track-player-play-button-triangle-fill: $black;
+$track-player-play-button-outline-stroke: $black;
+$track-player-dotty-stroke: $black;
+$track-player-pause-button-stroke: $white;
+$track-player-pause-button-fill: $black;
 $big-player-time-text: $white;
 $big-player-time-total-text: $grey800;
 

--- a/app/assets/stylesheets/themes/white.scss
+++ b/app/assets/stylesheets/themes/white.scss
@@ -112,6 +112,7 @@ $track-content-comment-textarea-text: $grey1000;
 $track-open-box-shadow: 0 11px 19px 4px #6566667a;
 $track-background: $white;
 $track-play-button-background: $black;
+$track-pause-button-stroke: $white;
 $track-seekbar-loaded-background: $grey50;
 $track-border-bottom: $grey50;
 $track-time-text: $grey800;

--- a/app/assets/stylesheets/themes/white.scss
+++ b/app/assets/stylesheets/themes/white.scss
@@ -328,7 +328,6 @@ $track-player-play-button-outline-stroke: $black;
 $track-player-dotty-stroke: $black;
 $track-player-pause-button-stroke: $white;
 $track-player-pause-button-fill: $black;
-
 $big-player-time-text: $white;
 $big-player-time-total-text: $grey800;
 

--- a/app/controllers/concerns/listens.rb
+++ b/app/controllers/concerns/listens.rb
@@ -15,6 +15,7 @@ module Listens
       if Rails.application.play_dummy_audio? || Rails.env.test?
         play_local_mp3
       else
+        sleep(2) if Rails.env.development? # simulate network loading, it'll be 2x with range requests
         redirect_to asset.download_location.to_s
       end
     end

--- a/app/javascript/animation/fave_animation.js
+++ b/app/javascript/animation/fave_animation.js
@@ -1,7 +1,7 @@
-import { TweenLite, AttrPlugin, Linear, Elastic, Power1, Power2, Power3, Sine, CSSPlugin, TimelineMax } from 'gsap/all'
-import MorphSVGPlugin from './MorphSVGPlugin'
+import { gsap } from 'gsap'
+import { MorphSVGPlugin } from './MorphSVGPlugin'
 
-const plugins = [CSSPlugin, AttrPlugin, MorphSVGPlugin, Linear, Elastic, Power1, Power2, Power3, Sine]
+gsap.registerPlugin(MorphSVGPlugin)
 
 export default function FaveAnimation(myDiv) {
     var mainTl;
@@ -26,31 +26,31 @@ export default function FaveAnimation(myDiv) {
 
     this.init = function() {
 
-        TweenLite.set([outline, heart], {
+        gsap.set([outline, heart], {
             // transformOrigin: '50% 50%',
             svgOrigin: "300 300"
         })
 
-        allPopTl = new TimelineMax().timeScale(1);
+        allPopTl = gsap.timeline().timeScale(1);
 
-        redPop2Tl = new TimelineMax({}).timeScale(1);
-        redPop3Tl = new TimelineMax({}).timeScale(1);
-        bluePopTl = new TimelineMax({}).timeScale(1);
-        yellowPopTl = new TimelineMax({}).timeScale(1);
-        greenPopTl = new TimelineMax({}).timeScale(1);
-        purplePopTl = new TimelineMax({}).timeScale(1);
-        redPopTl = new TimelineMax({}).timeScale(1);
-        heartTl = new TimelineMax({}).timeScale(1);
-        mainTl = new TimelineMax({ paused: true }).timeScale(1.6);
+        redPop2Tl = gsap.timeline({}).timeScale(1);
+        redPop3Tl = gsap.timeline({}).timeScale(1);
+        bluePopTl = gsap.timeline({}).timeScale(1);
+        yellowPopTl = gsap.timeline({}).timeScale(1);
+        greenPopTl = gsap.timeline({}).timeScale(1);
+        purplePopTl = gsap.timeline({}).timeScale(1);
+        redPopTl = gsap.timeline({}).timeScale(1);
+        heartTl = gsap.timeline({}).timeScale(1);
+        mainTl = gsap.timeline({ paused: true }).timeScale(1.6);
 
         mainTl.addLabel('clickFave')
             .to(outline, 0.2, {
                 scale: 0.9,
-                ease: Linear.easeNone
+                ease:  'none'
             })
             .to(outline, 0.2, {
                 scale: 1,
-                ease: Linear.easeNone
+                ease:  'none'
             })
             .set(outline, {
                 autoAlpha: 0,
@@ -59,7 +59,7 @@ export default function FaveAnimation(myDiv) {
             .from(heart, 1, {
                 scale: 0,
                 fill: '#f638a8',
-                ease: Elastic.easeOut.config(1.5, 0.7)
+                ease: 'elastic(1.5, 0.7)',
             }, '-=0.34')
 
             .addLabel('setFave')
@@ -77,7 +77,7 @@ export default function FaveAnimation(myDiv) {
             }, '-=0.4')
             .to(outline, 1, {
                 scale: 1,
-                ease: Elastic.easeOut.config(1.5, 0.7)
+                ease: 'elastic(1.5, 0.7)',
             }, '-=0.3')
             .addLabel('setUnfave')
 
@@ -90,17 +90,17 @@ export default function FaveAnimation(myDiv) {
                 attr: {
                     r: 100
                 },
-                ease: Power1.easeOut
+                ease:  'power1.out'
             })
             .from(purplePop, 0.6, {
                 strokeWidth: 23,
-                ease: Power3.easeInOut
+                ease:  'power3.inOut'
             }, '-=0.4')
             .to(purplePop, 0.2, {
                 attr: {
                     r: 110
                 },
-                ease: Power3.easeOut
+                ease:  'power3.out'
             }, '-=0.2 ')
 
         redPopTl.fromTo(redPop, 0.4, {
@@ -111,17 +111,17 @@ export default function FaveAnimation(myDiv) {
                 attr: {
                     r: 100
                 },
-                ease: Power1.easeOut
+                ease:  'power1.out'
             })
             .from(redPop, 0.6, {
                 strokeWidth: 23,
-                ease: Power3.easeInOut
+                ease:  'power3.inOut'
             }, '-=0.4')
             .to(redPop, 0.2, {
                 attr: {
                     r: 110
                 },
-                ease: Power3.easeOut
+                ease:  'power3.out'
             }, '-=0.2 ')
 
 
@@ -133,17 +133,17 @@ export default function FaveAnimation(myDiv) {
                 attr: {
                     r: 100
                 },
-                ease: Power1.easeOut
+                ease:  'power1.out'
             })
             .from(greenPop, 0.6, {
                 strokeWidth: 23,
-                ease: Power3.easeInOut
+                ease:  'power3.inOut'
             }, '-=0.4')
             .to(greenPop, 0.2, {
                 attr: {
                     r: 110
                 },
-                ease: Power3.easeOut
+                ease:  'power3.out'
             }, '-=0.2 ')
 
         yellowPopTl.fromTo(yellowPop, 0.4, {
@@ -154,17 +154,17 @@ export default function FaveAnimation(myDiv) {
                 attr: {
                     r: 100
                 },
-                ease: Power1.easeOut
+                ease:  'power1.out'
             })
             .from(yellowPop, 0.6, {
                 strokeWidth: 23,
-                ease: Power3.easeInOut
+                ease:  'power3.inOut'
             }, '-=0.4')
             .to(yellowPop, 0.2, {
                 attr: {
                     r: 110
                 },
-                ease: Power3.easeOut
+                ease:  'power3.out'
             }, '-=0.2 ')
 
         bluePopTl.fromTo(bluePop, 0.4, {
@@ -175,17 +175,17 @@ export default function FaveAnimation(myDiv) {
                 attr: {
                     r: 100
                 },
-                ease: Power1.easeOut
+                ease:  'power1.out'
             })
             .from(bluePop, 0.6, {
                 strokeWidth: 23,
-                ease: Power3.easeInOut
+                ease:  'power3.inOut'
             }, '-=0.4')
             .to(bluePop, 0.2, {
                 attr: {
                     r: 110
                 },
-                ease: Power3.easeOut
+                ease:  'power3.out'
             }, '-=0.2 ')
 
         redPop2Tl.fromTo(redPop2, 0.4, {
@@ -196,17 +196,17 @@ export default function FaveAnimation(myDiv) {
                 attr: {
                     r: 100
                 },
-                ease: Power1.easeOut
+                ease:  'power1.out'
             })
             .from(redPop2, 0.6, {
                 strokeWidth: 23,
-                ease: Power3.easeInOut
+                ease:  'power3.inOut'
             }, '-=0.4')
             .to(redPop2, 0.2, {
                 attr: {
                     r: 110
                 },
-                ease: Power3.easeOut
+                ease:  'power3.out'
             }, '-=0.2 ')
 
         redPop3Tl.fromTo(redPop3, 0.4, {
@@ -217,17 +217,17 @@ export default function FaveAnimation(myDiv) {
                 attr: {
                     r: 100
                 },
-                ease: Power1.easeOut
+                ease:  'power1.out'
             })
             .from(redPop3, 0.6, {
                 strokeWidth: 23,
-                ease: Power3.easeInOut
+                ease:  'power3.inOut'
             }, '-=0.4')
             .to(redPop3, 0.2, {
                 attr: {
                     r: 110
                 },
-                ease: Power3.easeOut
+                ease:  'power3.out'
             }, '-=0.2 ');
 
         allPopTl.add(redPopTl)

--- a/app/javascript/animation/fave_animation.js
+++ b/app/javascript/animation/fave_animation.js
@@ -1,7 +1,7 @@
 import { gsap } from 'gsap'
-import { MorphSVGPlugin } from './MorphSVGPlugin'
+import MorphSVGPlugin from './MorphSVGPlugin'
 
-gsap.registerPlugin(MorphSVGPlugin)
+if (MorphSVGPlugin) gsap.registerPlugin(MorphSVGPlugin)
 
 export default function FaveAnimation(myDiv) {
     var mainTl;

--- a/app/javascript/animation/large_play_animation.js
+++ b/app/javascript/animation/large_play_animation.js
@@ -1,7 +1,7 @@
-import { TweenLite, AttrPlugin, Linear, Elastic, Power1, Power2, Power3, Sine, CSSPlugin, TimelineMax } from 'gsap/all'
-import MorphSVGPlugin from './MorphSVGPlugin'
+import { gsap } from 'gsap'
+import { MorphSVGPlugin } from './MorphSVGPlugin'
 
-const plugins = [CSSPlugin, AttrPlugin, MorphSVGPlugin, Linear, Elastic, Power1, Power2, Power3, Sine]
+gsap.registerPlugin(MorphSVGPlugin)
 
 export default function LargePlayAnimation() {
 
@@ -28,29 +28,29 @@ export default function LargePlayAnimation() {
 
     this.reset()
 
-    eyesTl = new TimelineMax({paused:true, repeat:-1}).timeScale(1.8);
-    dottyRotationTl = new TimelineMax({}).timeScale(1.9);
-    mainTl = new TimelineMax({paused:true}).timeScale(2.6);
+    eyesTl = gsap.timeline({paused:true, repeat:-1}).timeScale(1.8);
+    dottyRotationTl = gsap.timeline({}).timeScale(1.9);
+    mainTl = gsap.timeline({paused:true}).timeScale(2.6);
 
     dottyRotationTl.to(dotty, 4, {
       rotation:360,
       repeat:-1,
-      ease:Linear.easeNone
+      ease:'none',
     })
 
     // eyes timeline
 
     eyesTl.to(pauseLoopGroup, 0.4, {
       scaleY:0.12,
-      ease:Sine.easeInOut
+      ease: 'sine.inOut',
     })
     .to(pauseLoopGroup, 0.4, {
       scaleY:0,
       repeat:1,
       yoyo:true,
       repeatDelay:0.41,
-      ease:Sine.easeIn,
-      delay:1
+      ease: 'sine.in',
+      delay:1,
     })
    .to(pauseLoopGroup, 0.65, {
       scaleY:0.25,
@@ -58,30 +58,30 @@ export default function LargePlayAnimation() {
       yoyo:true,
       repeatDelay:0,
       delay:1.5,
-      ease:Power1.easeInOut
+      ease: 'power1.inOut',
     })
     .to(pauseLoopGroup, 0.2, {
       scaleY:0.12,
-      ease:Sine.easeOut
+      ease: 'sine.out',
     })
     .to(pauseLoopGroup, 0.16, {
       scaleY:0.01,
       repeat:1,
       yoyo:true,
-      ease:Sine.easeIn,
-      delay:2
+      ease: 'sine.in',
+      delay:2,
     })
     .to(pauseLoopGroup, 0.16, {
       scaleY:0.01,
       repeat:3,
       yoyo:true,
-      ease:Sine.easeIn,
-      delay:4
+      ease: 'sine.in',
+      delay:4,
     })
     .to(pauseLoopGroup, 0.16, {
       scaleY:0,
-      ease:Sine.easeIn,
-      delay:1
+      ease: 'sine.in',
+      delay:1,
     })
 
     // main timeline
@@ -92,53 +92,48 @@ export default function LargePlayAnimation() {
       .to(dotty, 1, {
         strokeWidth:128,
         scale:1,
-        ease:Power1.easeInOut
+        ease: 'power1.inOut',
       })
       .to(icon, 1, {
         scale:0.4,
-        ease:Power1.easeInOut
+        ease: 'power1.inOut',
       },'-=1')
       .from(centerCircle, 1, {
         scale:0.01,
-        ease:Power1.easeInOut
+        ease: 'power1.inOut',
       },'-=1')
       .to(outline, 1, {
         strokeWidth:30,
         scale:0.97,
         stroke: '#000',
-        ease:Power1.easeInOut
+        ease: 'power1.inOut',
       },'-=1')
       .to(pauseContainer, 1, {
         scaleY:1,
-        ease:Power1.easeInOut
+        ease: 'power1.inOut',
       })
       .addPause()
       .addLabel('showPause')
       .to(pauseContainer, 0.5, {
-        scaleY:0
+        scaleY:0,
       })
       .to(centerCircle, 1, {
         attr:{
-          r:245
+          r:245,
         },
-      ease:Power1.easeInOut
+      ease: 'power1.inOut',
       },'-=0.5')
       .to(dotty, 1.2, {
         strokeWidth:0,
         scale:1,
-        ease:Power1.easeInOut
+        ease: 'power1.inOut',
       },'-=1')
       .to(pauseGroup, 1, {
         scaleY:1,
-        ease:Power1.easeInOut
+        ease: 'power1.inOut',
       },'-=1.2')
-      .staggerTo(allPauseLines, 1, {
-        cycle:{
-          attr:[{x1:235, x2:235}, {x1:365, x2:365}]
-        }
-      },0, '-=1')
+      .to(allPauseLines, { duration: 1, attr: gsap.utils.wrap([{ x1: 235, x2: 235 }, { x1: 365, x2: 365 }]) }, '-=1')
       .addLabel('setPause')
-
   }
 
   this.play = function(pos) {
@@ -160,34 +155,34 @@ export default function LargePlayAnimation() {
   }
 
   this.showLoading = function(){
-    TweenLite.set(".dotty", { visibility: "visible" });
-    TweenLite.set(".pauseContainer", { visibility: "visible" });
-    TweenLite.set(".centerCircle", { visibility: "visible" });
+    gsap.set(".dotty", { visibility: "visible" });
+    gsap.set(".pauseContainer", { visibility: "visible" });
+    gsap.set(".centerCircle", { visibility: "visible" });
     mainTl.play('showloading')
     eyesTl.play();
   }
 
   this.reset = function() {
-    TweenLite.set([dotty, centerCircle], {
+    gsap.set([dotty, centerCircle], {
       transformOrigin: '50% 50%',
-      strokeWidth: 0
+      strokeWidth: 0,
     })
 
-    TweenLite.set(icon, {
+    gsap.set(icon, {
       transformOrigin: '35% 50%',
     })
 
-    TweenLite.set(outline, {
-      transformOrigin: '50% 50%'
+    gsap.set(outline, {
+      transformOrigin: '50% 50%',
     })
 
-    TweenLite.set([pauseContainer, pauseGroup, pauseLoopGroup], {
+    gsap.set([pauseContainer, pauseGroup, pauseLoopGroup], {
       transformOrigin: '50% 50%',
       scaleY: 0,
-      visibility: 'visible'
+      visibility: 'visible',
     })
-    TweenLite.set(mainSVG, {
-      visibility: 'visible'
+    gsap.set(mainSVG, {
+      visibility: 'visible',
     })
   }
 

--- a/app/javascript/animation/large_play_animation.js
+++ b/app/javascript/animation/large_play_animation.js
@@ -3,195 +3,179 @@ import { MorphSVGPlugin } from './MorphSVGPlugin'
 
 gsap.registerPlugin(MorphSVGPlugin)
 
-export default function LargePlayAnimation() {
-
-  var xmlns = "http://www.w3.org/2000/svg",
-    xlinkns = "http://www.w3.org/1999/xlink",
-    select = function(s) {
-      return document.querySelector(s);
-    },
-    selectAll = function(s) {
-      return document.querySelectorAll(s);
-    },
-    mainSVG = select('.largePlaySVG'),
-    mainTl, dottyRotationTl,eyesTl,
-    centerCircle = select('.centerCircle'),
-    pauseContainer = select('.pauseContainer'),
-    pauseLoopGroup = select('.pauseLoopGroup'),
-    pauseGroup = select('.pauseGroup'),
-    outline = select('.outline'),
-    dotty = selectAll('.dotty'),
-    icon = select('.icon'),
-    allPauseLines = selectAll('.pauseGroup line')
-
-  this.init = function() {
-
-    this.reset()
-
-    eyesTl = gsap.timeline({paused:true, repeat:-1}).timeScale(1.8);
-    dottyRotationTl = gsap.timeline({}).timeScale(1.9);
-    mainTl = gsap.timeline({paused:true}).timeScale(2.6);
-
-    dottyRotationTl.to(dotty, 4, {
-      rotation:360,
-      repeat:-1,
-      ease:'none',
-    })
-
-    // eyes timeline
-
-    eyesTl.to(pauseLoopGroup, 0.4, {
-      scaleY:0.12,
-      ease: 'sine.inOut',
-    })
-    .to(pauseLoopGroup, 0.4, {
-      scaleY:0,
-      repeat:1,
-      yoyo:true,
-      repeatDelay:0.41,
-      ease: 'sine.in',
-      delay:1,
-    })
-   .to(pauseLoopGroup, 0.65, {
-      scaleY:0.25,
-      repeat:1,
-      yoyo:true,
-      repeatDelay:0,
-      delay:1.5,
-      ease: 'power1.inOut',
-    })
-    .to(pauseLoopGroup, 0.2, {
-      scaleY:0.12,
-      ease: 'sine.out',
-    })
-    .to(pauseLoopGroup, 0.16, {
-      scaleY:0.01,
-      repeat:1,
-      yoyo:true,
-      ease: 'sine.in',
-      delay:2,
-    })
-    .to(pauseLoopGroup, 0.16, {
-      scaleY:0.01,
-      repeat:3,
-      yoyo:true,
-      ease: 'sine.in',
-      delay:4,
-    })
-    .to(pauseLoopGroup, 0.16, {
-      scaleY:0,
-      ease: 'sine.in',
-      delay:1,
-    })
-
-    // main timeline
-
-    mainTl
-      .addLabel('setPlay')
-      .addLabel('showLoading')
-      .to(dotty, 1, {
-        strokeWidth:128,
-        scale:1,
-        ease: 'power1.inOut',
-      })
-      .to(icon, 1, {
-        scale:0.4,
-        ease: 'power1.inOut',
-      },'-=1')
-      .from(centerCircle, 1, {
-        scale:0.01,
-        ease: 'power1.inOut',
-      },'-=1')
-      .to(outline, 1, {
-        strokeWidth:30,
-        scale:0.97,
-        stroke: '#000',
-        ease: 'power1.inOut',
-      },'-=1')
-      .to(pauseContainer, 1, {
-        scaleY:1,
-        ease: 'power1.inOut',
-      })
-      .addPause()
-      .addLabel('showPause')
-      .to(pauseContainer, 0.5, {
-        scaleY:0,
-      })
-      .to(centerCircle, 1, {
-        attr:{
-          r:245,
-        },
-      ease: 'power1.inOut',
-      },'-=0.5')
-      .to(dotty, 1.2, {
-        strokeWidth:0,
-        scale:1,
-        ease: 'power1.inOut',
-      },'-=1')
-      .to(pauseGroup, 1, {
-        scaleY:1,
-        ease: 'power1.inOut',
-      }, '-=1.2')
-      .to(allPauseLines, { duration: 1, attr: gsap.utils.wrap([{ x1: 235, x2: 235 }, { x1: 365, x2: 365 }]) }, '-=1')
-      .addLabel('setPause')
+export default class LargePlayAnimation {
+  constructor(elementToReplace) {
+    this.mainSVG = document.querySelector('.largePlaySVG')
+    this.setupTimelines()
   }
 
-  this.play = function(pos) {
-    if(pos){mainTl.play(pos);} return;
-    mainTl.play();
-  }
+  setupTimelines() {
+    this.eyesTl = gsap.timeline({ repeat: -1 }).timeScale(1.8);
+    this.dottyRotationTl = gsap.timeline({}).timeScale(1.9);
+    this.tl = gsap.timeline({ paused: true }).timeScale(2.6);
 
-  this.pause = function(pos) {
-    if(pos){mainTl.pause(pos);} return;
-    mainTl.pause();
-  }
+    this.centerCircle = this.select('.centerCircle')
+    this.pauseContainer = this.select('.pauseContainer')
+    this.pauseLoopGroup = this.select('.pauseLoopGroup')
+    this.pauseGroup = this.select('.pauseGroup')
+    this.outline = this.select('.outline')
+    this.dotty = this.selectAll('.dotty')
+    this.icon = this.select('.icon')
+    this.allPauseLines = this.selectAll('.pauseGroup line')
 
-  this.timeline = function() {
-    return mainTl;
-  }
-
-  this.setPlay = function(){
-    mainTl.pause('setPlay')
-  }
-
-  this.showLoading = function(){
-    gsap.set(".dotty", { visibility: "visible" });
-    gsap.set(".pauseContainer", { visibility: "visible" });
-    gsap.set(".centerCircle", { visibility: "visible" });
-    mainTl.play('showloading')
-    eyesTl.play();
-  }
-
-  this.reset = function() {
-    gsap.set([dotty, centerCircle], {
+    gsap.set([this.dotty, this.centerCircle], {
       transformOrigin: '50% 50%',
       strokeWidth: 0,
+      visibility: 'visible',
     })
 
-    gsap.set(icon, {
+    gsap.set(this.icon, {
       transformOrigin: '35% 50%',
+      visibility: 'visible',
     })
 
-    gsap.set(outline, {
+    gsap.set(this.outline, {
       transformOrigin: '50% 50%',
+      visibility: 'visible',
     })
 
-    gsap.set([pauseContainer, pauseGroup, pauseLoopGroup], {
+    gsap.set([this.pauseContainer, this.pauseGroup, this.pauseLoopGroup], {
       transformOrigin: '50% 50%',
       scaleY: 0,
       visibility: 'visible',
     })
-    gsap.set(mainSVG, {
-      visibility: 'visible',
+
+    this.dottyRotationTl.to(this.dotty, 4, {
+      rotation: 360,
+      repeat: -1,
+      ease: 'none',
+    })
+
+    // eyes timeline
+    this.eyesTl.to(this.pauseLoopGroup, 0.4, {
+      scaleY: 0.12,
+      ease: 'sine.inOut',
+    })
+    .to(this.pauseLoopGroup, 0.4, {
+      scaleY: 0,
+      repeat: 1,
+      yoyo: true,
+      repeatDelay: 0.41,
+      ease: 'sine.in',
+      delay: 1,
+    })
+   .to(this.pauseLoopGroup, 0.65, {
+      scaleY: 0.25,
+      repeat: 1,
+      yoyo: true,
+      repeatDelay: 0,
+      delay: 1.5,
+      ease: 'power1.inOut',
+    })
+    .to(this.pauseLoopGroup, 0.2, {
+      scaleY: 0.12,
+      ease: 'sine.out',
+    })
+    .to(this.pauseLoopGroup, 0.16, {
+      scaleY: 0.01,
+      repeat: 1,
+      yoyo: true,
+      ease: 'sine.in',
+      delay: 2,
+    })
+    .to(this.pauseLoopGroup, 0.16, {
+      scaleY: 0.01,
+      repeat: 3,
+      yoyo: true,
+      ease: 'sine.in',
+      delay: 4,
+    })
+    .to(this.pauseLoopGroup, 0.16, {
+      scaleY: 0,
+      ease: 'sine.in',
+      delay: 1,
+    })
+
+    // main timeline
+    this.tl
+      .addLabel('playButton')
+      .addLabel('loadingAnimation')
+      .to(this.dotty, 1, {
+        strokeWidth: 128,
+        scale: 1,
+        ease: 'power1.inOut',
+      })
+      .to(this.icon, 1, {
+        scale: 0.4,
+        ease: 'power1.inOut',
+      }, '-=1')
+      .from(this.centerCircle, 1, {
+        scale: 0.01,
+        ease: 'power1.inOut',
+      }, '-=1')
+      .to(this.outline, 1, {
+        strokeWidth: 30,
+        scale: 0.97,
+        stroke: '#000',
+        ease: 'power1.inOut',
+      }, '-=1')
+      .to(this.pauseContainer, 1, {
+        scaleY: 1,
+        ease: 'power1.inOut',
+      })
+      .addPause()
+      .addLabel('pausingAnimation')
+      .to(this.pauseContainer, 0.5, {
+        scaleY: 0,
+      })
+      .to(this.centerCircle, 1, {
+        attr: {
+          r: 245,
+        },
+        ease: 'power1.inOut',
+      }, '-=0.5')
+      .to(this.dotty, 1.2, {
+        strokeWidth: 0,
+        scale: 1,
+        ease: 'power1.inOut',
+      }, '-=1')
+      .to(this.pauseGroup, 1, {
+        scaleY: 1,
+        ease: 'power1.inOut',
+      }, '-=1.2')
+      .to(this.allPauseLines, { duration: 1, attr: gsap.utils.wrap([{ x1: 235, x2: 235 }, { x1: 365, x2: 365 }]) }, '-=1')
+      .addLabel('pauseButton')
+  }
+
+
+  loadingAnimation() {
+    this.tl.play('loadingAnimation')
+  }
+
+  pausingAnimation() {
+    this.tl.play('pausingAnimation')
+  }
+
+  showPlayButton() {
+    this.tl.pause('playButton')
+  }
+
+  showPauseButton() {
+    this.tl.pause('pauseButton')
+  }
+
+  reset() {
+    gsap.set([this.dotty, this.centerCircle, this.icon, this.outline,
+      this.pauseContainer, this.pauseGroup, this.pauseLoopGroup], {
+      clearProps: 'all',
     })
   }
 
-  this.showPause = function(){
-    mainTl.play('showPause')
+  select(s) {
+    return this.mainSVG.querySelector(s)
   }
 
-  this.setPause = function(){
-    mainTl.pause('setPause')
+  selectAll(s) {
+    return this.mainSVG.querySelectorAll(s)
   }
-
 }

--- a/app/javascript/animation/large_play_animation.js
+++ b/app/javascript/animation/large_play_animation.js
@@ -24,7 +24,6 @@ export default function LargePlayAnimation() {
     icon = select('.icon'),
     allPauseLines = selectAll('.pauseGroup line')
 
-
   this.init = function() {
 
     this.reset()
@@ -39,7 +38,7 @@ export default function LargePlayAnimation() {
       ease:Linear.easeNone
     })
 
-    // eyes timline
+    // eyes timeline
 
     eyesTl.to(pauseLoopGroup, 0.4, {
       scaleY:0.12,
@@ -69,7 +68,6 @@ export default function LargePlayAnimation() {
       scaleY:0.01,
       repeat:1,
       yoyo:true,
-      //repeatDelay:0.41,
       ease:Sine.easeIn,
       delay:2
     })
@@ -77,71 +75,69 @@ export default function LargePlayAnimation() {
       scaleY:0.01,
       repeat:3,
       yoyo:true,
-      //repeatDelay:0.41,
       ease:Sine.easeIn,
       delay:4
     })
     .to(pauseLoopGroup, 0.16, {
       scaleY:0,
-      //repeatDelay:0.41,
       ease:Sine.easeIn,
       delay:1
     })
 
-   // main timeline
+    // main timeline
 
-    mainTl.addLabel('setPlay')
+    mainTl
+      .addLabel('setPlay')
       .addLabel('showLoading')
       .to(dotty, 1, {
-      strokeWidth:128,
-      scale:1,
+        strokeWidth:128,
+        scale:1,
+        ease:Power1.easeInOut
+      })
+      .to(icon, 1, {
+        scale:0.4,
+        ease:Power1.easeInOut
+      },'-=1')
+      .from(centerCircle, 1, {
+        scale:0.01,
+        ease:Power1.easeInOut
+      },'-=1')
+      .to(outline, 1, {
+        strokeWidth:30,
+        scale:0.97,
+        stroke: '#000',
+        ease:Power1.easeInOut
+      },'-=1')
+      .to(pauseContainer, 1, {
+        scaleY:1,
+        ease:Power1.easeInOut
+      })
+      .addPause()
+      .addLabel('showPause')
+      .to(pauseContainer, 0.5, {
+        scaleY:0
+      })
+      .to(centerCircle, 1, {
+        attr:{
+          r:245
+        },
       ease:Power1.easeInOut
-    })
-    .to(icon, 1, {
-      scale:0.4,
-      ease:Power1.easeInOut
-    },'-=1')
-    .from(centerCircle, 1, {
-      scale:0.01,
-      ease:Power1.easeInOut
-    },'-=1')
-    .to(outline, 1, {
-      strokeWidth:30,
-      scale:0.97,
-      stroke: '#000',
-      ease:Power1.easeInOut
-    },'-=1')
-    .to(pauseContainer, 1, {
-      scaleY:1,
-      ease:Power1.easeInOut
-    })
-    .addPause()
-    .addLabel('showPause')
-    .to(pauseContainer, 0.5, {
-      scaleY:0
-    })
-    .to(centerCircle, 1, {
-      attr:{
-        r:245
-      },
-    ease:Power1.easeInOut
-    },'-=0.5')
-    .to(dotty, 1.2, {
-      strokeWidth:0,
-      scale:1,
-      ease:Power1.easeInOut
-    },'-=1')
-    .to(pauseGroup, 1, {
-      scaleY:1,
-      ease:Power1.easeInOut
-      //ease:Elastic.easeOut.config(0.95,0.3)
-    },'-=1.2')
-    .staggerTo(allPauseLines, 1, {
-      cycle:{
-        attr:[{x1:235, x2:235}, {x1:365, x2:365}]
-      }
-    },0, '-=1')
-    .addLabel('setPause')
+      },'-=0.5')
+      .to(dotty, 1.2, {
+        strokeWidth:0,
+        scale:1,
+        ease:Power1.easeInOut
+      },'-=1')
+      .to(pauseGroup, 1, {
+        scaleY:1,
+        ease:Power1.easeInOut
+      },'-=1.2')
+      .staggerTo(allPauseLines, 1, {
+        cycle:{
+          attr:[{x1:235, x2:235}, {x1:365, x2:365}]
+        }
+      },0, '-=1')
+      .addLabel('setPause')
 
   }
 

--- a/app/javascript/animation/large_play_animation.js
+++ b/app/javascript/animation/large_play_animation.js
@@ -116,7 +116,7 @@ export default class LargePlayAnimation {
       .to(this.outline, 1, {
         strokeWidth: 30,
         scale: 0.97,
-        stroke: '#000',
+        opacity: '1',
         ease: 'power1.inOut',
       }, '-=1')
       .to(this.pauseContainer, 1, {

--- a/app/javascript/animation/large_play_animation.js
+++ b/app/javascript/animation/large_play_animation.js
@@ -1,7 +1,7 @@
 import { gsap } from 'gsap'
 import { MorphSVGPlugin } from './MorphSVGPlugin'
 
-gsap.registerPlugin(MorphSVGPlugin)
+if (MorphSVGPlugin) gsap.registerPlugin(MorphSVGPlugin)
 
 export default class LargePlayAnimation {
   constructor(elementToReplace) {

--- a/app/javascript/animation/large_play_animation.js
+++ b/app/javascript/animation/large_play_animation.js
@@ -131,7 +131,7 @@ export default function LargePlayAnimation() {
       .to(pauseGroup, 1, {
         scaleY:1,
         ease: 'power1.inOut',
-      },'-=1.2')
+      }, '-=1.2')
       .to(allPauseLines, { duration: 1, attr: gsap.utils.wrap([{ x1: 235, x2: 235 }, { x1: 365, x2: 365 }]) }, '-=1')
       .addLabel('setPause')
   }

--- a/app/javascript/animation/play_animation.js
+++ b/app/javascript/animation/play_animation.js
@@ -2,9 +2,11 @@
 
 There are 3 things that make this svg/animation tricky to implement.
 
-1. We want the resting state of the svg to be a play button but they way it's built requires init() to set scale properly (css doesn't work).
-2. init() is not idempotent, it can only be called once
-3. More than one copy of the svg cannot occur on the page at one time without changing the mask id.
+1. We want the resting state of the svg to be a play button, but certain elements have to be hidden for it not to be a cluttered ball of junk. On this small play button, we actually only swap in the animation svg once play is pressed. On the large play button we hide the problematic svg elements until the animation is initialized in js.
+
+2. Attaching these animations to an svg element is not idempotent, as everything is scaled as it is first attached. This becomes problematic because if we navigate away from a page and then come back via turbolinks, the svg has been modified in the DOM, but the animation then modifies and scales it up again.
+
+3. More than one copy of the svg cannot occur on the page at one time without changing the mask ids. This seems to be a general limitation of masking with svg.
 
 */
 

--- a/app/javascript/animation/play_animation.js
+++ b/app/javascript/animation/play_animation.js
@@ -39,18 +39,6 @@ export default class PlayAnimation {
       scaleY: 0,
     })
 
-    this.spinballTl.to(this.spinballGroup, 2, {
-      rotation: '+=360',
-      ease: 'none',
-      repeat: -1,
-    })
-
-    this.dottyRotationTl.to(this.dotty, 4, {
-      rotation: '-=360',
-      repeat: -1,
-      ease: 'none',
-    })
-
     this.tl.addLabel('playButton')
       .addLabel('loadingAnimation')
       .to(this.icon, 1, {
@@ -98,6 +86,16 @@ export default class PlayAnimation {
   }
 
   loadingAnimation() {
+    this.spinballTl.to(this.spinballGroup, 2, {
+      rotation: '+=360',
+      ease: 'none',
+      repeat: -1,
+    })
+    this.dottyRotationTl.to(this.dotty, 4, {
+      rotation: '-=360',
+      repeat: -1,
+      ease: 'none',
+    })
     this.tl.play('loadingAnimation')
   }
 

--- a/app/javascript/animation/play_animation.js
+++ b/app/javascript/animation/play_animation.js
@@ -35,7 +35,6 @@ export default function PlayAnimation(mainSVG) {
 
     outlinePath = 'M300,545C164.69,545,55,435.31,55,300S164.69,55,300,55,545,164.69,545,300,435.31,545,300,545Z';
 
-
     TweenLite.set(mainSVG, {
       visibility: 'visible'
     })
@@ -96,7 +95,7 @@ export default function PlayAnimation(mainSVG) {
         ease: Elastic.easeOut.config(0.3, 0.9),
       })
       .to(spinballGroup, 0.2, {
-        // autoAlpha:0
+        autoAlpha:0
       }, '-=1')
       .to(pauseGroup, 2, {
         scaleY: 0.7,

--- a/app/javascript/animation/play_animation.js
+++ b/app/javascript/animation/play_animation.js
@@ -13,7 +13,8 @@ There are 3 things that make this svg/animation tricky to implement.
 import { gsap } from 'gsap'
 import { MorphSVGPlugin } from './MorphSVGPlugin'
 
-gsap.registerPlugin(MorphSVGPlugin)
+// In test mode, this file is empty, as we can't legally have it in public git
+if (MorphSVGPlugin) gsap.registerPlugin(MorphSVGPlugin)
 
 export default class PlayAnimation {
   constructor(elementToReplace) {

--- a/app/javascript/animation/play_animation.js
+++ b/app/javascript/animation/play_animation.js
@@ -99,12 +99,12 @@ export default class PlayAnimation {
 
   loadingAnimation() {
     this.tl.play('loadingAnimation')
-    this.dottyRotationTl.play()
   }
 
   pauseAnimation() {
     this.tl.play('pauseAnimation')
     this.dottyRotationTl.pause()
+    this.spinballTl.pause()
   }
 
   showPlayButton() {

--- a/app/javascript/animation/play_animation.js
+++ b/app/javascript/animation/play_animation.js
@@ -1,126 +1,117 @@
-import { TweenLite, AttrPlugin, Linear, Elastic, Power1, Power2, Power3, Sine, CSSPlugin, TimelineMax } from 'gsap/all'
-import MorphSVGPlugin from './MorphSVGPlugin'
+import { gsap } from 'gsap'
+import { MorphSVGPlugin } from './MorphSVGPlugin'
 
-const plugins = [CSSPlugin, AttrPlugin, MorphSVGPlugin, Linear, Elastic, Power1, Power2, Power3, Sine]
+gsap.registerPlugin(MorphSVGPlugin)
 
-export default function PlayAnimation(mainSVG) {
-  const select = function (s) {
-    return mainSVG.querySelector(s)
+export default class PlayAnimation {
+  constructor(mainSVG) {
+    this.mainSVG = mainSVG
+
+    this.pauseGroup = this.select('.pauseGroup')
+    this.spinballGroup = this.select('.spinballGroup')
+    this.outline = this.select('.outline')
+    this.dotty = this.selectAll('.dotty')
+    this.icon = this.select('.icon')
+    this.outlinePath = 'M300,545C164.69,545,55,435.31,55,300S164.69,55,300,55,545,164.69,545,300,435.31,545,300,545Z';
+
+    this.tl = gsap.timeline({ paused: true }).timeScale(2.2);
+    this.spinballTl = gsap.timeline().timeScale(1);
+    this.dottyRotationTl = gsap.timeline().timeScale(1);
   }
 
-  const selectAll = function (s) {
-    return mainSVG.querySelectorAll(s)
-  }
-
-  let mainTl
-  let dottyRotationTl
-  let spinballTl
-
-  let pauseGroup = select('.pauseGroup')
-  let spinballGroup = select('.spinballGroup')
-
-  let outline = select('.outline');
-  let dotty = selectAll('.dotty');
-  let icon = select('.icon');
-
-  let outlinePath = 'M300,545C164.69,545,55,435.31,55,300S164.69,55,300,55,545,164.69,545,300,435.31,545,300,545Z';
-
-  this.init = function () {
-    pauseGroup = select('.pauseGroup');
-    spinballGroup = select('.spinballGroup');
-
-    outline = select('.outline');
-    dotty = selectAll('.dotty');
-    icon = select('.icon');
-
-    outlinePath = 'M300,545C164.69,545,55,435.31,55,300S164.69,55,300,55,545,164.69,545,300,435.31,545,300,545Z';
-
-    TweenLite.set(mainSVG, {
-      visibility: 'visible'
+  init() {
+    gsap.set(this.mainSVG, {
+      visibility: 'visible',
     })
 
-    TweenLite.set(dotty, {
+    gsap.set(this.dotty, {
       transformOrigin: '50% 50%',
       scale: 1.3,
     })
 
-    TweenLite.set(spinballGroup, {
+    gsap.set(this.spinballGroup, {
       transformOrigin: '50% 50%',
       scale: 0,
     })
 
-    TweenLite.set(pauseGroup, {
+    gsap.set(this.pauseGroup, {
       transformOrigin: '50% 50%',
       scaleY: 0,
     })
 
-    mainTl = new TimelineMax({ paused: true }).timeScale(2.2);
-    
-    spinballTl = new TimelineMax({}).timeScale(1);
-    spinballTl.to(spinballGroup, 2, {
+    this.spinballTl.to(this.spinballGroup, 2, {
       rotation: '+=360',
-      ease: Linear.easeNone,
+      ease: 'none',
       repeat: -1,
     })
 
-    dottyRotationTl = new TimelineMax({}).timeScale(1);
-    dottyRotationTl.to(dotty, 4, {
+    this.dottyRotationTl.to(this.dotty, 4, {
       rotation: '-=360',
       repeat: -1,
-      ease: Linear.easeNone,
+      ease: 'none',
     })
 
-    mainTl.addLabel('setPlay')
-      .addLabel('showLoading')
-      .to(icon, 1, {
-        morphSVG: { shape: outlinePath, shapeIndex: 'auto' },
-        ease: Power1.easeInOut,
+    this.tl.addLabel('playButton')
+      .addLabel('loadingAnimation')
+      .to(this.icon, 1, {
+        morphSVG: { shape: this.outlinePath, shapeIndex: 'auto' },
+        ease: 'power1.inOut',
       })
-      .to(dotty, 1, {
+      .to(this.dotty, 1, {
         scale: 1,
-        ease: Power2.easeOut,
+        ease: 'power2.out',
       }, '-=1')
-      .to(outline, 0.5, {
+      .to(this.outline, 0.5, {
         strokeWidth: 16,
-        ease: Linear.easeNone,
+        ease: 'none',
       }, '-=0.5')
-      .to(spinballGroup, 1, {
+      .to(this.spinballGroup, 1, {
         scale: 1,
-        ease: Power1.easeInOut,
+        ease: 'power1.inOut',
       }, '-=1')
       .addPause()
-      .addLabel('showPause')
-      .to(spinballGroup, 1, {
+      .addLabel('pauseAnimation')
+      .to(this.spinballGroup, 1, {
         scale: 0,
-        ease: Elastic.easeOut.config(0.3, 0.9),
+        ease: 'elastic(0.3, 0.9)',
       })
-      .to(spinballGroup, 0.2, {
-        autoAlpha:0
+      .to(this.spinballGroup, 0.2, {
+        autoAlpha: 0
       }, '-=1')
-      .to(pauseGroup, 2, {
+      .to(this.pauseGroup, 2, {
         scaleY: 0.7,
-        ease: Elastic.easeOut.config(1, 0.5),
+        ease: 'elastic(1, 0.5)',
       }, '-=1')
-      .to(dotty, 1, {
+      .to(this.dotty, 1, {
         scale: 1.3,
-        ease: Elastic.easeOut.config(0.3, 0.9),
+        ease: 'elastic(0.3, 0.9)',
       }, '-=2')
-      .addLabel('setPause')
+      .addLabel('pauseButton')
   }
 
-  this.setPlay = function () {
-    mainTl.pause('setPlay')
+  select(s) {
+    return this.mainSVG.querySelector(s)
   }
 
-  this.showLoading = function () {
-    mainTl.play('showloading')
+  selectAll(s) {
+    return this.mainSVG.querySelectorAll(s)
   }
 
-  this.showPause = function () {
-    mainTl.play('showPause')
+  loadingAnimation() {
+    this.tl.play('loadingAnimation')
+    this.dottyRotationTl.play()
   }
 
-  this.setPause = function () {
-    mainTl.pause('setPause')
+  pauseAnimation() {
+    this.tl.play('pauseAnimation')
+    this.dottyRotationTl.pause()
+  }
+
+  showPlayButton() {
+    this.tl.pause('playButton')
+  }
+
+  showPauseButton() {
+    this.tl.pause('pauseButton')
   }
 }

--- a/app/javascript/animation/play_animation.js
+++ b/app/javascript/animation/play_animation.js
@@ -55,8 +55,14 @@ export default function PlayAnimation(mainSVG) {
       scaleY: 0,
     })
 
-    spinballTl = new TimelineMax({}).timeScale(1);
     mainTl = new TimelineMax({ paused: true }).timeScale(2.2);
+    
+    spinballTl = new TimelineMax({}).timeScale(1);
+    spinballTl.to(spinballGroup, 2, {
+      rotation: '+=360',
+      ease: Linear.easeNone,
+      repeat: -1,
+    })
 
     dottyRotationTl = new TimelineMax({}).timeScale(1);
     dottyRotationTl.to(dotty, 4, {
@@ -101,11 +107,6 @@ export default function PlayAnimation(mainSVG) {
         ease: Elastic.easeOut.config(0.3, 0.9),
       }, '-=2')
       .addLabel('setPause')
-    spinballTl.to(spinballGroup, 2, {
-      rotation: '+=360',
-      ease: Linear.easeNone,
-      repeat: -1,
-    })
   }
 
   this.setPlay = function () {

--- a/app/javascript/animation/play_animation.js
+++ b/app/javascript/animation/play_animation.js
@@ -88,7 +88,7 @@ export default class PlayAnimation {
         ease: 'power1.inOut',
       }, '-=1')
       .addPause()
-      .addLabel('pauseAnimation')
+      .addLabel('pausingAnimation')
       .to(this.spinballGroup, 1, {
         scale: 0,
         ease: 'elastic(0.3, 0.9)',
@@ -129,8 +129,8 @@ export default class PlayAnimation {
     this.tl.play('loadingAnimation')
   }
 
-  pauseAnimation() {
-    this.tl.play('pauseAnimation')
+  pausingAnimation() {
+    this.tl.play('pausingAnimation')
     this.dottyRotationTl.pause()
     this.spinballTl.pause()
   }

--- a/app/javascript/controllers/big_play_controller.js
+++ b/app/javascript/controllers/big_play_controller.js
@@ -10,29 +10,24 @@ export default class extends Controller {
     this.percentPlayed = 0.0
     this.setDelegate()
     this.setupPlayhead()
-    console.log('initializing....')
+    this.setAnimationState()
   }
 
   setAnimationState() {
     if (this.delegate && this.delegate.isPlaying && !this.delegate.loaded) {
       // instantiated while an mp3 is still loading
       this.animation.loadingAnimation()
-      console.log('still loading')
     } else if (this.delegate && this.delegate.isPlaying) {
       // ...while in the middle of playing
-      console.log('in the middle of playing yo')
       this.animation.pausingAnimation()
       this.startPlayhead()
     } else if (this.delegate && this.delegate.positionFromStart(0.1)) {
       // ...after playing once but now paused
-      console.log("yes, this is the problem")
       this.animation.showPlayButton()
       this.showPlayhead()
       this.update(this.delegate.percentPlayed())
     } else {
       // ....loaded but not playing
-      console.log('this is the else state')
-      console.log(this.delegate, this.delegate.positionFromStart(0.1))
       this.animation.showPlayButton()
     }
   }
@@ -80,7 +75,7 @@ export default class extends Controller {
     this.percentPlayed = this.delegate.percentPlayed()
     this.timeTarget.innerHTML = this.delegate.time
     if (Math.abs(this.percentPlayed - this.timeline.progress()) > 0.02) {
-      console.log(`playhead jogged from ${this.timeline.progress()} to ${this.percentPlayed}`)
+      // console.log(`playhead jogged from ${this.timeline.progress()} to ${this.percentPlayed}`)
       this.timeline.progress(this.percentPlayed)
     }
   }

--- a/app/javascript/controllers/big_play_controller.js
+++ b/app/javascript/controllers/big_play_controller.js
@@ -9,8 +9,6 @@ export default class extends Controller {
     this.animation = new LargePlayAnimation()
     this.percentPlayed = 0.0
     this.setDelegate()
-    this.animation.init()
-    this.animation.play()
     this.setupPlayhead()
     console.log('initializing....')
   }
@@ -18,25 +16,24 @@ export default class extends Controller {
   setAnimationState() {
     if (this.delegate && this.delegate.isPlaying && !this.delegate.loaded) {
       // instantiated while an mp3 is still loading
-      this.animation.showLoading()
+      this.animation.loadingAnimation()
       console.log('still loading')
     } else if (this.delegate && this.delegate.isPlaying) {
       // ...while in the middle of playing
       console.log('in the middle of playing yo')
-      this.animation.showLoading()
-      this.animation.showPause()
+      this.animation.pausingAnimation()
       this.startPlayhead()
     } else if (this.delegate && this.delegate.positionFromStart(0.1)) {
       // ...after playing once but now paused
       console.log("yes, this is the problem")
-      this.animation.setPlay()
+      this.animation.showPlayButton()
       this.showPlayhead()
       this.update(this.delegate.percentPlayed())
     } else {
       // ....loaded but not playing
       console.log('this is the else state')
       console.log(this.delegate, this.delegate.positionFromStart(0.1))
-      this.animation.setPlay()
+      this.animation.showPlayButton()
     }
   }
 
@@ -51,13 +48,13 @@ export default class extends Controller {
 
   // called from whileLoading()
   play() {
-    this.animation.showPause()
+    this.animation.showPauseButton()
     this.startPlayhead()
   }
 
   pause() {
     this.timeline.pause()
-    this.animation.setPlay()
+    this.animation.showPlayButton()
   }
 
   togglePlay(e) {
@@ -89,8 +86,7 @@ export default class extends Controller {
   }
 
   stop() {
-    this.animation.reset()
-    this.animation.setPlay()
+    this.animation.showPlayButton()
     this.playheadAnimation.stop()
   }
 
@@ -117,5 +113,9 @@ export default class extends Controller {
     if (this.timeline.duration() === 1) {
       this.timeline.duration(this.delegate.duration)
     }
+  }
+
+  disconnect() {
+    this.animation.reset()
   }
 }

--- a/app/javascript/controllers/big_play_controller.js
+++ b/app/javascript/controllers/big_play_controller.js
@@ -1,4 +1,5 @@
 import { Controller } from 'stimulus'
+import { gsap } from 'gsap'
 import LargePlayAnimation from '../animation/large_play_animation'
 
 export default class extends Controller {
@@ -11,25 +12,30 @@ export default class extends Controller {
     this.animation.init()
     this.animation.play()
     this.setupPlayhead()
-    this.setAnimationState()
+    console.log('initializing....')
   }
 
   setAnimationState() {
     if (this.delegate && this.delegate.isPlaying && !this.delegate.loaded) {
       // instantiated while an mp3 is still loading
       this.animation.showLoading()
+      console.log('still loading')
     } else if (this.delegate && this.delegate.isPlaying) {
       // ...while in the middle of playing
+      console.log('in the middle of playing yo')
       this.animation.showLoading()
       this.animation.showPause()
       this.startPlayhead()
-    } else if (this.delegate && this.delegate.positionFromStart(1)) {
+    } else if (this.delegate && this.delegate.positionFromStart(0.1)) {
       // ...after playing once but now paused
+      console.log("yes, this is the problem")
       this.animation.setPlay()
       this.showPlayhead()
       this.update(this.delegate.percentPlayed())
     } else {
       // ....loaded but not playing
+      console.log('this is the else state')
+      console.log(this.delegate, this.delegate.positionFromStart(0.1))
       this.animation.setPlay()
     }
   }
@@ -89,14 +95,14 @@ export default class extends Controller {
   }
 
   setupPlayhead() {
-    this.timeline = new TimelineMax({ paused: true, duration: 1 })
+    this.timeline = gsap.timeline({ paused: true, duration: 1 })
     this.playheadAnimation = this.timeline.to(this.progressContainerInnerTarget, 1, {
       left: '100%',
-      ease: Linear.easeNone,
+      ease:  'none',
     }, 0)
     this.waveformAnimation = this.timeline.to('#waveform_reveal', 1, {
       attr: { x: '0' },
-      ease: Linear.easeNone,
+      ease:  'none',
     }, 0)
   }
 

--- a/app/javascript/controllers/big_play_controller.js
+++ b/app/javascript/controllers/big_play_controller.js
@@ -43,7 +43,7 @@ export default class extends Controller {
 
   // called from whileLoading()
   play() {
-    this.animation.showPauseButton()
+    this.animation.pausingAnimation()
     this.startPlayhead()
   }
 

--- a/app/javascript/controllers/flash_controller.js
+++ b/app/javascript/controllers/flash_controller.js
@@ -1,5 +1,5 @@
 import { Controller } from 'stimulus'
-import { TimelineMax, TweenLite, Elastic, Power4, CSSPlugin } from 'gsap/all'
+import { gsap } from 'gsap'
 
 export let flashController
 
@@ -12,7 +12,7 @@ export default class extends Controller {
 
   alert(message) {
     this.element.innerHTML = message
-    new TimelineMax({})
+    gsap.timeline({})
       .to(this.element, 0, { autoAlpha: 0, y: 50 })
       .to(this.element, 0.5, { autoAlpha: 1, y: 0 })
       .to(this.element, 1, { autoAlpha: 0, y: 0 }, 3)

--- a/app/javascript/controllers/normal_playback_controller.js
+++ b/app/javascript/controllers/normal_playback_controller.js
@@ -23,7 +23,7 @@ export default class extends PlaybackController {
   }
 
   playCallback() {
-    this.showAnimation()
+    this.showLoadingAnimationOrPauseButton()
     this.openDetails()
     this.updateSeekBarLoaded()
     this.registeredListen = true
@@ -76,11 +76,11 @@ export default class extends PlaybackController {
     }
   }
 
-  showAnimation() {
+  showLoadingAnimationOrPauseButton() {
     this.cloneAnimationIfNeeded()
     if (!this.loaded) {
       this.playButtonTarget.style.display = 'none' // hide the dummy play button
-      this.animateLoading()
+      this.animation.loadingAnimation()
     } else this.animation.showPauseButton()
   }
 
@@ -88,17 +88,15 @@ export default class extends PlaybackController {
   // Until this point, the play button has been a placeholder icon SVG
   // After this point, the play button is an animatable SVG
   cloneAnimationIfNeeded() {
+    console.log(this.animation)
     if (this.animation === undefined) {
       const animationElement = document.getElementById('playAnimationSVG').cloneNode(true);
-      animationElement.id = this.data.get('id')
+      animationElement.id = ''
+      animationElement.classList.add('playAnimationSVG')
       this.playTarget.firstElementChild.append(animationElement)
       this.animation = new PlayAnimation(animationElement)
+      this.animation.init()
     }
-  }
-
-  animateLoading() {
-    this.animation.init()
-    this.animation.loadingAnimation()
   }
 
   // With SoundManager we used to animate this width to display
@@ -130,6 +128,11 @@ export default class extends PlaybackController {
   disconnect() {
     if (this.sound.playing()) {
       this.sound.pause()
+    }
+    if (this.animation !== undefined) {
+      this.playTarget.getElementsByClassName('playAnimationSVG')[0].remove()
+      this.playButtonTarget.style.display = 'block' // hide the dummy play button
+
     }
     if (this.element.classList.contains('open')) {
       this.element.classList.remove('open')

--- a/app/javascript/controllers/normal_playback_controller.js
+++ b/app/javascript/controllers/normal_playback_controller.js
@@ -15,7 +15,7 @@ export default class extends PlaybackController {
 
   whilePlayingCallback() {
     if (!this.loaded) {
-      this.animation.showPause()
+      this.animation.pauseAnimation()
       this.loaded = true
     }
     this.updateSeekBarPlayed()
@@ -31,11 +31,11 @@ export default class extends PlaybackController {
   }
 
   pauseCallback() {
-    this.animation.setPlay()
+    this.animation.showPlayButton()
   }
 
   stopCallback() {
-    this.animation.setPlay()
+    this.animation.showPlayButton()
   }
 
   toggleDetails(e) {
@@ -81,7 +81,7 @@ export default class extends PlaybackController {
     if (!this.loaded) {
       this.playButtonTarget.style.display = 'none' // hide the dummy play button
       this.animateLoading()
-    } else this.animation.setPause()
+    } else this.animation.showPauseButton()
   }
 
   // Print our own copy of #playAnimationSVG to animate freely as we like
@@ -98,8 +98,7 @@ export default class extends PlaybackController {
 
   animateLoading() {
     this.animation.init()
-    this.animation.setPlay()
-    this.animation.showLoading()
+    this.animation.loadingAnimation()
   }
 
   // With SoundManager we used to animate this width to display

--- a/app/javascript/controllers/normal_playback_controller.js
+++ b/app/javascript/controllers/normal_playback_controller.js
@@ -15,7 +15,7 @@ export default class extends PlaybackController {
 
   whilePlayingCallback() {
     if (!this.loaded) {
-      this.animation.pauseAnimation()
+      this.animation.pausingAnimation()
       this.loaded = true
     }
     this.updateSeekBarPlayed()
@@ -80,7 +80,7 @@ export default class extends PlaybackController {
     this.setupAnimation()
     if (!this.loaded) {
       this.animation.loadingAnimation()
-    } else this.animation.pauseAnimation()
+    } else this.animation.pausingAnimation()
   }
 
   // We have one single #playAnimationSVG element to move around and animate

--- a/app/javascript/controllers/playback_controller.js
+++ b/app/javascript/controllers/playback_controller.js
@@ -21,9 +21,9 @@ export default class extends Controller {
   }
 
   disconnect() {
-    if (this.sound.playing()) {
-      this.sound.pause()
-    }
+    this.sound.pause()
+    player = null
+    this.isPlaying = false
   }
 
   setupHowl() {

--- a/app/javascript/controllers/playlist_form_controller.js
+++ b/app/javascript/controllers/playlist_form_controller.js
@@ -66,7 +66,6 @@ export default class extends Controller {
     e.preventDefault()
     this.coverTarget.innerHTML = '<div class="no_pic"></div>'
     this.fileFieldTarget.value = ''
-    console.log(this.fileFieldTarget)
 
   }
 

--- a/app/javascript/controllers/playlist_playback_controller.js
+++ b/app/javascript/controllers/playlist_playback_controller.js
@@ -104,4 +104,8 @@ export default class extends PlaybackController {
   isCurrentTrack() {
     return this.playTarget.getAttribute('href') === document.location.pathname
   }
+
+  disconnect() {
+    super.disconnect()
+  }
 }

--- a/app/javascript/controllers/playlist_playback_controller.js
+++ b/app/javascript/controllers/playlist_playback_controller.js
@@ -80,6 +80,7 @@ export default class extends PlaybackController {
   whilePlayingCallback() {
     if (!this.bigPlay) this.setBigPlay()
     if (!this.loaded) {
+      // Trigger the transition from loading to playing
       this.loaded = true
       this.bigPlay.play()
     }

--- a/app/javascript/controllers/save_controller.js
+++ b/app/javascript/controllers/save_controller.js
@@ -1,5 +1,5 @@
 import { Controller } from 'stimulus'
-import { Tweenlite } from 'gsap/all'
+import { gsap } from 'gsap'
 
 export default class extends Controller {
   static targets = ['response', 'spinner']
@@ -8,13 +8,13 @@ export default class extends Controller {
     this.responseTarget.classList.remove('ajax_success', 'ajax_fail')
     this.responseTarget.innerHTML = ''
     this.spinnerTarget.style.display = 'block'
-    TweenLite.to(this.spinnerTarget, 0, { autoAlpha: 1 })
-    TweenLite.to(this.responseTarget, 0, { autoAlpha: 1 })
+    gsap.to(this.spinnerTarget, 0, { autoAlpha: 1 })
+    gsap.to(this.responseTarget, 0, { autoAlpha: 1 })
   }
 
   complete() {
-    TweenLite.to(this.spinnerTarget, .25, { autoAlpha: 0 }).delay(.25)
-    TweenLite.to(this.responseTarget, 1, { autoAlpha: 0 }).delay(4)
+    gsap.to(this.spinnerTarget, .25, { autoAlpha: 0 }).delay(.25)
+    gsap.to(this.responseTarget, 1, { autoAlpha: 0 }).delay(4)
   }
 
   success() {

--- a/app/javascript/controllers/user_dropdown_controller.js
+++ b/app/javascript/controllers/user_dropdown_controller.js
@@ -1,5 +1,4 @@
 import { Controller } from 'stimulus'
-import { TweenMax } from 'gsap/all'
 import Turbolinks from 'turbolinks'
 import Rails from '@rails/ujs'
 

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -15,7 +15,6 @@ import gsap from 'gsap' // needed for tests to run
 import { bugsnagClient } from '../misc/bugsnag.js.erb'
 import { makeSVGFromTitle } from '../animation/default_playlist_images'
 
-
 Rails.start()
 Turbolinks.start()
 

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -11,6 +11,7 @@ import Rails from '@rails/ujs'
 import Turbolinks from 'turbolinks'
 import { Application } from 'stimulus'
 import { definitionsFromContext } from 'stimulus/webpack-helpers'
+import gsap from 'gsap' // needed for tests to run
 import { bugsnagClient } from '../misc/bugsnag.js.erb'
 import { makeSVGFromTitle } from '../animation/default_playlist_images'
 
@@ -52,3 +53,6 @@ function handlers() {
 }
 document.addEventListener('turbolinks:load', handlers)
 
+export {
+  gsap
+}

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -124,7 +124,7 @@ class Asset < ApplicationRecord
   # needed for views in case we've got multiple assets on the same page
   # TODO: this is a view concern, move to helper, or better yet, deal w/it in .js
   def unique_id
-    object_id
+    object_id.to_s
   end
 
   # make sure the title is there, and if not, the filename is used...

--- a/app/views/assets/_normal_playback.html.erb
+++ b/app/views/assets/_normal_playback.html.erb
@@ -1,5 +1,5 @@
 <%= cache([asset, asset.user, logged_in?, local_assigns[:favorite], 'v2']) do %>
-  <div class="asset" data-controller="normal-playback" data-normal-playback-id="<% asset.id %>">
+  <div class="asset" data-controller="normal-playback">
   <%= yield %>
   </div>
 <% end %>

--- a/config/webpack/environment.js
+++ b/config/webpack/environment.js
@@ -1,7 +1,12 @@
 const { environment } = require('@rails/webpacker')
-const erb =  require('./loaders/erb')
+const erb = require('./loaders/erb')
 
-environment.config.set('output.library', 'alonetone')
+environment.config.merge({
+  output: {
+    library: 'Alonetone',
+    libraryTarget: 'var',
+  },
+})
 environment.loaders.append('erb', erb)
 module.exports = environment
 // webpack.config.js

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "@rails/webpacker": "^4.2.2",
     "babel-loader": "^8.0.5",
     "babel-preset-minify": "^0.5.1",
-    "gsap": "^2.1.3",
+    "gsap": "^3.1.1",
     "howler": "https://github.com/goldfire/howler.js.git",
     "local-time": "^2.1.0",
     "rails-erb-loader": "^5.5.2",

--- a/spec/support/capybara_helpers.rb
+++ b/spec/support/capybara_helpers.rb
@@ -9,13 +9,11 @@ module RSpec
       end
 
       def pause_animations
-        page.execute_script("gsap.globalTimeline.timeScale(0)")
-        page.execute_script("whilePlayingCallbackFrequency = 2000")
+        page.execute_script("Alonetone.gsap.globalTimeline.timeScale(0)")
       end
 
       def resume_animations
-        page.execute_script("gsap.globalTimeline.timeScale(1)")
-        page.execute_script("whilePlayingCallbackFrequency = 100")
+        page.execute_script("Alonetone.gsap.globalTimeline.timeScale(1)")
       end
 
       def with_animations_paused
@@ -25,8 +23,7 @@ module RSpec
       end
 
       def fast_forward_animations
-        page.execute_script("gsap.globalTimeline.timeScale(2)")
-        page.execute_script("whilePlayingCallbackFrequency = 10")
+        page.execute_script("Alonetone.gsap.globalTimeline.timeScale(2)")
         sleep(0.1)
       end
 

--- a/spec/support/capybara_helpers.rb
+++ b/spec/support/capybara_helpers.rb
@@ -9,12 +9,12 @@ module RSpec
       end
 
       def pause_animations
-        page.execute_script("TweenMax.globalTimeScale(0)")
+        page.execute_script("gsap.globalTimeline.timeScale(0)")
         page.execute_script("whilePlayingCallbackFrequency = 2000")
       end
 
       def resume_animations
-        page.execute_script("TweenMax.globalTimeScale(1)")
+        page.execute_script("gsap.globalTimeline.timeScale(1)")
         page.execute_script("whilePlayingCallbackFrequency = 100")
       end
 
@@ -25,7 +25,7 @@ module RSpec
       end
 
       def fast_forward_animations
-        page.execute_script("TweenMax.globalTimeScale(2)")
+        page.execute_script("gsap.globalTimeline.timeScale(2)")
         page.execute_script("whilePlayingCallbackFrequency = 10")
         sleep(0.1)
       end

--- a/yarn.lock
+++ b/yarn.lock
@@ -4206,10 +4206,10 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.3.tgz#4a12ff1b60376ef09862c2093edd908328be8423"
   integrity sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==
 
-gsap@^2.1.3:
-  version "2.1.3"
-  resolved "https://registry.yarnpkg.com/gsap/-/gsap-2.1.3.tgz#c63ee3a50f0b7dc3b46ed0845bb0f09049feb944"
-  integrity sha512-8RFASCqi2FOCBuv7X4o7M6bLdy+1hbR0azg+MG7zz+EVsI+OmJblYsTk0GEepQd2Jg/ItMPiVTibF7r3EVxjZQ==
+gsap@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/gsap/-/gsap-3.1.1.tgz#b3f5f646563d4099aab9681d16703613f5de6a8c"
+  integrity sha512-ISkCKuXMtBbmbchJxWXuZydXnnWVV9SqNqd8vAevvtq0yzyBapMbXLxwambK73S/2kpTIVzYW8eJXlDD7yHhvw==
 
 gzip-size@^5.0.0:
   version "5.1.1"


### PR DESCRIPTION
Fixes #843 and #552 

**IMPORTANT: New version of MorphSVGPlugin.js must be manually placed on server during deployment.**

Upgrades gsap to 3.1.x

We've run into 3 issues historically with these svgs and gsap code.

1. We want the resting state of the svg to be a play button before javascript kicks in, but certain elements have to be hidden for it not first flash on the screen as a cluttered ball of junk.

2. Attaching these animations to an svg element is not idempotent. Everything is scaled as it is first attached. This becomes problematic because if we navigate away from a page and then come back via turbolinks: the svg has been modified in the DOM, but attaching the animation then modifies and scales it up again.

3. More than one copy of the svg cannot occur on the page at one time without changing the mask ids. This seems to be a general limitation of masking with svg. 

The solution taken here is:

1.  On the small play button, we display a static button and only swap in and initialized the animation svg once play is pressed. We close the animation out of the DOM and manually set the mask ids to a random string to prevent any conflict in the case of multiple play buttons. When we navigate away from the page, we throw away the clone and swap the static play button back in, ensuring that if we navigate away and back, a fresh clone will occur.

2. On the large play button we hide the unwanted svg elements until the animation is initialized in js, at which point we mark them as visible with `gsap.set`.  Navigating away, we call `clearProps: 'all'` on the animation which clears all values that were set in the DOM by gsap, allowing the animation to be connected back up if we navigate back.