### PR TITLE
Re-order SCSS color variables and implement page_container shared class

### DIFF
--- a/app/assets/stylesheets/components/comments.scss
+++ b/app/assets/stylesheets/components/comments.scss
@@ -18,11 +18,6 @@
 
 .comments_columns {
   .columns_header {
-    max-width: $site_max_width;
-    box-sizing: border-box;
-    padding: 0 36px;
-    margin-left: auto;
-    margin-right: auto;
     @media #{$mobile} {
       padding-left: 0;
     }

--- a/app/assets/stylesheets/components/get_an_account.scss
+++ b/app/assets/stylesheets/components/get_an_account.scss
@@ -1,4 +1,4 @@
-.page_container.get_an_account_container {
+.get_an_account_container {
   .box {
     @include shadow6();
     margin-bottom: 0;

--- a/app/assets/stylesheets/components/get_an_account.scss
+++ b/app/assets/stylesheets/components/get_an_account.scss
@@ -1,8 +1,4 @@
 .page_container.get_an_account_container {
-  @media #{$mobile} {
-    padding-left: 0;
-    padding-right: 0;
-  }
   .box {
     @include shadow6();
     margin-bottom: 0;

--- a/app/assets/stylesheets/components/get_an_account.scss
+++ b/app/assets/stylesheets/components/get_an_account.scss
@@ -1,9 +1,4 @@
 .get_an_account_container {
-  max-width: $site_max_width;
-  box-sizing: border-box;
-  padding: 0 36px;
-  margin-left: auto;
-  margin-right: auto;
   @media #{$mobile} {
     padding-left: 0;
     padding-right: 0;

--- a/app/assets/stylesheets/components/get_an_account.scss
+++ b/app/assets/stylesheets/components/get_an_account.scss
@@ -1,4 +1,4 @@
-.get_an_account_container {
+.page_container.get_an_account_container {
   @media #{$mobile} {
     padding-left: 0;
     padding-right: 0;

--- a/app/assets/stylesheets/components/history.scss
+++ b/app/assets/stylesheets/components/history.scss
@@ -1,10 +1,5 @@
 .history {
   .columns_header {
-    max-width: $site_max_width;
-    box-sizing: border-box;
-    padding: 0 36px;
-    margin-left: auto;
-    margin-right: auto;
     @media #{$mobile} {
       padding-left: 0;
     }

--- a/app/assets/stylesheets/components/home.scss
+++ b/app/assets/stylesheets/components/home.scss
@@ -3,12 +3,8 @@
   margin-bottom: 48px;
   background-color: $hero-background;
   .hero-inner {
-    margin: 0 auto;
-    max-width: $site_max_width;
-    padding: 0 $baseline * 1.5;
     padding-top: 80px;
     padding-bottom: 30px;
-    box-sizing: border-box;  
     display: flex;
     align-items: flex-start; 
     @media only screen and (max-width: 890px) {
@@ -107,10 +103,6 @@
 
 #home_grid {
   display: grid;
-  margin: 0 auto;
-  max-width: $site_max_width;
-  padding: 0 $baseline * 1.5;
-  box-sizing: border-box;
   grid-template-columns: repeat(2, 1fr);
   grid-template-rows: auto;
   grid-column-gap: $baseline * 1.5;

--- a/app/assets/stylesheets/components/playlist_edit.scss
+++ b/app/assets/stylesheets/components/playlist_edit.scss
@@ -1,8 +1,4 @@
-.page_container.edit_playlist_info_container {
-  @media #{$mobile} {
-    padding-left: 0;
-    padding-right: 0;
-  }
+.edit_playlist_info_container {
   #edit_playlist_info {
     padding: 0;
     margin-left: auto;

--- a/app/assets/stylesheets/components/playlist_edit.scss
+++ b/app/assets/stylesheets/components/playlist_edit.scss
@@ -1,9 +1,8 @@
-.edit_playlist_info_container {
+.page_container.edit_playlist_info_container {
   @media #{$mobile} {
     padding-left: 0;
     padding-right: 0;
   }
-
   #edit_playlist_info {
     padding: 0;
     margin-left: auto;

--- a/app/assets/stylesheets/components/playlist_edit.scss
+++ b/app/assets/stylesheets/components/playlist_edit.scss
@@ -1,9 +1,4 @@
 .edit_playlist_info_container {
-  max-width: $site_max_width;
-  padding: 0 $baseline * 1.5;
-  box-sizing: border-box;
-  margin-left: auto;
-  margin-right: auto;
   @media #{$mobile} {
     padding-left: 0;
     padding-right: 0;

--- a/app/assets/stylesheets/components/playlists_index.scss
+++ b/app/assets/stylesheets/components/playlists_index.scss
@@ -7,8 +7,4 @@
       padding-left: 2.5%;
     }
   }
-  @media #{$mobile} {
-    padding-left: 0;
-    padding-right: 0;
-  }
 }

--- a/app/assets/stylesheets/components/playlists_index.scss
+++ b/app/assets/stylesheets/components/playlists_index.scss
@@ -7,11 +7,6 @@
       padding-left: 2.5%;
     }
   }
-  max-width: $site_max_width;
-  padding: 0 $baseline * 1.5;
-  box-sizing: border-box;
-  margin-left: auto;
-  margin-right: auto;
   @media #{$mobile} {
     padding-left: 0;
     padding-right: 0;

--- a/app/assets/stylesheets/components/search_results.scss
+++ b/app/assets/stylesheets/components/search_results.scss
@@ -2,14 +2,6 @@
 	margin-bottom: 0;
 }
 
-.no_search_results {
-	max-width: $site_max_width;
-	padding: 0 $baseline * 1.5;
-	box-sizing: border-box;
-	margin-left: auto;
-	margin-right: auto;
-}
-
 .user_search_results_heading {
 	@media #{$mobile} {
 		padding-left: 12px;

--- a/app/assets/stylesheets/components/shared.scss
+++ b/app/assets/stylesheets/components/shared.scss
@@ -8,6 +8,10 @@ body {
   margin-right: auto;
   padding: 0 $baseline * 1.5;
   box-sizing: border-box;
+  @media #{$mobile} {
+    padding-left: 0;
+    padding-right: 0;
+  }
 }
 
 .box {

--- a/app/assets/stylesheets/components/shared.scss
+++ b/app/assets/stylesheets/components/shared.scss
@@ -2,13 +2,12 @@ body {
   background-color: $body-background;
 }
 
-ul {
-  padding-left: 0;
-  list-style: none;
-}
-
-.hidden {
-  display: none;
+.page_container {
+  max-width: $site_max_width;
+  margin-left: auto;
+  margin-right: auto;
+  padding: 0 $baseline * 1.5;
+  box-sizing: border-box;
 }
 
 .box {
@@ -147,4 +146,13 @@ ul {
   .only_alonetone_mods {
     color: $white;
   }
+}
+
+ul {
+  padding-left: 0;
+  list-style: none;
+}
+
+.hidden {
+  display: none;
 }

--- a/app/assets/stylesheets/components/single_and_playlists_player/playlist.scss
+++ b/app/assets/stylesheets/components/single_and_playlists_player/playlist.scss
@@ -1,9 +1,4 @@
 #playlist_and_track_content_header {
-  max-width: $site_max_width;
-  padding: 0 36px;
-  box-sizing: border-box;
-  margin-left: auto;
-  margin-right: auto;
   margin-top: -18px;
   @media #{$one-column} {
     width: 96%;
@@ -15,11 +10,6 @@
 #playlist_and_track_content {
   display: flex;
   justify-content: center;
-  max-width: $site_max_width;
-  padding: 0 36px;
-  box-sizing: border-box;
-  margin-left: auto;
-  margin-right: auto;
   flex-wrap: wrap;
   align-items: flex-start;
   @media #{$one-column} {

--- a/app/assets/stylesheets/components/site_header.scss
+++ b/app/assets/stylesheets/components/site_header.scss
@@ -4,11 +4,6 @@ header#site_header {
   height: 60px;
   .header_inner {
     position: relative;
-    margin-right: auto;
-    margin-left: auto;
-    max-width: $site_max_width;
-    padding: 0 36px;
-    box-sizing: border-box;
     display: flex;
     @media #{$mobile} {
       width: 100%;

--- a/app/assets/stylesheets/components/static_pages.scss
+++ b/app/assets/stylesheets/components/static_pages.scss
@@ -19,11 +19,6 @@
     }
   }
   .static_page_content {
-    max-width: $site_max_width;
-    box-sizing: border-box;
-    padding: 0 $baseline * 1.5;
-    margin-left: auto;
-    margin-right: auto;
     @media #{$mobile} {
       padding-left: 0;
       padding-right: 0;

--- a/app/assets/stylesheets/components/sub_nav.scss
+++ b/app/assets/stylesheets/components/sub_nav.scss
@@ -4,10 +4,6 @@
   top: -48px;
   background-color: $sub-nav-background;
   .sub_nav_inner {
-    box-sizing: border-box;
-    max-width: $site_max_width;
-    padding: 0 $baseline * 1.5;
-    margin: 0 auto;
     height: $baseline * 1.5;
     ul {
       display: flex;

--- a/app/assets/stylesheets/components/thredded_theme.scss
+++ b/app/assets/stylesheets/components/thredded_theme.scss
@@ -12,11 +12,6 @@ $thredded-font-size-small: 13px;
 @import "thredded";
 
 .thredded_container {
-  max-width: $site_max_width;
-  padding: 0 $baseline * 1.5;
-  box-sizing: border-box;
-  margin-left: auto;
-  margin-right: auto;
   @media #{$one-column} {
     padding-left: 4%;
     padding-right: 4%;

--- a/app/assets/stylesheets/components/user.scss
+++ b/app/assets/stylesheets/components/user.scss
@@ -1,10 +1,6 @@
 main {
   #user_home {
-    box-sizing: border-box;
     display: grid;
-    max-width: $site_max_width;
-    padding: 0 $baseline * 1.5;
-    margin: 0 auto;
     grid-template-columns: repeat(2, 1fr);
     grid-template-rows: auto;
     grid-column-gap: $baseline * 1.5;

--- a/app/assets/stylesheets/components/user_playlists.scss
+++ b/app/assets/stylesheets/components/user_playlists.scss
@@ -1,8 +1,4 @@
 .user_playlists {
-  @media #{$mobile} {
-    padding-left: 0;
-    padding-right: 0;
-  }
   h1 {
     @media #{$mobile} {
       padding-left: 2.5%;

--- a/app/assets/stylesheets/components/user_playlists.scss
+++ b/app/assets/stylesheets/components/user_playlists.scss
@@ -1,36 +1,28 @@
-main {
-  .user_playlists {
-    width: 100%;
-    margin-right: auto;
-    margin-left: auto;
-    max-width: $site_max_width;
-    padding: 0 $baseline * 1.5;
-    box-sizing: border-box;
+.user_playlists {
+  @media #{$mobile} {
+    padding-left: 0;
+    padding-right: 0;
+  }
+  h1 {
     @media #{$mobile} {
-      padding-left: 0;
-      padding-right: 0;
+      padding-left: 2.5%;
     }
-    h1 {
-      @media #{$mobile} {
-        padding-left: 2.5%;
-      }
+  }
+  .sort_instructions {
+    color: $user-playlists-sort-instructions;
+    margin: 8px 0;
+    @media #{$mobile} {
+      padding-left: 2.5%;
     }
-    .sort_instructions {
-      color: $user-playlists-sort-instructions;
-      margin: 8px 0;
-      @media #{$mobile} {
-        padding-left: 2.5%;
-      }
+  }
+  ul.playlists {
+    @media #{$mobile} {
+      width: 100%;
+      margin-right: 0;
     }
-    ul.playlists {
-      @media #{$mobile} {
-        width: 100%;
-        margin-right: 0;
-      }
-      li {
-        &.sortable-ghost {
-          opacity: .2;
-        }
+    li {
+      &.sortable-ghost {
+        opacity: .2;
       }
     }
   }

--- a/app/assets/stylesheets/components/user_tracks.scss
+++ b/app/assets/stylesheets/components/user_tracks.scss
@@ -1,10 +1,5 @@
 .user_tracks {
   .columns_header {
-    max-width: $site_max_width;
-    box-sizing: border-box;
-    padding: 0 36px;
-    margin-left: auto;
-    margin-right: auto;
     @media #{$mobile} {
       padding-left: 0;
     }

--- a/app/assets/stylesheets/components/users_index.scss
+++ b/app/assets/stylesheets/components/users_index.scss
@@ -3,10 +3,6 @@
   flex-wrap: wrap;
   justify-content: space-between;
   align-items: flex-start;
-  @media #{$mobile} {
-    padding-left: 0;
-    padding-right: 0;
-  }
   #large_users_grid {
     display: flex;
     flex-wrap: wrap;

--- a/app/assets/stylesheets/components/users_index.scss
+++ b/app/assets/stylesheets/components/users_index.scss
@@ -3,11 +3,6 @@
   flex-wrap: wrap;
   justify-content: space-between;
   align-items: flex-start;
-  box-sizing: border-box;
-  max-width: $site_max_width;
-  padding: 0 $baseline * 1.5;
-  margin-left: auto;
-  margin-right: auto;
   @media #{$mobile} {
     padding-left: 0;
     padding-right: 0;

--- a/app/assets/stylesheets/themes/dark.scss
+++ b/app/assets/stylesheets/themes/dark.scss
@@ -4,82 +4,22 @@
 $accent: $orangetone;
 $theme-accent: $orange300;
 
-// variables.scss
-$default-button-text: $black;
-$default-button-background: $grey500;
-$default-button-background-hover: $grey800;
-$primary-button-background-hover: $orange600;
-$primary-button-background-active: $orange800;
+// admin.scss
+$admin-search-text: $grey50;
+$admin-search-background: $grey1100;
+$admin-column-heading-text: $grey50;
 
-// shared.scss
-$body-background: $grey1200;
+$admin-nav-item-background-hover: $grey900;
+$admin-nav-item-total-text: $grey1000;
+$admin-nav-item-current-text: $black;
+$admin-header-border: $grey500;
+$admin-row-border: $grey100;
+$admin-spam-row-background: $orange100;
+$admin-deleted-row-background: $grey1000;
 
-$box-background: $grey1100;
-
-$box-h2-bottom-border: $grey1000;
-
-$back-to-text: $grey600;
-$back-to-background: $grey1100;
-
-$back-to-caret-background: $orange800;
-$back-to-span-text: $orange600;
-
-$view-all-background: $grey1100;
-$view-all-text: $grey800;
-
-$private-message-warning-background: $red800;
-$private-message-warning-border: $red600;
-$private-message-warning-text: $orange100;
-
-// pagination.scss
-$mini-paginator-background: $grey1100;
-$pagy-link-text: $grey800;
-$pagy-link-text-active: $accent;
-
-// notifications.scss
-$flash-text: $black;
-
-$ajax-fail-border: $red600;
-$ajax-fail-text: $red800;
-$ajax-success-border: $green400;
-$ajax-success-text: $green600;
-
-$floating-feedback-background: $grey1100;
-
-$error-message-background: $red1100;
-$error-message-shadow: $red1000;
-$error-message-heading-text: $white;
-$error-message-list-items-text: $red200;
-
-$input-rejected-background: $red1100;
-$input-rejected-border: $red1000;
-
-$input-accepted-background: $grey1100;
-$input-accepted-border: $green1000;
-
-// typography.scss
-$body-text: $white;
-
-// forms.scss
-$forms-heading-text: $grey400;
-
-$forms-label-text: $grey800;
-$forms-input-text: $grey200;
-$forms-background: $grey1100;
-$forms-border: $grey800;
-
-$forms-hint-background: $grey1000;
-$forms-hint-text: $grey200;
-
-$inline-form-error-text: $red500;
-
-$forms-placeholder-text: $grey800;
-
-$checkbox-checked-background: $grey800;
-$checkbox-checked-border: $grey800;
-
-$checkbox-not-checked-background: $grey1000;
-$checkbox-not-checked-border: $grey500;
+$admin-default-data-text: $grey50;
+$admin-deleted-at-text: $grey50;
+$admin-user-ip-text: $grey50;
 
 // comments.scss
 $comment-as-text: $grey800;
@@ -108,120 +48,71 @@ $track-content-comment-background: $grey1150;
 $track-content-comment-textarea-background: $grey1100;
 $track-content-comment-textarea-text: $grey400;
 
-// tracks.scss
-$track-open-box-shadow: none;
-$track-background: $grey1100;
-$track-play-button-background: $accent;
-$track-seekbar-loaded-background: $grey1000;
-$track-border-bottom: $grey1000;
-$track-time-text: $grey500;
-$track-artist-text: $grey800;
-$track-reveal-top-background: $grey1000;
-$track-description-text: $grey100;
-$track-created-text: $grey800;
-$track-view-more-text: $orange300;
-$track-stats-created-text: $grey800;
-$track-stats-text: $grey800;
-$track-stats-icon-background: $grey600;
-$track-stats-icon-favorites-background: $red500;
-$track-favorited-when-text: $grey500;
+// forms.scss
+$forms-heading-text: $grey400;
 
-// playlists.scss
-$card-background: $grey1100;
-$card-private-background: $grey300;
-$card-private-text: $black;
-$card-title-font: 'Alright-v2-Normal-Medium', sans-serif;
-$card-title-weight: normal;
-$card-title-text: $white;
-$card-artist-font: 'Alright-v2-Normal', sans-serif;
-$card-artist-weight: bold;
-$card-artist-text: $orange300;
-$card-by-font: 'Alright-v2-Normal', sans-serif;
-$card-by-weight: bold;
-$card-by-text: $grey800;
+$forms-label-text: $grey800;
+$forms-input-text: $grey200;
+$forms-background: $grey1100;
+$forms-border: $grey800;
 
-// site_header.scss
-$site-header-background: $grey1100;
-$site-header-box-shadow: none;
+$forms-hint-background: $grey1000;
+$forms-hint-text: $grey200;
 
-$site-icon-background: transparent image-url("alonetone_logo_dark.svg") no-repeat;
+$inline-form-error-text: $red500;
 
-$site-header-user-dropdown-shadow: 0px 6px 24px rgba(0, 0, 0, 0.75);
-$profile-link-background: $grey900;
-$profile-link-background-image: image-url("svg/icon_profile_link_down_arrow_dark.svg");
-$site-header-search-magnifying-glass-image: image-url("svg/icon_search_magnifying_glass_dark.svg");
+$forms-placeholder-text: $grey800;
 
-$site-header-input-background: $grey900;
-$site-header-input-background-focus: $grey1100;
+$checkbox-checked-background: $grey800;
+$checkbox-checked-border: $grey800;
 
-$site-header-input-text: $grey50;
+$checkbox-not-checked-background: $grey1000;
+$checkbox-not-checked-border: $grey500;
 
-$site-header-mobile-search-reveal-button-background: $grey900;
+// home.scss
+$hero-background: $grey1150;
+$hero-heading-text: $orangetone;
+$hero-paragraph-text: $grey50;
 
-$site-header-user-dropdown-background: $grey1200;
-$site-header-user-dropdown-profile-edit-text: $orange300;
-$site-header-user-dropdown-profile-edit-border: $grey900;
-$site-header-user-dropdown-logout-background: $grey1000;
-$site-header-user-dropdown-logout-text: $grey400;
-$site-header-user-dropdown-list-item-background: $grey1100;
-$site-header-user-dropdown-list-item-text: $grey200;
+// illustrations.scss
+$background_position-y: 0;
 
-// site_footer.scss
-$footer-alonetoners-text: $grey800;
-$footer-forum-topics-accent: $orange600;
-$footer-forum-topics-background: $grey1200;
-$footer-forum-topics-link-background: $grey1100;
-$footer-forum-topics-link-text: $grey400;
-$footer-forum-topics-artist-text: $grey800;
-$footer-bottom-background: $grey1150;
-$footer-bottom-column-background: $grey1100;
-$footer-bottom-link-text: $white;
+// notifications.scss
+$flash-text: $black;
 
-// sub_nav.scss
-$sub-nav-background: $grey1150;
-$sub-nav-text: $grey400;
-$sub-nav-text-hover: $white;
-$sub-nav-current-background: $orangetone;
-$sub-nav-link-background: $grey1100;
+$ajax-fail-border: $red600;
+$ajax-fail-text: $red800;
+$ajax-success-border: $green400;
+$ajax-success-text: $green600;
 
-// users_index.scss
-$user-card-background: $grey1100;
+$floating-feedback-background: $grey1100;
 
-// user.scss
-$user-header-avatar-border: $black;
-$user-follow-background: $grey1100;
-$user-follow-background-hover: $grey1100;
-$user-card-background: $grey1100;
-$user-card-shadow: none;
-$user-card-bio-text: $grey50;
-$user-card-content-divider-background: $grey900;
-$user-follows-background: $grey1100;
-$user-stats-background: $grey1100;
-$user-links-text: $black;
-$user-links-background: $grey1000;
-$user-stats-label-text: $grey800;
-$user-stats-data-text: $grey50;
-$user-mod-stats-heading-text: $grey1000;
-$user-mod-stats-background: $grey900;
-$user-mod-stats-agent-border: $white;
-$user-actions-area-background: $grey900;
+$error-message-background: $red1100;
+$error-message-shadow: $red1000;
+$error-message-heading-text: $white;
+$error-message-list-items-text: $red200;
 
-// static_pages.scss
-$static-page-heading-background: $grey1150;
-$static-page-heading-text: $grey100;
-$static-page-content-background: $grey1100;
-$static-page-h2-text: $orange300;
-$static-page-paragraph-text: $grey400;
-$static-page-content-seperator: $grey1150;
-$static-page-anchor: $grey1000;
-$static-page-anchor-hover: $orange300;
-$static-page-anchor-visited: $grey400;
+$input-rejected-background: $red1100;
+$input-rejected-border: $red1000;
 
-// user_playlists.scss
-$user-playlists-sort-instructions: $grey800;
+$input-accepted-background: $grey1100;
+$input-accepted-border: $green1000;
 
-// upload.scss
-$upload-asset-background: $grey1000;
+// pagination.scss
+$mini-paginator-background: $grey1100;
+$pagy-link-text: $grey800;
+$pagy-link-text-active: $accent;
+
+// playlist.scss
+$playlist-sidebar-background: $grey1150;
+
+// playlist_cover_view.scss
+$playlist-options-background: $grey1000;
+$playlist-options-link-background: $grey1000;
+$playlist-options-link-background-hover: $black;
+$playlist-options-link-border: $black;
+$playlist-options-link-text: $white;
+$playlist-options-link-action-text: $grey800;
 
 // playlist_edit.scss
 $edit-playlist-track-button-background: $grey200;
@@ -250,9 +141,6 @@ $edit-playlist-drag-handle-border-active: $accent;
 $edit-playlist-playlist-size-background: $grey1000;
 $edit-playlist-playlist-size-text: $grey800;
 
-// playlist.scss
-$playlist-sidebar-background: $grey1150;
-
 // playlist_sidebar.scss
 $playlist-sidebar-artist-text: $grey800;
 $playlist-sidebar-artist-by-text: $grey800;
@@ -280,13 +168,131 @@ $sidebar-link-background-hover: $grey1000;
 $sidebar-link-text: $white;
 $sidebar-link-action-text: $grey800;
 
-// playlist_cover_view.scss
-$playlist-options-background: $grey1000;
-$playlist-options-link-background: $grey1000;
-$playlist-options-link-background-hover: $black;
-$playlist-options-link-border: $black;
-$playlist-options-link-text: $white;
-$playlist-options-link-action-text: $grey800;
+// playlists.scss
+$card-background: $grey1100;
+$card-private-background: $grey300;
+$card-private-text: $black;
+$card-title-font: 'Alright-v2-Normal-Medium', sans-serif;
+$card-title-weight: normal;
+$card-title-text: $white;
+$card-artist-font: 'Alright-v2-Normal', sans-serif;
+$card-artist-weight: bold;
+$card-artist-text: $orange300;
+$card-by-font: 'Alright-v2-Normal', sans-serif;
+$card-by-weight: bold;
+$card-by-text: $grey800;
+
+// secretz.scss
+$secretz-row-background: $grey1100;
+$secretz-odd-row-background: $grey1000;
+
+// shared.scss
+$body-background: $grey1200;
+
+$box-background: $grey1100;
+
+$box-h2-bottom-border: $grey1000;
+
+$back-to-text: $grey600;
+$back-to-background: $grey1100;
+
+$back-to-caret-background: $orange800;
+$back-to-span-text: $orange600;
+
+$view-all-background: $grey1100;
+$view-all-text: $grey800;
+
+$private-message-warning-background: $red800;
+$private-message-warning-border: $red600;
+$private-message-warning-text: $orange100;
+
+// site_footer.scss
+$footer-alonetoners-text: $grey800;
+$footer-forum-topics-accent: $orange600;
+$footer-forum-topics-background: $grey1200;
+$footer-forum-topics-link-background: $grey1100;
+$footer-forum-topics-link-text: $grey400;
+$footer-forum-topics-artist-text: $grey800;
+$footer-bottom-background: $grey1150;
+$footer-bottom-column-background: $grey1100;
+$footer-bottom-link-text: $white;
+
+// site_header.scss
+$site-header-background: $grey1100;
+$site-header-box-shadow: none;
+
+$site-icon-background: transparent image-url("alonetone_logo_dark.svg") no-repeat;
+
+$site-header-user-dropdown-shadow: 0px 6px 24px rgba(0, 0, 0, 0.75);
+$profile-link-background: $grey900;
+$profile-link-background-image: image-url("svg/icon_profile_link_down_arrow_dark.svg");
+$site-header-search-magnifying-glass-image: image-url("svg/icon_search_magnifying_glass_dark.svg");
+
+$site-header-input-background: $grey900;
+$site-header-input-background-focus: $grey1100;
+
+$site-header-input-text: $grey50;
+
+$site-header-mobile-search-reveal-button-background: $grey900;
+
+$site-header-user-dropdown-background: $grey1200;
+$site-header-user-dropdown-profile-edit-text: $orange300;
+$site-header-user-dropdown-profile-edit-border: $grey900;
+$site-header-user-dropdown-logout-background: $grey1000;
+$site-header-user-dropdown-logout-text: $grey400;
+$site-header-user-dropdown-list-item-background: $grey1100;
+$site-header-user-dropdown-list-item-text: $grey200;
+
+// static_pages.scss
+$static-page-heading-background: $grey1150;
+$static-page-heading-text: $grey100;
+$static-page-content-background: $grey1100;
+$static-page-h2-text: $orange300;
+$static-page-paragraph-text: $grey400;
+$static-page-content-seperator: $grey1150;
+$static-page-anchor: $grey1000;
+$static-page-anchor-hover: $orange300;
+$static-page-anchor-visited: $grey400;
+
+// sub_nav.scss
+$sub-nav-background: $grey1150;
+$sub-nav-text: $grey400;
+$sub-nav-text-hover: $white;
+$sub-nav-current-background: $orangetone;
+$sub-nav-link-background: $grey1100;
+
+// thredded_theme.scss
+$thredded-user-navigation-link-background: $grey1000;
+$thredded-search-background: $grey1000;
+$thredded-search-color: $grey400;
+$thredded-user-navigation-link-text: $grey400;
+$thredded-breadcrumbs-text: $orangetone;
+$thredded-preferences-title-text: $grey400;
+$thredded-form-list-hint-text: $grey400;
+$thredded-main-section-background: $grey1100;
+$thredded-messageboards-group-messageboard-background: $grey1150;
+$thredded-messsageboards-group-title-text: $grey400;
+$thredded-messageboard-title-color: $orange300;
+$thredded--messageboard--description-text: $grey400;
+$thredded-messageboard-meta-text: $grey800;
+$thredded-message-board-actions-link-background: $grey100;
+$thredded-message-board-actions-link-text: $grey900;
+$thredded-topics-heading-text: $grey400;
+$thredded-started-by-text: $grey400;
+$thredded-followers-text: $grey400;
+$thredded-topics-description-text: $grey400;
+$thredded-topics-background: $grey1150;
+$thredded-topics-alt-background: $grey1100;
+$thredded-topics-title-text: $grey100;
+$thredded-topics-updated-text: $grey600;
+$thredded-post-user-text: $grey400;
+$thredded-post-created-at-text: $grey400;
+$thredded-post-dropdown-background: $grey800;
+$thredded-post-content-text: $grey400;
+$thredded-post-form-title-text: $grey400;
+$thredded-form-list-textarea-background: $grey1000;
+$thredded-form-list-textarea-text: $grey200;
+$thredded-new-topic-background: $grey1150;
 
 // track_content.scss
 $track-content-child-background: $grey1100;
@@ -324,64 +330,58 @@ $big-player-time-total-text: $grey800;
 // track_social.scss
 $track-social-heading-text: $grey1000;
 
-// admin.scss
-$admin-search-text: $grey50;
-$admin-search-background: $grey1100;
-$admin-column-heading-text: $grey50;
+// tracks.scss
+$track-open-box-shadow: none;
+$track-background: $grey1100;
+$track-play-button-background: $accent;
+$track-seekbar-loaded-background: $grey1000;
+$track-border-bottom: $grey1000;
+$track-time-text: $grey500;
+$track-artist-text: $grey800;
+$track-reveal-top-background: $grey1000;
+$track-description-text: $grey100;
+$track-created-text: $grey800;
+$track-view-more-text: $orange300;
+$track-stats-created-text: $grey800;
+$track-stats-text: $grey800;
+$track-stats-icon-background: $grey600;
+$track-stats-icon-favorites-background: $red500;
+$track-favorited-when-text: $grey500;
 
-$admin-nav-item-background-hover: $grey900;
-$admin-nav-item-total-text: $grey1000;
-$admin-nav-item-current-text: $black;
-$admin-header-border: $grey500;
-$admin-row-border: $grey100;
-$admin-spam-row-background: $orange100;
-$admin-deleted-row-background: $grey1000;
+// typography.scss
+$body-text: $white;
 
-$admin-default-data-text: $grey50;
-$admin-deleted-at-text: $grey50;
-$admin-user-ip-text: $grey50;
+// upload.scss
+$upload-asset-background: $grey1000;
 
-// secretz.scss
-$secretz-row-background: $grey1100;
-$secretz-odd-row-background: $grey1000;
+// user.scss
+$user-header-avatar-border: $black;
+$user-follow-background: $grey1100;
+$user-follow-background-hover: $grey1100;
+$user-card-background: $grey1100;
+$user-card-shadow: none;
+$user-card-bio-text: $grey50;
+$user-card-content-divider-background: $grey900;
+$user-follows-background: $grey1100;
+$user-stats-background: $grey1100;
+$user-links-text: $black;
+$user-links-background: $grey1000;
+$user-stats-label-text: $grey800;
+$user-stats-data-text: $grey50;
+$user-mod-stats-heading-text: $grey1000;
+$user-mod-stats-background: $grey900;
+$user-mod-stats-agent-border: $white;
+$user-actions-area-background: $grey900;
 
-// illustrations.scss
-$background_position-y: 0;
+// user_playlists.scss
+$user-playlists-sort-instructions: $grey800;
 
-// thredded_theme.scss
-$thredded-user-navigation-link-background: $grey1000;
-$thredded-search-background: $grey1000;
-$thredded-search-color: $grey400;
-$thredded-user-navigation-link-text: $grey400;
-$thredded-breadcrumbs-text: $orangetone;
-$thredded-preferences-title-text: $grey400;
-$thredded-form-list-hint-text: $grey400;
-$thredded-main-section-background: $grey1100;
-$thredded-messageboards-group-messageboard-background: $grey1150;
-$thredded-messsageboards-group-title-text: $grey400;
-$thredded-messageboard-title-color: $orange300;
-$thredded--messageboard--description-text: $grey400;
-$thredded-messageboard-meta-text: $grey800;
-$thredded-message-board-actions-link-background: $grey100;
-$thredded-message-board-actions-link-text: $grey900;
-$thredded-topics-heading-text: $grey400;
-$thredded-started-by-text: $grey400;
-$thredded-followers-text: $grey400;
-$thredded-topics-description-text: $grey400;
-$thredded-topics-background: $grey1150;
-$thredded-topics-alt-background: $grey1100;
-$thredded-topics-title-text: $grey100;
-$thredded-topics-updated-text: $grey600;
-$thredded-post-user-text: $grey400;
-$thredded-post-created-at-text: $grey400;
-$thredded-post-dropdown-background: $grey800;
-$thredded-post-content-text: $grey400;
-$thredded-post-form-title-text: $grey400;
-$thredded-form-list-textarea-background: $grey1000;
-$thredded-form-list-textarea-text: $grey200;
-$thredded-new-topic-background: $grey1150;
+// users_index.scss
+$user-card-background: $grey1100;
 
-// home.scss
-$hero-background: $grey1150;
-$hero-heading-text: $orangetone;
-$hero-paragraph-text: $grey50;
+// variables.scss
+$default-button-text: $black;
+$default-button-background: $grey500;
+$default-button-background-hover: $grey800;
+$primary-button-background-hover: $orange600;
+$primary-button-background-active: $orange800;

--- a/app/assets/stylesheets/themes/white.scss
+++ b/app/assets/stylesheets/themes/white.scss
@@ -4,82 +4,22 @@
 $accent: $orangetone;
 $theme-accent: $orangetone;
 
-// variables.scss
-$default-button-text: $white;
-$default-button-background: $grey500;
-$default-button-background-hover: $grey800;
-$primary-button-background-hover: $orange600;
-$primary-button-background-active: $orange800;
+// admin.scss
+$admin-search-text: $grey1000;
+$admin-search-background: $white;
+$admin-column-heading-text: $grey1000;
 
-// shared.scss
-$body-background: $grey50;
+$admin-nav-item-background-hover: $grey100;
+$admin-nav-item-total-text: $grey500;
+$admin-nav-item-current-text: $white;
+$admin-header-border: $grey500;
+$admin-row-border: $grey100;
+$admin-spam-row-background: $orange100;
+$admin-deleted-row-background: $grey50;
 
-$box-background: $white;
-
-$box-h2-bottom-border: $grey100;
-
-$back-to-text: $grey900;
-$back-to-background: $white;
-
-$back-to-caret-background: $orangetone;
-$back-to-span-text: $orange600;
-
-$view-all-background: $white;
-$view-all-text: $grey800;
-
-$private-message-warning-background: $red500;
-$private-message-warning-border: $red600;
-$private-message-warning-text: $orange100;
-
-// pagination.scss
-$mini-paginator-background: $white;
-$pagy-link-text: $grey800;
-$pagy-link-text-active: $accent;
-
-// notifications.scss
-$flash-text: $white;
-
-$ajax-fail-border: $red600;
-$ajax-fail-text: $red800;
-$ajax-success-border: $green400;
-$ajax-success-text: $green600;
-
-$floating-feedback-background: $white;
-
-$error-message-background: $red100;
-$error-message-shadow: $red200;
-$error-message-heading-text: $red1100;
-$error-message-list-items-text: $red1100;
-
-$input-rejected-background: $red100;
-$input-rejected-border: $red600;
-
-$input-accepted-background: $grey25;
-$input-accepted-border: $green600;
-
-// typography.scss
-$body-text: $black;
-
-// forms.scss
-$forms-heading-text: $grey1000;
-
-$forms-label-text: $grey600;
-$forms-input-text: $grey1000;
-$forms-background: $white;
-$forms-border: $grey200;
-
-$forms-hint-background: $grey50;
-$forms-hint-text: $grey1000;
-
-$inline-form-error-text: $red800;
-
-$forms-placeholder-text: $grey800;
-
-$checkbox-checked-background: $grey800;
-$checkbox-checked-border: $grey800;
-
-$checkbox-not-checked-background: $grey50;
-$checkbox-not-checked-border: $grey500;
+$admin-default-data-text: $grey1000;
+$admin-deleted-at-text: $grey1000;
+$admin-user-ip-text: $grey1000;
 
 // comments.scss
 $comment-as-text: $grey600;
@@ -108,120 +48,71 @@ $track-content-comment-background: $grey100-alpha50;
 $track-content-comment-textarea-background: $white;
 $track-content-comment-textarea-text: $grey1000;
 
-// tracks.scss
-$track-open-box-shadow: 0 11px 19px 4px #6566667a;
-$track-background: $white;
-$track-play-button-background: $black;
-$track-seekbar-loaded-background: $grey50;
-$track-border-bottom: $grey50;
-$track-time-text: $grey800;
-$track-artist-text: $grey800;
-$track-reveal-top-background: $grey50;
-$track-description-text: $grey900;
-$track-created-text: $grey500;
-$track-view-more-text: $orange600;
-$track-stats-created-text: $grey600;
-$track-stats-text: $grey400;
-$track-stats-icon-background: $grey600;
-$track-stats-icon-favorites-background: $red800;
-$track-favorited-when-text: $grey800;
+// forms.scss
+$forms-heading-text: $grey1000;
 
-// playlists.scss
-$card-background: $white;
-$card-private-background: $grey1000;
-$card-private-text: $white;
-$card-title-font: 'Alright-v2-Normal', sans-serif;
-$card-title-weight: bold;
-$card-title-text: $black;
-$card-artist-font: 'Alright-v2-Normal-Medium', sans-serif;
-$card-artist-weight: normal;
-$card-artist-text: $orange600;
-$card-by-font: 'Alright-v2-Normal', sans-serif;
-$card-by-weight: normal;
-$card-by-text: $grey800;
+$forms-label-text: $grey600;
+$forms-input-text: $grey1000;
+$forms-background: $white;
+$forms-border: $grey200;
 
-// site_header.scss
-$site-header-background: $white;
-$site-header-box-shadow: 0 3px 4px -2px #65666627;
+$forms-hint-background: $grey50;
+$forms-hint-text: $grey1000;
 
-$site-icon-background: transparent image-url("alonetone_big-notext-flat.png") no-repeat;
+$inline-form-error-text: $red800;
 
-$site-header-user-dropdown-shadow: 0px 6px 24px rgba(134, 134, 134, 0.75);
-$profile-link-background: $grey100;
-$profile-link-background-image: image-url("svg/icon_profile_link_down_arrow.svg");
-$site-header-search-magnifying-glass-image: image-url("svg/icon_search_magnifying_glass.svg");
+$forms-placeholder-text: $grey800;
 
-$site-header-input-background: $grey100;
-$site-header-input-background-focus: $white;
+$checkbox-checked-background: $grey800;
+$checkbox-checked-border: $grey800;
 
-$site-header-input-text: $grey1000;
+$checkbox-not-checked-background: $grey50;
+$checkbox-not-checked-border: $grey500;
 
-$site-header-mobile-search-reveal-button-background: $grey100;
+// home.scss
+$hero-background: $grey100;
+$hero-heading-text: $orangetone;
+$hero-paragraph-text: $grey1000;
 
-$site-header-user-dropdown-background: $white;
-$site-header-user-dropdown-profile-edit-text: $orange800;
-$site-header-user-dropdown-profile-edit-border: $grey300;
-$site-header-user-dropdown-logout-background: $grey400;
-$site-header-user-dropdown-logout-text: $white;
-$site-header-user-dropdown-list-item-background: $grey50;
-$site-header-user-dropdown-list-item-text: $grey1000;
+// illustrations.scss
+$background_position-y: -5000px;
 
-// site_footer.scss
-$footer-alonetoners-text: $grey800;
-$footer-forum-topics-accent: $orange600;
-$footer-forum-topics-background: $grey25;
-$footer-forum-topics-link-background: $white;
-$footer-forum-topics-link-text: $black;
-$footer-forum-topics-artist-text: $grey800;
-$footer-bottom-background: $grey1100;
-$footer-bottom-column-background: $grey1000;
-$footer-bottom-link-text: $white;
+// notifications.scss
+$flash-text: $white;
 
-// sub_nav.scss
-$sub-nav-background: $grey100;
-$sub-nav-text: $grey1000;
-$sub-nav-text-hover: $grey1000;
-$sub-nav-current-background: $orange600;
-$sub-nav-link-background: $white;
+$ajax-fail-border: $red600;
+$ajax-fail-text: $red800;
+$ajax-success-border: $green400;
+$ajax-success-text: $green600;
 
-// users_index.scss
-$user-card-background: $white;
+$floating-feedback-background: $white;
 
-// user.scss
-$user-header-avatar-border: $black;
-$user-follow-background: $white;
-$user-follow-background-hover: $white;
-$user-card-background: $white;
-$user-card-shadow: 0px 2px 4px rgba(0, 0, 0, 0.15), 0px 6px 24px rgba(134, 134, 134, 0.75);
-$user-card-bio-text: $grey1000;
-$user-card-content-divider-background: $grey100;
-$user-follows-background: $white;
-$user-stats-background: $white;
-$user-links-text: $white;
-$user-links-background: $grey1000;
-$user-stats-label-text: $grey800;
-$user-stats-data-text: $grey1000;
-$user-mod-stats-heading-text: $grey500;
-$user-mod-stats-background: $grey100;
-$user-mod-stats-agent-border: $white;
-$user-actions-area-background: $grey100;
+$error-message-background: $red100;
+$error-message-shadow: $red200;
+$error-message-heading-text: $red1100;
+$error-message-list-items-text: $red1100;
 
-// static_pages.scss
-$static-page-heading-background: $grey100-alpha50;
-$static-page-heading-text: $grey1000;
-$static-page-content-background: $white;
-$static-page-h2-text: $orange600;
-$static-page-paragraph-text: $grey1000;
-$static-page-content-seperator: $grey50;
-$static-page-anchor: $grey400;
-$static-page-anchor-hover: $orangetone;
-$static-page-anchor-visited: $orange1000;
+$input-rejected-background: $red100;
+$input-rejected-border: $red600;
 
-// user_playlists.scss
-$user-playlists-sort-instructions: $grey800;
+$input-accepted-background: $grey25;
+$input-accepted-border: $green600;
 
-// upload.scss
-$upload-asset-background: $grey50;
+// pagination.scss
+$mini-paginator-background: $white;
+$pagy-link-text: $grey800;
+$pagy-link-text-active: $accent;
+
+// playlist.scss
+$playlist-sidebar-background: $white;
+
+// playlist_cover_view.scss
+$playlist-options-background: $grey1000;
+$playlist-options-link-background: $grey1000;
+$playlist-options-link-background-hover: $black;
+$playlist-options-link-border: $black;
+$playlist-options-link-text: $grey50;
+$playlist-options-link-action-text: $grey800;
 
 // playlist_edit.scss
 $edit-playlist-track-button-background: $grey200;
@@ -250,9 +141,6 @@ $edit-playlist-drag-handle-border-active: $accent;
 $edit-playlist-playlist-size-background: $grey50;
 $edit-playlist-playlist-size-text: $grey800;
 
-// playlist.scss
-$playlist-sidebar-background: $white;
-
 // playlist_sidebar.scss
 $playlist-sidebar-artist-text: $orangetone;
 $playlist-sidebar-artist-by-text: $black;
@@ -280,13 +168,131 @@ $sidebar-link-background-hover: $grey1000;
 $sidebar-link-text: $white;
 $sidebar-link-action-text: $grey800;
 
-// playlist_cover_view.scss
-$playlist-options-background: $grey1000;
-$playlist-options-link-background: $grey1000;
-$playlist-options-link-background-hover: $black;
-$playlist-options-link-border: $black;
-$playlist-options-link-text: $grey50;
-$playlist-options-link-action-text: $grey800;
+// playlists.scss
+$card-background: $white;
+$card-private-background: $grey1000;
+$card-private-text: $white;
+$card-title-font: 'Alright-v2-Normal', sans-serif;
+$card-title-weight: bold;
+$card-title-text: $black;
+$card-artist-font: 'Alright-v2-Normal-Medium', sans-serif;
+$card-artist-weight: normal;
+$card-artist-text: $orange600;
+$card-by-font: 'Alright-v2-Normal', sans-serif;
+$card-by-weight: normal;
+$card-by-text: $grey800;
+
+// secretz.scss
+$secretz-row-background: $white;
+$secretz-odd-row-background: $grey50;
+
+// shared.scss
+$body-background: $grey50;
+
+$box-background: $white;
+
+$box-h2-bottom-border: $grey100;
+
+$back-to-text: $grey900;
+$back-to-background: $white;
+
+$back-to-caret-background: $orangetone;
+$back-to-span-text: $orange600;
+
+$view-all-background: $white;
+$view-all-text: $grey800;
+
+$private-message-warning-background: $red500;
+$private-message-warning-border: $red600;
+$private-message-warning-text: $orange100;
+
+// site_footer.scss
+$footer-alonetoners-text: $grey800;
+$footer-forum-topics-accent: $orange600;
+$footer-forum-topics-background: $grey25;
+$footer-forum-topics-link-background: $white;
+$footer-forum-topics-link-text: $black;
+$footer-forum-topics-artist-text: $grey800;
+$footer-bottom-background: $grey1100;
+$footer-bottom-column-background: $grey1000;
+$footer-bottom-link-text: $white;
+
+// site_header.scss
+$site-header-background: $white;
+$site-header-box-shadow: 0 3px 4px -2px #65666627;
+
+$site-icon-background: transparent image-url("alonetone_big-notext-flat.png") no-repeat;
+
+$site-header-user-dropdown-shadow: 0px 6px 24px rgba(134, 134, 134, 0.75);
+$profile-link-background: $grey100;
+$profile-link-background-image: image-url("svg/icon_profile_link_down_arrow.svg");
+$site-header-search-magnifying-glass-image: image-url("svg/icon_search_magnifying_glass.svg");
+
+$site-header-input-background: $grey100;
+$site-header-input-background-focus: $white;
+
+$site-header-input-text: $grey1000;
+
+$site-header-mobile-search-reveal-button-background: $grey100;
+
+$site-header-user-dropdown-background: $white;
+$site-header-user-dropdown-profile-edit-text: $orange800;
+$site-header-user-dropdown-profile-edit-border: $grey300;
+$site-header-user-dropdown-logout-background: $grey400;
+$site-header-user-dropdown-logout-text: $white;
+$site-header-user-dropdown-list-item-background: $grey50;
+$site-header-user-dropdown-list-item-text: $grey1000;
+
+// static_pages.scss
+$static-page-heading-background: $grey100-alpha50;
+$static-page-heading-text: $grey1000;
+$static-page-content-background: $white;
+$static-page-h2-text: $orange600;
+$static-page-paragraph-text: $grey1000;
+$static-page-content-seperator: $grey50;
+$static-page-anchor: $grey400;
+$static-page-anchor-hover: $orangetone;
+$static-page-anchor-visited: $orange1000;
+
+// sub_nav.scss
+$sub-nav-background: $grey100;
+$sub-nav-text: $grey1000;
+$sub-nav-text-hover: $grey1000;
+$sub-nav-current-background: $orange600;
+$sub-nav-link-background: $white;
+
+// thredded_theme.scss
+$thredded-user-navigation-link-background: $white;
+$thredded-search-background: $white;
+$thredded-search-color: $grey800;
+$thredded-user-navigation-link-text: $grey800;
+$thredded-breadcrumbs-text: $orange600;
+$thredded-preferences-title-text: $black;
+$thredded-form-list-hint-text: $black;
+$thredded-main-section-background: $white;
+$thredded-messageboards-group-messageboard-background: $grey25;
+$thredded-messsageboards-group-title-text: $black;
+$thredded-messageboard-title-color: $orange600;
+$thredded--messageboard--description-text: $grey900;
+$thredded-messageboard-meta-text: $grey600;
+$thredded-message-board-actions-link-background: $grey100;
+$thredded-message-board-actions-link-text: $grey900;
+$thredded-topics-heading-text: $grey1000;
+$thredded-started-by-text: $grey900;
+$thredded-followers-text: $grey900;
+$thredded-topics-description-text: $grey900;
+$thredded-topics-background: $grey25;
+$thredded-topics-alt-background: $white;
+$thredded-topics-title-text: $grey1200;
+$thredded-topics-updated-text: $grey600;
+$thredded-post-user-text: $grey900;
+$thredded-post-created-at-text: $grey900;
+$thredded-post-dropdown-background: $white;
+$thredded-post-content-text: $grey900;
+$thredded-post-form-title-text: $grey900;
+$thredded-form-list-textarea-background: $white;
+$thredded-form-list-textarea-text: $black;
+$thredded-new-topic-background: $grey100;
 
 // track_content.scss
 $track-content-child-background: $white;
@@ -324,64 +330,58 @@ $big-player-time-total-text: $grey800;
 // track_social.scss
 $track-social-heading-text: $grey500;
 
-// admin.scss
-$admin-search-text: $grey1000;
-$admin-search-background: $white;
-$admin-column-heading-text: $grey1000;
+// tracks.scss
+$track-open-box-shadow: 0 11px 19px 4px #6566667a;
+$track-background: $white;
+$track-play-button-background: $black;
+$track-seekbar-loaded-background: $grey50;
+$track-border-bottom: $grey50;
+$track-time-text: $grey800;
+$track-artist-text: $grey800;
+$track-reveal-top-background: $grey50;
+$track-description-text: $grey900;
+$track-created-text: $grey500;
+$track-view-more-text: $orange600;
+$track-stats-created-text: $grey600;
+$track-stats-text: $grey400;
+$track-stats-icon-background: $grey600;
+$track-stats-icon-favorites-background: $red800;
+$track-favorited-when-text: $grey800;
 
-$admin-nav-item-background-hover: $grey100;
-$admin-nav-item-total-text: $grey500;
-$admin-nav-item-current-text: $white;
-$admin-header-border: $grey500;
-$admin-row-border: $grey100;
-$admin-spam-row-background: $orange100;
-$admin-deleted-row-background: $grey50;
+// typography.scss
+$body-text: $black;
 
-$admin-default-data-text: $grey1000;
-$admin-deleted-at-text: $grey1000;
-$admin-user-ip-text: $grey1000;
+// upload.scss
+$upload-asset-background: $grey50;
 
-// secretz.scss
-$secretz-row-background: $white;
-$secretz-odd-row-background: $grey50;
+// user.scss
+$user-header-avatar-border: $black;
+$user-follow-background: $white;
+$user-follow-background-hover: $white;
+$user-card-background: $white;
+$user-card-shadow: 0px 2px 4px rgba(0, 0, 0, 0.15), 0px 6px 24px rgba(134, 134, 134, 0.75);
+$user-card-bio-text: $grey1000;
+$user-card-content-divider-background: $grey100;
+$user-follows-background: $white;
+$user-stats-background: $white;
+$user-links-text: $white;
+$user-links-background: $grey1000;
+$user-stats-label-text: $grey800;
+$user-stats-data-text: $grey1000;
+$user-mod-stats-heading-text: $grey500;
+$user-mod-stats-background: $grey100;
+$user-mod-stats-agent-border: $white;
+$user-actions-area-background: $grey100;
 
-// illustrations.scss
-$background_position-y: -5000px;
+// user_playlists.scss
+$user-playlists-sort-instructions: $grey800;
 
-// thredded_theme.scss
-$thredded-user-navigation-link-background: $white;
-$thredded-search-background: $white;
-$thredded-search-color: $grey800;
-$thredded-user-navigation-link-text: $grey800;
-$thredded-breadcrumbs-text: $orange600;
-$thredded-preferences-title-text: $black;
-$thredded-form-list-hint-text: $black;
-$thredded-main-section-background: $white;
-$thredded-messageboards-group-messageboard-background: $grey25;
-$thredded-messsageboards-group-title-text: $black;
-$thredded-messageboard-title-color: $orange600;
-$thredded--messageboard--description-text: $grey900;
-$thredded-messageboard-meta-text: $grey600;
-$thredded-message-board-actions-link-background: $grey100;
-$thredded-message-board-actions-link-text: $grey900;
-$thredded-topics-heading-text: $grey1000;
-$thredded-started-by-text: $grey900;
-$thredded-followers-text: $grey900;
-$thredded-topics-description-text: $grey900;
-$thredded-topics-background: $grey25;
-$thredded-topics-alt-background: $white;
-$thredded-topics-title-text: $grey1200;
-$thredded-topics-updated-text: $grey600;
-$thredded-post-user-text: $grey900;
-$thredded-post-created-at-text: $grey900;
-$thredded-post-dropdown-background: $white;
-$thredded-post-content-text: $grey900;
-$thredded-post-form-title-text: $grey900;
-$thredded-form-list-textarea-background: $white;
-$thredded-form-list-textarea-text: $black;
-$thredded-new-topic-background: $grey100;
+// users_index.scss
+$user-card-background: $white;
 
-// home.scss
-$hero-background: $grey100;
-$hero-heading-text: $orangetone;
-$hero-paragraph-text: $grey1000;
+// variables.scss
+$default-button-text: $white;
+$default-button-background: $grey500;
+$default-button-background-hover: $grey800;
+$primary-button-background-hover: $orange600;
+$primary-button-background-active: $orange800;

--- a/app/views/account_requests/new.html.erb
+++ b/app/views/account_requests/new.html.erb
@@ -1,4 +1,4 @@
-<div class="get_an_account_container">
+<div class="page_container get_an_account_container">
   <div class="blank_slate">
     <div class="left">
       <div class="blank_slate_illustration">

--- a/app/views/assets/index.html.erb
+++ b/app/views/assets/index.html.erb
@@ -1,5 +1,5 @@
 <div class="user_tracks">
-  <div class="columns_header">
+  <div class="page_container columns_header">
     <%= render partial: 'shared/back_to_artist' %>
   </div>
   <div id="columns">

--- a/app/views/assets/latest.html.erb
+++ b/app/views/assets/latest.html.erb
@@ -1,6 +1,6 @@
 <% unless logged_in? %>
 <section class="hero">
-  <div class="hero-inner">
+  <div class="page_container hero-inner">
     <div class="hero-content">
       <h1>Welcome to alonetone</h1>
       <p>
@@ -26,7 +26,7 @@
 </section>
 <% end %>
 
-<div id="home_grid">
+<div class="page_container" id="home_grid">
   <% if @playlists.present? %>
   <div id="home_playlists_area">
     <div class="latest-playlists-header">

--- a/app/views/assets/radio.html.erb
+++ b/app/views/assets/radio.html.erb
@@ -1,5 +1,5 @@
 <nav class="sub_nav">
-  <div class="sub_nav_inner" data-controller="subnav" data-action="resize@window->subnav#resize">
+  <div class="page_container sub_nav_inner" data-controller="subnav" data-action="resize@window->subnav#resize">
       <ul>
         <%= navigation_item 'Latest Uploaded', radio_home_path %>
         <%= navigation_item 'Most Popular', radio_source_home_path('popular') %>

--- a/app/views/comments/index.html.erb
+++ b/app/views/comments/index.html.erb
@@ -1,6 +1,6 @@
 <div class="comments_columns">
 
-  <div class="columns_header">
+  <div class="page_container columns_header">
       <%= render partial: 'shared/back_to_artist' if @user.present? %>
   </div>
 

--- a/app/views/layouts/pages.html.erb
+++ b/app/views/layouts/pages.html.erb
@@ -7,7 +7,7 @@
       <%= @page_title %>
     </h1>
 
-    <div class="static_page_content">
+    <div class="page_container static_page_content">
       <div class="static_page_content_inner">
         <%= yield %>
       </div>

--- a/app/views/layouts/thredded.html.erb
+++ b/app/views/layouts/thredded.html.erb
@@ -29,7 +29,7 @@
 
   <main>
       <nav class="sub_nav">
-      <div class="sub_nav_inner" data-controller="subnav" data-action="resize@window->subnav#resize">
+      <div class="page_container sub_nav_inner" data-controller="subnav" data-action="resize@window->subnav#resize">
           <ul>
             <% Thredded::Messageboard.ordered_by_position.each do |m| %>
               <%= navigation_item m.name, "/forums/#{m.slug}" %>
@@ -37,7 +37,7 @@
           </ul>
       </div>
     </nav>
-    <div class="thredded_container">
+    <div class="page_container thredded_container">
       <%= yield %>
     </div>
   </main>

--- a/app/views/listens/index.html.erb
+++ b/app/views/listens/index.html.erb
@@ -1,6 +1,6 @@
 <div class="history">
 
-  <div class="columns_header">
+  <div class="page_container columns_header">
     <%= render partial: 'shared/back_to_artist' %>
   </div>
 

--- a/app/views/pages/_navigation.html.erb
+++ b/app/views/pages/_navigation.html.erb
@@ -1,5 +1,5 @@
 <nav class="sub_nav">
-  <div class="sub_nav_inner" data-controller="subnav" data-action="resize@window->subnav#resize">
+  <div class="page_container sub_nav_inner" data-controller="subnav" data-action="resize@window->subnav#resize">
     <ul>
       <%= navigation_item "What is alonetone?", '/about' %>
       <%= navigation_item "FAQ", about_faq_path %>

--- a/app/views/playlists/_form.html.erb
+++ b/app/views/playlists/_form.html.erb
@@ -1,5 +1,5 @@
 <%= error_messages_for :playlist %>
-<div class="edit_playlist_info_container">
+<div class="page_container edit_playlist_info_container">
   <% if @playlist.persisted? %>
     <%= render partial: 'back_to_playlist' %>
   <% else %>

--- a/app/views/playlists/all.html.erb
+++ b/app/views/playlists/all.html.erb
@@ -1,6 +1,5 @@
-<div class="playlists_container">
+<div class="page_container playlists_container">
   <h2>Browse Playlists</h2>
-
   <ul class="playlists responsive_grid">
     <%= render partial: 'shared/playlist', collection: @playlists, as: :playlist %>
   </ul>

--- a/app/views/playlists/index.html.erb
+++ b/app/views/playlists/index.html.erb
@@ -1,5 +1,5 @@
 
-<div class="user_playlists" data-controller="playlists-sort" data-playlists-sort-enabled="<%= current_user_is_mod_or_owner?(@user) %>">
+<div class="page_container user_playlists" data-controller="playlists-sort" data-playlists-sort-enabled="<%= current_user_is_mod_or_owner?(@user) %>">
   <h1><%= @user.name %>'s Playlists</h1>
   <% if current_user_is_mod_or_owner?(@user) %>
     <p class='sort_instructions'>

--- a/app/views/playlists/show.html.erb
+++ b/app/views/playlists/show.html.erb
@@ -4,10 +4,10 @@
   <% end %>
 <% end %>
 
-<div id="playlist_and_track_content_header">
+<div class="page_container" id="playlist_and_track_content_header">
   <%= render partial: 'shared/back_to_artist' %>
 </div>
-<div id="playlist_and_track_content">
+<div class="page_container" id="playlist_and_track_content">
   <%= render 'playlist' %>
 
   <% if @asset %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,4 +1,4 @@
-  <div class="header_inner">
+  <div class="page_container header_inner">
 
     <a href="/" title="home" class="header_logo"></a>
     <div class="headway" id="headway_container"></div>

--- a/app/views/users/_users.html.erb
+++ b/app/views/users/_users.html.erb
@@ -1,5 +1,5 @@
 <nav class="sub_nav">
-  <div class="sub_nav_inner" data-controller="subnav" data-action="resize@window->subnav#resize">
+  <div class="page_container sub_nav_inner" data-controller="subnav" data-action="resize@window->subnav#resize">
        <ul>
         <%= navigation_item "Last Online", {action: 'index', sort: nil} %>
         <%= navigation_item "Last Uploaded", {action: 'index', sort: 'last_uploaded'} %>
@@ -11,7 +11,7 @@
   </div>
 </nav>
 
-<div id="user_index">
+<div class="page_container" id="user_index">
   <ul id="large_users_grid" class="responsive_grid">
     <% if @sort == 'dedicated_listeners'%>
       <% cache("dedicated/#{params[:page]}/", expires_in: 4.hours) do %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,4 +1,4 @@
-<div id="user_home">
+<div class="page_container" id="user_home">
   <div id="user_header_area">
     <div id="user_header">
       <div class="user_name_and_follow">


### PR DESCRIPTION
# Iterate through the changes in this PR. Why did you implement them this way?

1. I re-arranged the order of the color variables in in dark.scss and white.scss 

2. I replaced about a dozen instances of specific layout rules with a page_container class. This handles most of the site's full width pages: padding, max-width, centering.

### Does anything special need to happen for deployment?


## "Ready For Review" checklist

These checklists are to help ensure the code review basics are covered. Consider removing to reduce noise.

* [ ] PR title accurately summarizes changes
* [ ] New tests were added for isolated methods or new endpoints
* [ ] I opened an issue for any logical followups
* [ ] If this fixes a bug, "Fixes #XXX" is either the very first or very last line of the description.

## Before code review *and after additional commits* during review.

* [ ] Update title and description to account for additional changes
* [ ] All tests green
* [ ] Migrations were tested locally and do the right thing
* [ ] Booted up the branch locally, exercised any new code
* [ ] Percy changes are purposeful or explained
* [ ] Css changes are happy on mobile (via Percy is ok)
