### PR TITLE
Improve playlist publishing

### DIFF
--- a/app/assets/stylesheets/components/playlist_edit.scss
+++ b/app/assets/stylesheets/components/playlist_edit.scss
@@ -160,7 +160,7 @@
           width: 100%;
           font-size: 12px;
           position: relative;
-          height: 54px;
+          height: 46px;
           @media #{$one-column} {
             flex-direction: column;
           }
@@ -178,6 +178,8 @@
       border-top: 1px solid $edit-playlist-info-bottom-border;
       .private_warning {
         text-align: center;
+        height: 17px;
+        line-height: 19px;
       }
       a.delete_playlist {
         margin-top: $baseline;

--- a/app/controllers/assets_controller.rb
+++ b/app/controllers/assets_controller.rb
@@ -248,7 +248,7 @@ class AssetsController < ApplicationController
 
   def playlist_attributes
     {
-      private: dont_publish_param?
+      published: !dont_publish_param?
     }
   end
 

--- a/app/controllers/playlists_controller.rb
+++ b/app/controllers/playlists_controller.rb
@@ -49,7 +49,7 @@ class PlaylistsController < ApplicationController
   end
 
   def new
-    @playlist = @user.playlists.build(private: true)
+    @playlist = @user.playlists.build
   end
 
   def edit
@@ -119,7 +119,9 @@ class PlaylistsController < ApplicationController
   end
 
   def update
+    is_private = params[:playlist].delete(:is_private)
     if @playlist.update(playlist_params)
+      @playlist.is_private = is_private
       redirect_to edit_user_playlist_path(@user, @playlist), notice: 'Playlist was successfully updated.'
     else
       render action: "edit"
@@ -139,7 +141,7 @@ class PlaylistsController < ApplicationController
   end
 
   def playlist_params
-    params.require(:playlist).permit!
+    params.require(:playlist).permit(:title, :year, :is_private, :link1, :link2, :link3, :credits)
   end
 
   def render_desired_partial

--- a/app/javascript/controllers/playlist_form_controller.js
+++ b/app/javascript/controllers/playlist_form_controller.js
@@ -48,9 +48,15 @@ export default class extends Controller {
 
   togglePrivate(e) {
     e.preventDefault()
-    // The label was clicked, so we still need to check the box
-    this.actualCheckboxTarget.checked = !this.actualCheckboxTarget.checked
-    this.actualCheckboxTarget.checked ? this.showPrivateBanner() : this.hidePrivateBanner()
+    if (this.actualCheckboxTarget.checked) {
+      this.actualCheckboxTarget.checked = false
+      this.actualCheckboxTarget.value = 0
+      this.hidePrivateBanner()
+    } else {
+      this.actualCheckboxTarget.checked = true
+      this.actualCheckboxTarget.value = 1
+      this.showPrivateBanner()
+    }
   }
 
   openFile(e) {

--- a/app/javascript/controllers/playlist_form_controller.js
+++ b/app/javascript/controllers/playlist_form_controller.js
@@ -7,26 +7,32 @@ export default class extends Controller {
 
   initialize() {
     this.tracksCount = 0
+    this.updateBanner()
   }
 
   // called by playlistSort on initialize/add/remove
   updateCount(newCount) {
     this.tracksCount = newCount
-    this.displayBanner()
-  }
-
-  displayBanner() {
     if (this.tracksCount < 2) {
       this.forcePrivate()
-    } else if (this.actualCheckboxTarget.checked) {
+    } else {
+      this.updateBanner()
+    }
+  }
+
+  updateBanner() {
+    if (this.actualCheckboxTarget.checked) {
+      this.actualCheckboxTarget.checked = true // redundant, but sometimes this attribute isn't present
       this.showPrivateBanner()
     } else {
+      this.actualCheckboxTarget.checked = false // redundant, but sometimes this attribute isn't present
       this.checkboxTarget.style.display = 'block'
+      this.hidePrivateBanner()
     }
   }
 
   forcePrivate() {
-    this.actualCheckboxTarget.checked = 1
+    this.actualCheckboxTarget.checked = true
     this.showNeedsTracksBanner()
     this.checkboxTarget.style.display = 'none'
   }
@@ -50,11 +56,9 @@ export default class extends Controller {
     e.preventDefault()
     if (this.actualCheckboxTarget.checked) {
       this.actualCheckboxTarget.checked = false
-      this.actualCheckboxTarget.value = 0
       this.hidePrivateBanner()
     } else {
       this.actualCheckboxTarget.checked = true
-      this.actualCheckboxTarget.value = 1
       this.showPrivateBanner()
     }
   }

--- a/app/models/playlist.rb
+++ b/app/models/playlist.rb
@@ -88,11 +88,15 @@ class Playlist < ActiveRecord::Base
 
   def check_visibility
     if publishing? && publishable?
-      self.published_at = Time.zone.now
-      self.published = true
+      publish!
     elsif publishing? && !publishable?
       self.published = false
     end
+  end
+
+  def publish!
+    self.published_at = Time.zone.now
+    self.published = true
   end
 
   def has_any_links?

--- a/app/views/playlists/_form.html.erb
+++ b/app/views/playlists/_form.html.erb
@@ -63,7 +63,7 @@
           <% if @playlist.persisted? %>
           <div class="edit_playlist_info_right_column_private_and_hidden" data-target="playlist-form.checkbox" style="display:none">
             <div class="input">
-              <%= f.check_box :private, data: { target: 'playlist-form.actualCheckbox' }, id: 'playlist_private' %>
+              <%= f.check_box :is_private, data: { target: 'playlist-form.actualCheckbox' }, id: 'playlist_private' %>
               <label for="playlist_private" data-target="playlist-form.markAsPrivate" data-action='click->playlist-form#togglePrivate'><span>Private</span></label>
             </div>
           </div>

--- a/app/views/playlists/_form.html.erb
+++ b/app/views/playlists/_form.html.erb
@@ -63,8 +63,8 @@
           <% if @playlist.persisted? %>
           <div class="edit_playlist_info_right_column_private_and_hidden" data-target="playlist-form.checkbox" style="display:none">
             <div class="input">
-              <%= f.check_box :is_private, data: { target: 'playlist-form.actualCheckbox' }, id: 'playlist_private' %>
-              <label for="playlist_private" data-target="playlist-form.markAsPrivate" data-action='click->playlist-form#togglePrivate'><span>Private</span></label>
+              <%= f.check_box :is_private?, { data: { target: 'playlist-form.actualCheckbox' }, id: 'playlist_private'}  %>
+              <label for="playlist_is_private" data-target="playlist-form.markAsPrivate" data-action='click->playlist-form#togglePrivate'><span>Private</span></label>
             </div>
           </div>
           <% end %>

--- a/app/views/shared/_playlist.html.erb
+++ b/app/views/shared/_playlist.html.erb
@@ -1,4 +1,4 @@
-<%= content_tag_for :li, playlist, data: { 'id': playlist.id }, class: "small_playlists #{'private' if playlist.private?}" do %>
+<%= content_tag_for :li, playlist, data: { 'id': playlist.id }, class: "small_playlists #{'private' unless playlist.published?}" do %>
   <%= link_to user_playlist_path(playlist.user.login, playlist), title: "#{playlist.title}" do %>
     <%= playlist_cover(playlist, variant: :playlist_card) %>
 	<% end %>

--- a/db/migrate/20200317165252_rename_private_to_published.rb
+++ b/db/migrate/20200317165252_rename_private_to_published.rb
@@ -1,0 +1,10 @@
+class RenamePrivateToPublished < ActiveRecord::Migration[6.0]
+  def change
+    rename_column :playlists, :private, :published
+    puts "flipping dat boolean"
+    Playlist.with_deleted.find_each do |p|
+      p.update_column :published, !p.published
+    end
+    change_column_default :playlists, :published, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_02_202230) do
+ActiveRecord::Schema.define(version: 2020_03_17_165252) do
 
   create_table "account_requests", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "email"
@@ -199,7 +199,7 @@ ActiveRecord::Schema.define(version: 2020_03_02_202230) do
     t.string "permalink"
     t.integer "tracks_count", default: 0
     t.boolean "is_mix"
-    t.boolean "private"
+    t.boolean "published", default: false
     t.boolean "is_favorite", default: false
     t.string "year"
     t.integer "position", default: 1

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -131,7 +131,7 @@ DESC
 playlist.save!
 playlist.tracks.create!(user: marie, asset: commonly_blue_green)
 playlist.tracks.create!(user: marie, asset: aqueous_suspension)
-playlist.update(private: false)
+playlist.publish!
 
 baguette_laonnaise = marie.assets.create!(extract_metadata(
   audio_file: piano_upload,

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -155,7 +155,7 @@ DESC
 playlist.save!
 playlist.tracks.create!(user: marie, asset: baguette_laonnaise)
 playlist.tracks.create!(user: marie, asset: appellation_description)
-playlist.update(private: false)
+playlist.publish!
 
 # --- Carole ---
 
@@ -196,7 +196,7 @@ DESC
 edible_coating.save!
 edible_coating.tracks.create!(user: carole, asset: creamy_interior)
 edible_coating.tracks.create!(user: carole, asset: cylindrical_rounds)
-edible_coating.update(private: false)
+edible_coating.publish!
 
 # --- Petere ---
 
@@ -237,7 +237,7 @@ DESC
 mrs_applebys_cheshire.save!
 mrs_applebys_cheshire.tracks.create!(user: petere, asset: keep_tradition_alive)
 mrs_applebys_cheshire.tracks.create!(user: petere, asset: much_like_cheddar)
-mrs_applebys_cheshire.update(private: false)
+mrs_applebys_cheshire.publish!
 
 # Some random listens.
 10.times do

--- a/spec/controllers/playlists_controller_spec.rb
+++ b/spec/controllers/playlists_controller_spec.rb
@@ -49,7 +49,6 @@ RSpec.describe PlaylistsController, type: :controller do
   end
 
   context "sorting" do
-
     it 'should allow sorting of playlists' do
       login(:sudara)
       order = playlists(:empty, :owp).map { |playlist| playlist.id.to_s }
@@ -134,24 +133,20 @@ RSpec.describe PlaylistsController, type: :controller do
   end
 
   describe "update" do
-    let(:user) { users(:jamie_kiesl) }
-
-    before do
-      login(user)
-    end
-
     it "should update published_at" do
-      expect(playlists(:jamie_kiesl_loves).published_at).to be_nil
-      expect(playlists(:jamie_kiesl_loves).private).to be(true)
-
+      expect(playlists(:henri_willig_unpublished).published_at).to be_nil
+      expect(playlists(:henri_willig_unpublished).published).to be(false)
+      login(:henri_willig)
       put :update, params: {
-        id: playlists(:jamie_kiesl_loves).id,
-        permalink: 'jamie-loves',
-        user_id: user.login,
+        id: 'unpublished',
+        user_id: 'henriwillig',
         playlist: {
-          private: false
-        }}
-      expect(playlists(:jamie_kiesl_loves).reload.published_at).not_to be_nil
+          title: 'unpublished',
+          is_private: false
+        }
+      }
+      expect(playlists(:henri_willig_unpublished).reload.published).to be_truthy
+      expect(playlists(:henri_willig_unpublished).published_at).not_to be_nil
     end
 
     it "should not publish if playlist has less than 2 tracks" do
@@ -160,10 +155,11 @@ RSpec.describe PlaylistsController, type: :controller do
       put :update, params: {
         id: playlists(:jamie_kiesl_playlist_with_soft_deleted_tracks).id,
         permalink: 'jamie-playlist-with-soft-delete',
-        user_id: user.login,
+        user_id: 'Jamiek',
         playlist: {
-          private: false
-        }}
+          is_private: false
+        }
+      }
       expect(playlists(:jamie_kiesl_playlist_with_soft_deleted_tracks).reload.published_at).to be_nil
     end
   end

--- a/spec/features/playlist_spec.rb
+++ b/spec/features/playlist_spec.rb
@@ -64,13 +64,13 @@ RSpec.describe 'playlists', type: :feature, js: true do
 
       # Ensure custom checkboxes are happy
       find('.edit_playlist_info_right_column_private_and_hidden label').click
+      find('.edit_playlist_info_right_column_private_and_hidden label').click
 
       # Move "Manfacturer of the Finest Cheese" to be the last song
       first_track_handle = find('.sortable .asset:first-child .drag_handle')
       last_track = find('.sortable .asset:last-child')
       first_track_handle.drag_to(last_track)
       expect(find('.sortable .asset:last-child .track_link').text).to eql('Manufacturer of the Finest Cheese')
-      sleep(30)
       Percy.snapshot(page, name: 'Playlist Edit')
     end
   end

--- a/spec/fixtures/playlists.yml
+++ b/spec/fixtures/playlists.yml
@@ -23,7 +23,7 @@ arthurs_playlist:
   title: Arthur's Playlist
   cover_quality: modern
   credits: arthurs playlist
-  private: true
+  published: false
   created_at: <%= 1.day.ago %>
 
 mix:
@@ -52,12 +52,11 @@ will_studd_rockfort:
   user: will_studd
   is_mix: false
   is_favorite: false
-  private: false
   permalink: rockfort
   title: Rockfort
   tracks_count: 3
   cover_quality: modern
-  private: false
+  published: true
   credits: >
     Roquefort (US: /ˈroʊkfərt/ or UK: /rɒkˈfɔːr/; French: [ʁɔkfɔʁ]; Occitan: ròcafòrt [ˌrɔkɔˈfɔɾt])
     is a sheep milk cheese from the south of France. Rockfort is Will's award winning musical
@@ -71,11 +70,10 @@ henri_willig_polderkaas:
   user: henri_willig
   is_mix: false
   is_favorite: false
-  private: false
+  published: true
   permalink: polderkaas
   title: Polderkaas
   tracks_count: 2
-  private: false
   cover_quality: modern
   link1: https://open.spotify.com/playlist/37i9dQZF1DX7pykHKVxv6o?si=uP1xUZdlTeCBsMviYTBKGA
   link2: bandcamp.com/some_band
@@ -86,12 +84,31 @@ henri_willig_polderkaas:
   published_at: <%= 1.day.ago %>
   created_at: <%= 1.day.ago %>
 
+# Polderkaas v2
+henri_willig_unpublished:
+  user: henri_willig
+  is_mix: false
+  is_favorite: false
+  published: false
+  permalink: unpublished
+  title: Unpublished
+  tracks_count: 2
+  cover_quality: modern
+  link1: https://open.spotify.com/playlist/37i9dQZF1DX7pykHKVxv6o?si=uP1xUZdlTeCBsMviYTBKGA
+  link2: bandcamp.com/some_band
+  link3: youtube.com/my_channel
+  credits: >
+    Polderkaas is a distinctive cheese brand by Henri Willig. The album has the same creamy
+    goodness as they cheese it was named after.
+  created_at: <%= 1.day.ago %>
+
+
 # Bill added all his favorite tracks to a playlist.
 william_shatners_favorites:
   user: william_shatner
   is_mix: true
   is_favorite: true
-  private: true
+  published: true
   permalink: bills-favorites
   title: Bill's favorites
   cover_quality: ancient
@@ -104,7 +121,7 @@ william_shatners_favorites:
 jamie_kiesl_loves:
   user: jamie_kiesl
   is_favorite: true
-  private: true
+  published: true
   permalink: jamie-loves
   title: Jamie Loves
   cover_quality: legacy
@@ -122,6 +139,6 @@ jamie_kiesl_playlist_with_soft_deleted_tracks:
   cover_quality: legacy
   credits: Playlist to test tracks_count change for when asset is soft deleted
   tracks_count: 1
-  private: true
+  published: false
   published_at: ~
   created_at: <%= 1.year.ago %>

--- a/spec/fixtures/tracks.yml
+++ b/spec/fixtures/tracks.yml
@@ -79,6 +79,19 @@ henri_willig_polderkaas_2:
   position: 2
   created_at: <%= 3.months.ago %>
 
+# All assets for Henry's unpublished playlist.
+henri_willig_unpublished_1:
+  playlist: henri_willig_unpublished
+  user: henri_willig
+  asset: henri_willig_finest_cheese
+  position: 1
+  created_at: <%= 3.months.ago %>
+henri_willig_unpublished_2:
+  playlist: henri_willig_unpublished
+  user: henri_willig
+  asset: henri_willig_the_goat
+  position: 2
+  created_at: <%= 3.months.ago %>
 
 # Bill's favorites.
 william_shatners_favorites_1:

--- a/spec/models/upload/zip_file_spec.rb
+++ b/spec/models/upload/zip_file_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe Upload::ZipFile, type: :model do
       playlist = zip_file.playlists.first
       expect(playlist.user).to eq(user)
       expect(playlist.title).to eq('Le Duc Vacherin')
-      expect(playlist.private).to be_nil
+      expect(playlist.published).to eq(false)
 
       expect(zip_file.assets.length).to eq(3)
       zip_file.assets.each do |asset|
@@ -124,7 +124,7 @@ RSpec.describe Upload::ZipFile, type: :model do
     end
     let(:playlist_attributes) do
       {
-        private: true,
+        published: false,
         year: '2019'
       }
     end
@@ -135,7 +135,7 @@ RSpec.describe Upload::ZipFile, type: :model do
 
       expect(zip_file.playlists.length).to eq(1)
       zip_file.playlists.each do |playlist|
-        expect(playlist.private).to eq(true)
+        expect(playlist.published).to eq(false)
         expect(playlist.year).to eq('2019')
       end
     end


### PR DESCRIPTION
* Replaces `playlist.private` with `playlist.published`
* Fixes #1000
* Handles the model cleanup specified in #882
* Ensures `published_at` doesn't get reset when things go private and then published again