### PR TITLE
Fix playlist uploading, add a spec to preemptively catch it

### DIFF
--- a/app/controllers/playlists_controller.rb
+++ b/app/controllers/playlists_controller.rb
@@ -141,7 +141,7 @@ class PlaylistsController < ApplicationController
   end
 
   def playlist_params
-    params.require(:playlist).permit(:title, :year, :is_private, :link1, :link2, :link3, :credits)
+    params.require(:playlist).permit(:cover_image, :title, :year, :is_private, :link1, :link2, :link3, :credits)
   end
 
   def render_desired_partial

--- a/spec/features/playlist_spec.rb
+++ b/spec/features/playlist_spec.rb
@@ -49,6 +49,11 @@ RSpec.describe 'playlists', type: :feature, js: true do
     logged_in(:henri_willig) do
       visit 'henriwillig/playlists/polderkaas/edit'
 
+      # add a playlist image
+      attach_file('playlist_cover_image', 'spec/fixtures/files/cheshire_cheese.jpg', make_visible: true)
+      find('input[name="commit"]').click
+      expect(find(".cover img")['src']).to have_content('cheshire_cheese.jpg')
+
       pause_animations
 
       # test that we can remove second track


### PR DESCRIPTION
#1004 broke playlist images by removing `permit!` and manually permitting attributes without including the `cover_image` attribute.