### PR TITLE
Create temporary settings table

### DIFF
--- a/app/models/new_settings.rb
+++ b/app/models/new_settings.rb
@@ -1,4 +1,4 @@
-class NewSetting < ApplicationRecord
-
+class NewSettings < ApplicationRecord
   belongs_to :user
+
 end

--- a/app/models/new_settings.rb
+++ b/app/models/new_settings.rb
@@ -1,0 +1,4 @@
+class NewSetting < ApplicationRecord
+
+  belongs_to :user
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -57,6 +57,7 @@ class User < ApplicationRecord
     }
 
   store :settings
+  has_one :new_settings, class_name: 'NewSettings'
 
   acts_as_authentic do |c|
     c.crypto_provider = Authlogic::CryptoProviders::SCrypt
@@ -79,9 +80,10 @@ class User < ApplicationRecord
   before_create :make_first_user_admin
   before_destroy :destroy_with_relations
   before_save { |u| u.display_name = u.login if u.display_name.blank? }
-  after_create :create_profile
+  after_create :create_profile, :create_new_settings
 
   has_one :profile, dependent: :destroy
+  has_one :new_settings, dependent: :destroy
   has_one :account_request
   belongs_to :invited_by, optional: true, class_name: 'User'
   has_many :invitees, foreign_key: 'invited_by_id'

--- a/db/migrate/20200410133915_create_settings.rb
+++ b/db/migrate/20200410133915_create_settings.rb
@@ -1,0 +1,39 @@
+class CreateSettings < ActiveRecord::Migration[6.0]
+
+  SETTINGS = {
+    display_listen_count: true,
+    block_guest_comments: false,
+    most_popular: true,
+    increase_ego: false,
+    email_comments: true,
+    email_new_tracks: true
+  }
+
+  def change
+    # temporary name until we drop the user.settings attribute
+    create_table :new_settings do |t|
+      t.add_reference :user, foreign_key: true
+      t.boolean :display_listen_count, default: true
+      t.boolean :block_guest_comments, default: false
+      t.boolean :most_popular, default: true
+      t.boolean :increase_ego, default: false
+      t.boolean :email_comments, default: true
+      t.boolean :email_new_tracks, default: true
+
+      t.timestamps
+    end
+
+    User.with_deleted.find_each do |user|
+      if user.settings # About 3k users have existing settings
+        attributes = user.settings.slice(*SETTINGS.keys) # get rid of settings we don't care about
+        attributes.each do |key, value|
+          attributes[key] = ActiveModel::Type::Boolean.new.cast(value) # we have booleans stored as strings right now
+        end
+        user.new_settings.create!(attributes)
+      else
+        user.new_settings.create!
+      end
+    end
+
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_17_165252) do
+ActiveRecord::Schema.define(version: 2020_04_10_133915) do
 
   create_table "account_requests", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "email"
@@ -188,6 +188,19 @@ ActiveRecord::Schema.define(version: 2020_03_17_165252) do
     t.boolean "admin"
     t.datetime "created_at"
     t.datetime "updated_at"
+  end
+
+  create_table "new_settings", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
+    t.bigint "user_id"
+    t.boolean "display_listen_count", default: true
+    t.boolean "block_guest_comments", default: false
+    t.boolean "most_popular", default: true
+    t.boolean "increase_ego", default: false
+    t.boolean "email_comments", default: true
+    t.boolean "email_new_tracks", default: true
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["user_id"], name: "index_new_settings_on_user_id"
   end
 
   create_table "playlists", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|


### PR DESCRIPTION
Before #893 can merge, we need a way to toggle boolean settings. 

Until now, defaults for settings were set by logic in the view, and settings were difficult to maintain and buggy.

I spent some time investigating continuing to use Active Record's `store` and adding defaults, typecasting, etc — however, all of that logic would come for free if we just actually used the database and Active Record.

This PR creates the table with the defaults and adds a record per user. The table is temporarily named `new_settings` and a PR will follow this one that 

1. Renames the table to `settings` 
2. Removes the `users.settings` attribute. 