### PR TITLE
More accurate assets counter cache

### DIFF
--- a/app/commands/asset_command.rb
+++ b/app/commands/asset_command.rb
@@ -9,6 +9,7 @@ class AssetCommand
   def soft_delete_with_relations
     time = Time.now
     # first update playlists
+    asset.user.decrement!(:assets_count)
     asset.playlists.update_all(['tracks_count = tracks_count - 1, playlists.updated_at = ?', Time.now]) unless asset.playlists.empty?
     asset.comments.update_all(deleted_at: time)
     asset.tracks.update_all(deleted_at: time)
@@ -18,6 +19,7 @@ class AssetCommand
 
   def restore_with_relations
     asset.restore
+    asset.user.increment!(:assets_count)
     asset.playlists.with_deleted.update_all(['tracks_count = tracks_count + 1, playlists.updated_at = ?', Time.now]) unless asset.playlists.with_deleted.empty?
     asset.comments.with_deleted.update_all(deleted_at: nil)
     asset.tracks.with_deleted.update_all(deleted_at: nil)

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -27,7 +27,9 @@ class Asset < ApplicationRecord
   scope :most_listened,   -> { where('listens_count > 0').reorder('listens_count DESC') }
   scope :with_preloads,   -> { includes(user: { avatar_image_attachment: :blob }) }
 
-  belongs_to :user, counter_cache: true
+  belongs_to :user
+  after_commit :update_user_assets_count, on: :create
+
   belongs_to :possibly_deleted_user,
     -> { with_deleted },
     class_name: 'User',
@@ -221,6 +223,10 @@ class Asset < ApplicationRecord
     else
       with_deleted.recent
     end
+  end
+
+  def update_user_assets_count
+    user.increment!(:assets_count, touch: true)
   end
 end
 

--- a/app/models/concerns/soft_deletion.rb
+++ b/app/models/concerns/soft_deletion.rb
@@ -7,6 +7,7 @@ module SoftDeletion
     scope :only_deleted, -> { unscope(where: :deleted_at).where.not(deleted_at: nil) }
     scope :with_deleted, -> { unscope(where: :deleted_at) }
     scope :destroyable,  -> { only_deleted.where('deleted_at < ?', 30.days.ago) }
+
     # doesn't validate the record, calls callbacks and saves
     def soft_delete
       update_attribute(:deleted_at, Time.now)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -171,9 +171,7 @@ class User < ApplicationRecord
   end
 
   def self.destroy_deleted_accounts_older_than_30_days
-    User.destroyable.find_each do |u|
-      u.destroy
-    end
+    User.destroyable.find_each(&:destroy)
   end
 
   def self.with_same_ip_as(user)

--- a/db/migrate/20200801120933_reset_asset_counters.rb
+++ b/db/migrate/20200801120933_reset_asset_counters.rb
@@ -1,0 +1,8 @@
+class ResetAssetCounters < ActiveRecord::Migration[6.0]
+  def change
+    User.find_each do |u|
+      # this is no longer a counter cache column
+      u.update_attribute(:assets_count, u.assets.count)
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_08_205412) do
+ActiveRecord::Schema.define(version: 2020_08_01_120933) do
 
   create_table "account_requests", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "email"

--- a/spec/fixtures/users.yml
+++ b/spec/fixtures/users.yml
@@ -24,6 +24,7 @@ arthur:
   last_request_at: <%= 1.days.ago.to_s :db %>
   last_login_at: <%= 1.days.ago.to_s :db %>
   current_login_ip: 9.9.9.9
+  assets_count: 3
 
 # deleted
 aaron:

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe User, type: :model do
   context '.destroy_deleted_accounts_older_than_30_days' do
     it 'should really destroy users deleted more than 30 days ago' do
       expect { User.destroy_deleted_accounts_older_than_30_days }
-        .to change{ User.with_deleted.count }.by(-1)
+        .to change { User.with_deleted.count }.by(-1)
     end
 
     it 'should not destroy a user deleted within last 30 days' do

--- a/spec/request/admin/assets_controller_spec.rb
+++ b/spec/request/admin/assets_controller_spec.rb
@@ -219,7 +219,6 @@ RSpec.describe Admin::AssetsController, type: :request do
       expect(playlist.reload.tracks_count).to eq(1)
     end
 
-
     it "should restore listens" do
       expect {
         put restore_admin_asset_path(asset.id)

--- a/spec/request/admin/users_controller_spec.rb
+++ b/spec/request/admin/users_controller_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe Admin::UsersController, type: :request do
 
     it "should redirect admin to root_path" do
       put delete_admin_user_path(users(:arthur))
-      expect(response).to redirect_to(admin_users_path({ filter_by: :deleted }))
+      expect(response).to redirect_to(admin_users_path(filter_by: :deleted))
     end
 
     it "sets deleted_at to true" do
@@ -154,7 +154,7 @@ RSpec.describe Admin::UsersController, type: :request do
 
     context "if deleted: true flag is passed" do
       it "should return users with deleted" do
-        get admin_users_path({ filter_by: :deleted })
+        get admin_users_path(filter_by: :deleted)
         expect(response.body).to match(/arthur/)
         expect(response.body).not_to match(/ben/)
       end
@@ -170,14 +170,14 @@ RSpec.describe Admin::UsersController, type: :request do
 
     context "with filter_by" do
       it "should return spam users only if flag is passed" do
-        get admin_users_path({ filter_by: :is_spam })
+        get admin_users_path(filter_by: :is_spam)
         expect(response.body).to match(/aaron/)
         expect(response.body).not_to match(/arthur/)
         expect(response.body).not_to match(/ben/)
       end
 
       it "should return only non spam users if is_spam is set to false" do
-        get admin_users_path({ filter_by: :not_spam })
+        get admin_users_path(filter_by: :not_spam)
         expect(response.body).not_to match(/aaron/)
         expect(response.body).to match(/arthur/)
         expect(response.body).to match(/ben/)


### PR DESCRIPTION
Fixes #981

* Manually juggles `User#assets_count` due to soft deletion needs
* Runs a migration to adjust counter caches for `Asset`