### PR TITLE
Add Stimulus controller to Playlist View to layout playlist credits and dynamically manage sidebar bottom right border radius

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -22,3 +22,6 @@ plugins:
   rubocop:
     enabled: true
     channel: rubocop-0-87
+  eslint:
+    enabled: true
+    channel: "eslint-7"

--- a/.github/workflows/specs.yml
+++ b/.github/workflows/specs.yml
@@ -50,7 +50,7 @@ jobs:
     - name: Set up Ruby and Bundle Install
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.7.2
+        ruby-version: 3.0.0
         bundler-cache: true
 
     - name: Yarn install

--- a/.github/workflows/specs.yml
+++ b/.github/workflows/specs.yml
@@ -50,7 +50,7 @@ jobs:
     - name: Set up Ruby and Bundle Install
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 3.0.0
+        ruby-version: 2.7.2
         bundler-cache: true
 
     - name: Yarn install

--- a/.percy.yml
+++ b/.percy.yml
@@ -1,3 +1,3 @@
 version: 1
 snapshot:
-  widths: [375, 1280]
+  widths: [320, 390, 768, 1280]

--- a/app/assets/stylesheets/components/single_and_playlists_player/playlist_cover_view.scss
+++ b/app/assets/stylesheets/components/single_and_playlists_player/playlist_cover_view.scss
@@ -26,6 +26,7 @@ body.cover_view {
       }
     }
     .playlist_credits {
+      max-width: 640px;
       font-size: 13px;
       line-height: 18px;
       padding: $baseline/2;
@@ -38,6 +39,7 @@ body.cover_view {
       position: absolute;
       @media only screen and (max-width: 850px) {
         position: static;
+        max-width: none;
       }
     }
     .large_cover {

--- a/app/assets/stylesheets/components/single_and_playlists_player/playlist_cover_view.scss
+++ b/app/assets/stylesheets/components/single_and_playlists_player/playlist_cover_view.scss
@@ -6,6 +6,9 @@ body.cover_view {
       &.rounded_bottom_right_corner {
         border-bottom-right-radius: 6px;
       }
+      @media only screen and (max-width: 850px) { // where playlist drops to one column
+        border-radius: 0px 0px 6px 6px ;
+      }
     }
   }
   .track_content {
@@ -18,8 +21,8 @@ body.cover_view {
       @include samo-shadow-and-radius();
       border-radius: 0 6px 6px 0;
       overflow: auto;
-      @media only screen and (max-width: 850px) {
-        border-radius: 6px 6px 0 0;
+      @media only screen and (max-width: 850px) { // where playlist drops to one column
+        border-radius: 6px 6px 0px 0px;
       }
     }
     .playlist_credits {
@@ -120,7 +123,6 @@ body.cover_view {
               font-size: 10px;
               display: block;
               color: $playlist-options-link-action-text;
-
             }
             &.spotify {
               background-image: image-url("svg/icon_playlist_spotify.svg");

--- a/app/assets/stylesheets/components/single_and_playlists_player/playlist_cover_view.scss
+++ b/app/assets/stylesheets/components/single_and_playlists_player/playlist_cover_view.scss
@@ -1,7 +1,9 @@
 body.cover_view {
-  .playlist_sidebar {
-    border-radius: 6px 0 0 6px;
-    align-self: stretch;
+  #playlist_and_track_content {
+    .playlist_sidebar {
+      border-radius: 6px 0 0 6px;
+      align-self: stretch;
+    }
   }
   .track_content {
     margin-left: -40px !important;

--- a/app/assets/stylesheets/components/single_and_playlists_player/playlist_cover_view.scss
+++ b/app/assets/stylesheets/components/single_and_playlists_player/playlist_cover_view.scss
@@ -28,7 +28,6 @@ body.cover_view {
       text-align: left;
       border-radius: 0;
       box-shadow: none;
-      max-width: 624px;
       background-color: transparent;
       position: absolute;
       @media only screen and (max-width: 850px) {

--- a/app/assets/stylesheets/components/single_and_playlists_player/playlist_cover_view.scss
+++ b/app/assets/stylesheets/components/single_and_playlists_player/playlist_cover_view.scss
@@ -3,6 +3,9 @@ body.cover_view {
     .playlist_sidebar {
       border-radius: 6px 0 0 6px;
       align-self: stretch;
+      &.rounded_bottom_right_corner {
+        border-bottom-right-radius: 6px;
+      }
     }
   }
   .track_content {

--- a/app/javascript/controllers/playlist_controller.js
+++ b/app/javascript/controllers/playlist_controller.js
@@ -1,15 +1,15 @@
 import { Controller } from 'stimulus'
 
 export default class extends Controller {
-  static targets = ['credits', 'sidebar', 'content']
+  static targets = ['credits', 'sidebar', 'content', 'cover']
 
   initialize() {
     this.resize()
   }
 
   resize() {
-    if (this.isCoverView()) {
-      if (this.hasCredits()) {
+    if (this.hasCoverTarget) {
+      if (this.hasCreditsTarget) {
         this.alignCredits()
       }
       this.roundBottomRightCorner()
@@ -32,14 +32,6 @@ export default class extends Controller {
      } else {
         this.sidebarTarget.classList.remove('rounded_bottom_right_corner')
     }
-  }
-  
-  hasCredits() {
-    return this.hasCreditsTarget
-  }
-
-  isCoverView() {
-    return document.body.classList.contains('cover_view')
   }
 
   isTwoColumn() {

--- a/app/javascript/controllers/playlist_controller.js
+++ b/app/javascript/controllers/playlist_controller.js
@@ -8,8 +8,10 @@ export default class extends Controller {
   }
 
   resize() {
-    if (this.isCoverView() ) {
-      this.alignCredits()
+    if (this.isCoverView()) {
+      if (this.hasCredits()) {
+        this.alignCredits()
+      }
       this.roundBottomRightCorner()
     }
   }
@@ -30,6 +32,10 @@ export default class extends Controller {
      } else {
         this.sidebarTarget.classList.remove('rounded_bottom_right_corner')
     }
+  }
+  
+  hasCredits() {
+    return this.hasCreditsTarget
   }
 
   isCoverView() {

--- a/app/javascript/controllers/playlist_controller.js
+++ b/app/javascript/controllers/playlist_controller.js
@@ -26,9 +26,9 @@ export default class extends Controller {
 
   roundBottomRightCorner() {
     if ( this.heightDifference() > 0 ) {
-      this.sidebarTarget.style = "border-bottom-right-radius: 6px"
-    } else {
-      this.sidebarTarget.style = "border-bottom-right-radius: 0px"
+      this.sidebarTarget.classList.add('rounded_bottom_right_corner')
+     } else {
+        this.sidebarTarget.classList.remove('rounded_bottom_right_corner')
     }
   }
 

--- a/app/javascript/controllers/playlist_controller.js
+++ b/app/javascript/controllers/playlist_controller.js
@@ -18,24 +18,24 @@ export default class extends Controller {
 
   alignCredits() {
     if (this.isTwoColumn()) {
-      this.creditsTarget.style.width = this.contentTarget.clientWidth + "px"
-      this.element.style.paddingBottom = this.offset() + "px"
+      this.creditsTarget.style.width = `${this.contentTarget.clientWidth}px`
+      this.element.style.paddingBottom = `${this.offset()}px`
     } else {
-      this.creditsTarget.style.width = "100%"
-      this.element.style.paddingBottom = "0px"
+      this.creditsTarget.style.width = '100%'
+      this.element.style.paddingBottom = '0px'
     }
   }
 
   roundBottomRightCorner() {
-    if ( this.heightDifference() > 0 ) {
+    if (this.heightDifference() > 0) {
       this.sidebarTarget.classList.add('rounded_bottom_right_corner')
-     } else {
-        this.sidebarTarget.classList.remove('rounded_bottom_right_corner')
+    } else {
+      this.sidebarTarget.classList.remove('rounded_bottom_right_corner')
     }
   }
 
   isTwoColumn() {
-    return window.getComputedStyle(this.creditsTarget).getPropertyValue('position') == 'absolute'
+    return window.getComputedStyle(this.creditsTarget).getPropertyValue('position') === 'absolute'
   }
 
   heightDifference() {
@@ -43,8 +43,8 @@ export default class extends Controller {
   }
 
   offset() {
-    const mainElement = document.getElementsByTagName("main")[0]
-    const mainPaddingBottom = parseInt( window.getComputedStyle(mainElement).getPropertyValue('padding-bottom'), 10 )
+    const mainElement = document.getElementsByTagName('main')[0]
+    const mainPaddingBottom = parseInt(window.getComputedStyle(mainElement).getPropertyValue('padding-bottom'), 10 )
     return this.creditsTarget.clientHeight - this.heightDifference() - mainPaddingBottom
   }
 

--- a/app/javascript/controllers/playlist_controller.js
+++ b/app/javascript/controllers/playlist_controller.js
@@ -4,8 +4,7 @@ export default class extends Controller {
   static targets = ['credits', 'sidebar', 'content', 'cover']
 
   initialize() {
-    this.creditsTarget.style.width = "10px"
-    //this.resize()
+    this.resize()
   }
 
   resize() {

--- a/app/javascript/controllers/playlist_controller.js
+++ b/app/javascript/controllers/playlist_controller.js
@@ -31,9 +31,7 @@ export default class extends Controller {
   }
 
   isTwoColumn() {
-    // return window.getComputedStyle( this.creditsTarget ).getPropertyValue('position') == 'absolute'
-    console.log( this.creditsTarget.style.position )
-    return this.creditsTarget.style.position == 'absolute'
+    return window.getComputedStyle(this.creditsTarget).getPropertyValue('position') == 'absolute'
   }
 
   heightDifference() {

--- a/app/javascript/controllers/playlist_controller.js
+++ b/app/javascript/controllers/playlist_controller.js
@@ -8,8 +8,10 @@ export default class extends Controller {
   }
 
   resize() {
-    this.alignCredits()
-    this.roundBottomRightCorner()
+    if (this.isCoverView() ) {
+      this.alignCredits()
+      this.roundBottomRightCorner()
+    }
   }
 
   alignCredits() {
@@ -28,6 +30,10 @@ export default class extends Controller {
     } else {
       this.sidebarTarget.style = "border-bottom-right-radius: 0px"
     }
+  }
+
+  isCoverView() {
+    return document.body.classList.contains('cover_view')
   }
 
   isTwoColumn() {

--- a/app/javascript/controllers/playlist_controller.js
+++ b/app/javascript/controllers/playlist_controller.js
@@ -1,0 +1,49 @@
+import { Controller } from 'stimulus'
+
+export default class extends Controller {
+  static targets = ['credits', 'sidebar', 'content']
+
+  initialize() {
+    this.resize()
+  }
+
+  resize() {
+    this.alignCredits()
+    this.roundBottomRightCorner()
+  }
+
+  alignCredits() {
+    if (this.isTwoColumn()) {
+      this.creditsTarget.style.width = this.contentTarget.clientWidth + "px"
+      this.element.style.paddingBottom = this.offset() + "px"
+    } else {
+      this.creditsTarget.style.width = "100%"
+      this.element.style.paddingBottom = "0px"
+    }
+  }
+
+  roundBottomRightCorner() {
+    if ( this.heightDifference() > 0 ) {
+      this.sidebarTarget.style = "border-bottom-right-radius: 6px"
+    } else {
+      this.sidebarTarget.style = "border-bottom-right-radius: 0px"
+    }
+  }
+
+  isTwoColumn() {
+    // return window.getComputedStyle( this.creditsTarget ).getPropertyValue('position') == 'absolute'
+    console.log( this.creditsTarget.style.position )
+    return this.creditsTarget.style.position == 'absolute'
+  }
+
+  heightDifference() {
+    return this.sidebarTarget.clientHeight - this.contentTarget.clientHeight
+  }
+
+  offset() {
+    const mainElement = document.getElementsByTagName("main")[0]
+    const mainPaddingBottom = parseInt( window.getComputedStyle(mainElement).getPropertyValue('padding-bottom'), 10 )
+    return this.creditsTarget.clientHeight - this.heightDifference() - mainPaddingBottom
+  }
+
+}

--- a/app/javascript/controllers/playlist_controller.js
+++ b/app/javascript/controllers/playlist_controller.js
@@ -4,7 +4,8 @@ export default class extends Controller {
   static targets = ['credits', 'sidebar', 'content', 'cover']
 
   initialize() {
-    this.resize()
+    this.creditsTarget.style.width = "10px"
+    //this.resize()
   }
 
   resize() {

--- a/app/views/playlists/_playlist.html.erb
+++ b/app/views/playlists/_playlist.html.erb
@@ -1,72 +1,69 @@
-<div class="playlist_sidebar">
+<%= link_to playlist_cover(@playlist, variant: :playlist_card),
+  user_playlist_path(@playlist.user, @playlist), class: 'small_cover', style: ('display:none;' unless @asset) %>
+<h1 class="<%= 'cover' unless @asset %>">
+  <%= @playlist.title %>
+</h1>
+<h2>
+  <span class="by">by</span> <%= link_to @user.name, user_home_path(@user) %>   <% if authorized? %>
+  <span class="parentheses">(</span> <%= link_to edit_user_playlist_path(@playlist.user, @playlist),
+    class: 'edit_playlist', :title => 'edit this playlist' do %>
+    edit
+  <% end %> <span class="parentheses">)</span>
+<% end %>
+</h2>
 
-  <%= link_to playlist_cover(@playlist, variant: :playlist_card),
-    user_playlist_path(@playlist.user, @playlist), class: 'small_cover', style: ('display:none;' unless @asset) %>
-  <h1 class="<%= 'cover' unless @asset %>">
-    <%= @playlist.title %>
-  </h1>
-  <h2>
-    <span class="by">by</span> <%= link_to @user.name, user_home_path(@user) %>   <% if authorized? %>
-    <span class="parentheses">(</span> <%= link_to edit_user_playlist_path(@playlist.user, @playlist),
-      class: 'edit_playlist', :title => 'edit this playlist' do %>
-      edit
-    <% end %> <span class="parentheses">)</span>
+<ul class="tracklist">
+<% @playlist.tracks.each do |track| %>
+  <li data-controller="playlist-playback"
+    data-action="popstate@window->playlist-playback#popTrack ajax:success->playlist-playback#loadTrack
+    track:play->playlist-playback#play
+    track:pause->playlist-playback#pause
+    track:playing->playlist-playback#playing
+    track:ended->playlist-playback#stop
+    track:whileLoading->playlist-playback#whileLoading
+    track:whilePlaying->playlist-playback#whilePlaying
+    track:registerListen->playlist-playback#registerListen
+    track:seeked->playlist-playback#seeked"
+    data-playlist-playback-id="<%= track.asset.id %>"
+    class="stitches_track <%= ' active' if first_active_track?(track, @asset) %>">
+
+  <!-- Play button automagically plays AND changes to relevant track details  -->
+  <%= link_to user_show_track_in_playlist_path(@user, @playlist, track.asset, format: :mp3),
+    class: 'play_button stitches_play', data: { "playlist-playback-target": "play" } do %>
+    <i class="icon_play"></i>
   <% end %>
-  </h2>
 
-  <ul class="tracklist">
-  <% @playlist.tracks.each do |track| %>
-    <li data-controller="playlist-playback"
-      data-action="popstate@window->playlist-playback#popTrack ajax:success->playlist-playback#loadTrack
-      track:play->playlist-playback#play
-      track:pause->playlist-playback#pause
-      track:playing->playlist-playback#playing
-      track:ended->playlist-playback#stop
-      track:whileLoading->playlist-playback#whileLoading
-      track:whilePlaying->playlist-playback#whilePlaying
-      track:registerListen->playlist-playback#registerListen
-      track:seeked->playlist-playback#seeked"
-      data-playlist-playback-id="<%= track.asset.id %>"
-      class="stitches_track <%= ' active' if first_active_track?(track, @asset) %>">
-
-    <!-- Play button automagically plays AND changes to relevant track details  -->
-    <%= link_to user_show_track_in_playlist_path(@user, @playlist, track.asset, format: :mp3),
-      class: 'play_button stitches_play', data: { "playlist-playback-target": "play" } do %>
-      <i class="icon_play"></i>
-    <% end %>
-
-    <!-- Track title just switches track details-->
-    <%= link_to user_show_track_in_playlist_path(@user, @playlist, track.asset),
-      remote: true, class: 'position_name_time', data: { 'playlist-playback-target': "loadTrack" } do %>
-      <span class="track_position">
-        <%= "%02d" % track.position %>.
-      </span>
-      <span class="track_name">
-        <%= track.name %>
-      </span>
-      <span class='time_text'><%= track.asset.length %></span>
-    <% end %>
-    </li>
+  <!-- Track title just switches track details-->
+  <%= link_to user_show_track_in_playlist_path(@user, @playlist, track.asset),
+    remote: true, class: 'position_name_time', data: { 'playlist-playback-target': "loadTrack" } do %>
+    <span class="track_position">
+      <%= "%02d" % track.position %>.
+    </span>
+    <span class="track_name">
+      <%= track.name %>
+    </span>
+    <span class='time_text'><%= track.asset.length %></span>
   <% end %>
+  </li>
+<% end %>
+</ul>
+
+<div class="sidebar_downloads"
+  style="<%= 'display:none' unless @asset %>">
+  <ul class="downloads_links">
   </ul>
 
-  <div class="sidebar_downloads"
-    style="<%= 'display:none' unless @asset %>">
-    <ul class="downloads_links">
-    </ul>
-
-    <ul class="external_links">
-      <% [:link1, :link2, :link3].collect do |link| %>
-        <% if valid_link = @playlist.send(link) %>
-          <% if external_link_for(valid_link) %>
-          <li>
-            <%= external_link_for(valid_link) %>
-          </li>
-          <% end %>
+  <ul class="external_links">
+    <% [:link1, :link2, :link3].collect do |link| %>
+      <% if valid_link = @playlist.send(link) %>
+        <% if external_link_for(valid_link) %>
+        <li>
+          <%= external_link_for(valid_link) %>
+        </li>
         <% end %>
       <% end %>
-    </ul>
-  </div>
-
+    <% end %>
+  </ul>
 </div>
+
 

--- a/app/views/playlists/show.html.erb
+++ b/app/views/playlists/show.html.erb
@@ -42,3 +42,41 @@
   <% end %>
 </div>
 
+<script>
+
+  const playlistCredits = document.getElementsByClassName("playlist_credits")[0]
+  const playlistSidebar = document.getElementsByClassName("playlist_sidebar")[0]
+  const trackContent = document.getElementsByClassName("track_content")[0]
+  const playlistAndTrackContent = document.getElementById("playlist_and_track_content")
+
+  const mainElement = document.getElementsByTagName("main")[0]
+  
+  const mainPaddingBottom = parseInt( window.getComputedStyle(mainElement).getPropertyValue('padding-bottom'), 10 )
+
+  const viewportResized = function () {
+
+    let heightDifference = playlistSidebar.clientHeight - trackContent.clientHeight
+    let offset = playlistCredits.clientHeight - heightDifference - mainPaddingBottom
+    
+    if ( window.getComputedStyle(playlistCredits).getPropertyValue('position') == "absolute") {
+      playlistAndTrackContent.setAttribute("style","padding-bottom:" + offset + "px")
+      playlistCredits.setAttribute("style", "width:" + trackContent.clientWidth + "px")
+    } else {
+      playlistAndTrackContent.setAttribute("style","padding-bottom: 0px")
+      playlistCredits.setAttribute("style", "width: 100%")
+    }
+
+    if ( heightDifference > 0 ) {
+      playlistSidebar.setAttribute("style","border-bottom-right-radius: 6px")
+    } else {
+      playlistSidebar.setAttribute("style","border-bottom-right-radius: 0px")
+    }
+  }
+
+  viewportResized()
+
+  window.addEventListener('resize', function () {
+    viewportResized()
+  }, false)
+
+</script>

--- a/app/views/playlists/show.html.erb
+++ b/app/views/playlists/show.html.erb
@@ -16,7 +16,7 @@
   <% else %>
     <%= content_for(:body_class, 'cover_view') %>
     <div class="track_content" data-playlist-target="content">
-      <div class="large_cover_and_credits">
+      <div class="large_cover_and_credits" data-playlist-target="cover">
         <div class="large_cover">
           <%= playlist_cover(@playlist, variant: :playlist_cover) %>
         </div>

--- a/app/views/playlists/show.html.erb
+++ b/app/views/playlists/show.html.erb
@@ -7,14 +7,15 @@
 <div class="page_container" id="playlist_and_track_content_header">
   <%= render partial: 'shared/back_to_artist' %>
 </div>
-<div class="page_container" id="playlist_and_track_content">
-  <%= render 'playlist' %>
-
+<div class="page_container" id="playlist_and_track_content" data-controller="playlist" data-action="resize@window->playlist#resize">
+  <div class="playlist_sidebar" data-playlist-target="sidebar">
+    <%= render 'playlist' %>
+  </div>
   <% if @asset %>
     <%= render partial: 'shared/asset' %>
   <% else %>
     <%= content_for(:body_class, 'cover_view') %>
-    <div class="track_content">
+    <div class="track_content" data-playlist-target="content">
       <div class="large_cover_and_credits">
         <div class="large_cover">
           <%= playlist_cover(@playlist, variant: :playlist_cover) %>
@@ -34,49 +35,10 @@
         </div>
       <% end %>
       <% if @playlist.credits.present? %>
-        <div class="playlist_credits">
+        <div class="playlist_credits" data-playlist-target="credits">
         <%= markdown(@playlist.credits) %>
       </div>
       <% end %>
     </div>
   <% end %>
 </div>
-
-<script>
-
-  const playlistCredits = document.getElementsByClassName("playlist_credits")[0]
-  const playlistSidebar = document.getElementsByClassName("playlist_sidebar")[0]
-  const trackContent = document.getElementsByClassName("track_content")[0]
-  const playlistAndTrackContent = document.getElementById("playlist_and_track_content")
-
-  const mainElement = document.getElementsByTagName("main")[0]
-  
-  const mainPaddingBottom = parseInt( window.getComputedStyle(mainElement).getPropertyValue('padding-bottom'), 10 )
-
-  const viewportResized = function () {
-
-    let heightDifference = playlistSidebar.clientHeight - trackContent.clientHeight
-    let offset = playlistCredits.clientHeight - heightDifference - mainPaddingBottom
-    
-    if ( window.getComputedStyle(playlistCredits).getPropertyValue('position') == "absolute") {
-      playlistAndTrackContent.setAttribute("style","padding-bottom:" + offset + "px")
-      playlistCredits.setAttribute("style", "width:" + trackContent.clientWidth + "px")
-    } else {
-      playlistAndTrackContent.setAttribute("style","padding-bottom: 0px")
-      playlistCredits.setAttribute("style", "width: 100%")
-    }
-
-    if ( heightDifference > 0 ) {
-      playlistSidebar.setAttribute("style","border-bottom-right-radius: 6px")
-    } else {
-      playlistSidebar.setAttribute("style","border-bottom-right-radius: 0px")
-    }
-  }
-
-  viewportResized()
-
-  window.addEventListener('resize', function () {
-    viewportResized()
-  }, false)
-
-</script>

--- a/spec/features/playlist_spec.rb
+++ b/spec/features/playlist_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'playlists', type: :feature, js: true do
       # Note: this only pauses GSAP animations
       with_animations_paused do
         first_track.hover
-        expect(first_track).to have_css('.active')
+        expect(first_track).to have_css(':hover')
         Percy.snapshot(page, name: 'Playlist Cover')
 
         # This click will be an ajax request

--- a/spec/features/playlist_spec.rb
+++ b/spec/features/playlist_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'playlists', type: :feature, js: true do
       # Note: this only pauses GSAP animations
       with_animations_paused do
         first_track.hover
-        expect(first_track).to have_selector('.active')
+        expect(first_track).to have_css('.active')
         Percy.snapshot(page, name: 'Playlist Cover')
 
         # This click will be an ajax request

--- a/spec/features/playlist_spec.rb
+++ b/spec/features/playlist_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe 'playlists', type: :feature, js: true do
       # Note: this only pauses GSAP animations
       with_animations_paused do
         first_track.hover
+        expect(first_track).to have_selector('.active')
         Percy.snapshot(page, name: 'Playlist Cover')
 
         # This click will be an ajax request

--- a/spec/features/playlist_spec.rb
+++ b/spec/features/playlist_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'playlists', type: :feature, js: true do
       # Note: this only pauses GSAP animations
       with_animations_paused do
         first_track.hover
-        expect(first_track).to have_css('.hover')
+        expect(first_track).to have_css(':hover')
         Percy.snapshot(page, name: 'Playlist Cover')
 
         # This click will be an ajax request

--- a/spec/features/playlist_spec.rb
+++ b/spec/features/playlist_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'playlists', type: :feature, js: true do
       # Note: this only pauses GSAP animations
       with_animations_paused do
         first_track.hover
-        expect(first_track).to have_css(':hover')
+        expect(first_track).to have_css('.hover')
         Percy.snapshot(page, name: 'Playlist Cover')
 
         # This click will be an ajax request

--- a/spec/features/playlist_spec.rb
+++ b/spec/features/playlist_spec.rb
@@ -7,13 +7,14 @@ RSpec.describe 'playlists', type: :feature, js: true do
       visit 'henri_willig/playlists/polderkaas'
       first_track = find('ul.tracklist li:first-child')
 
+      first_track.hover
+      expect(first_track).to have_css(':hover')
+      Percy.snapshot(page, name: 'Playlist Cover')
+
       # I hoped we could pause and resume animations as needed
       # But we require absolutely 0 DOM variation to please Percy
       # Note: this only pauses GSAP animations
       with_animations_paused do
-        first_track.hover
-        expect(first_track).to have_css(':hover')
-        Percy.snapshot(page, name: 'Playlist Cover')
 
         # This click will be an ajax request
         # And in some cases our Snapshot will fire before the DOM is updated

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -15,7 +15,7 @@ require 'percy'
 # to its API.
 WebMock.disable_net_connect!(
   allow_localhost: true,
-  allow: ['percy.io', 'chromedriver.storage.googleapis.com']
+  allow: ['percy.io', 'chromedriver.storage.googleapis.com', 'ownandship.io']
 )
 
 # Reloads schema.rb when database has pending migrations.


### PR DESCRIPTION
Fixes #704

We created a stimulus playlist_controller and hooked it into the playlists/show template.

Because of the nature of flexbox managing the layouts of the sidebar and cover view across different screen widths, some javascript was needed to fix the layout of optional credits that can float below those two. The credits were absolutely positioned so they could float below the cover, but this was problematic if they were long.

This script calculates the space needed to show those correctly and adds it via padding of the playlist_and_track_content div.

The reason the padding of the main element is needed in the calculations is because the credits div is still absolutely positioned, so it's floating free of the regular HTML flow and doesn't respect that padding above the footer.

The border-radius code detects if the sidebar column is taller than the cover view, and if so, it will dynamically add a rounded edge to it's bottom right corner.


## "Ready For Review" checklist

These checklists are to help ensure the code review basics are covered. Consider removing to reduce noise.

* [x] PR title accurately summarizes changes
* [ ] New tests were added for isolated methods or new endpoints
* [ ] I opened an issue for any logical followups
* [x] If this fixes a bug, "Fixes #XXX" is either the very first or very last line of the description.

## Before code review *and after additional commits* during review.

* [ ] Update title and description to account for additional changes
* [ ] All tests green
* [ ] Migrations were tested locally and do the right thing
* [ ] Booted up the branch locally, exercised any new code
* [ ] Percy changes are purposeful or explained
* [ ] Css changes are happy on mobile (via Percy is ok)
