### PR TITLE
Allows admins to create mass invites and visitors to use them

### DIFF
--- a/app/assets/stylesheets/components/admin.scss
+++ b/app/assets/stylesheets/components/admin.scss
@@ -262,4 +262,24 @@
       }
     }
   }
+  table {
+    border-collapse: collapse;
+    th {
+      font-weight: bold;
+    }
+    th, td {
+      text-align: left;
+      vertical-align: top;
+      padding: 0.375em 0.5em;
+    }
+  }
+  form {
+    padding: 0 1em;
+    ul.actions {
+      list-style-type: none;
+      li {
+        display: inline-block;
+      }
+    }
+  }
 }

--- a/app/assets/stylesheets/components/blank_slate.scss
+++ b/app/assets/stylesheets/components/blank_slate.scss
@@ -60,6 +60,10 @@
         display: none;
       }
     }
+    a {
+      text-decoration: underline;
+      color: $orange600;  
+    }
   }
   .contributor_name {
     line-height: 1.2;

--- a/app/assets/stylesheets/components/blank_slate.scss
+++ b/app/assets/stylesheets/components/blank_slate.scss
@@ -23,6 +23,12 @@
         height: 0;
         padding-bottom: 144%;
       }
+      &.alec {
+        background-image: image-url("illustrations/contributors/alec-talking.png");
+      }
+      &.jenya {
+        background-image: image-url("illustrations/contributors/jenya-talking.png");
+      }
     }
     .contributor_name.mobile_only, .contributor_title.mobile_only {
       display: none;
@@ -77,9 +83,4 @@
   background-position-y: $background_position-y;
   position: relative;
   top: -48px;
-  .left {
-    .blank_slate_illustration {
-      background-image: image-url("illustrations/contributors/alec-talking.png");
-    }
-  }
 }

--- a/app/assets/stylesheets/components/blank_slate.scss
+++ b/app/assets/stylesheets/components/blank_slate.scss
@@ -16,6 +16,7 @@
     .blank_slate_illustration {
       background-size: 100%;
       background-repeat: no-repeat;
+      background-position-y: bottom;
       height: 100%;
       min-width: 238px;
       @media only screen and (max-width: 540px) {

--- a/app/controllers/admin/mass_invites_controller.rb
+++ b/app/controllers/admin/mass_invites_controller.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Admin
+  class MassInvitesController < Admin::BaseController
+    def index
+      @pagy, @mass_invites = pagy(MassInvite.recent)
+    end
+
+    def new
+      @mass_invite = MassInvite.new
+    end
+
+    def create
+      @mass_invite = MassInvite.new(mass_invite_params)
+      if @mass_invite.save
+        redirect_to admin_mass_invites_url
+      else
+        render :new
+      end
+    end
+
+    private
+
+    def mass_invite_params
+      params.require(:mass_invite).permit(:name, :token)
+    end
+  end
+end

--- a/app/controllers/admin/mass_invites_controller.rb
+++ b/app/controllers/admin/mass_invites_controller.rb
@@ -3,7 +3,7 @@
 module Admin
   class MassInvitesController < Admin::BaseController
     def index
-      @pagy, @mass_invites = pagy(MassInvite.recent)
+      @pagy, @mass_invites = pagy(filtered_mass_invites)
     end
 
     def new
@@ -23,6 +23,10 @@ module Admin
 
     def mass_invite_params
       params.require(:mass_invite).permit(:name, :token)
+    end
+
+    def filtered_mass_invites
+      MassInvite.recent.where(archived: params[:filter_by] == 'archived')
     end
   end
 end

--- a/app/controllers/admin/mass_invites_controller.rb
+++ b/app/controllers/admin/mass_invites_controller.rb
@@ -13,16 +13,21 @@ module Admin
     def create
       @mass_invite = MassInvite.new(mass_invite_params)
       if @mass_invite.save
-        redirect_to admin_mass_invites_url
+        redirect_to admin_mass_invites_url(filter_by: 'active')
       else
         render :new
       end
     end
 
+    def update
+      MassInvite.where(token: params[:token]).update_all(**mass_invite_params)
+      redirect_to admin_mass_invites_url(filter_by: 'active')
+    end
+
     private
 
     def mass_invite_params
-      params.require(:mass_invite).permit(:name, :token)
+      params.require(:mass_invite).permit(:name, :token, :archived)
     end
 
     def filtered_mass_invites

--- a/app/controllers/concerns/user_creation.rb
+++ b/app/controllers/concerns/user_creation.rb
@@ -28,6 +28,7 @@ module UserCreation
       # Sets the perishable token used for email confirmation and saves the record.
       user.reset_perishable_token!
       UserNotification.signup(user).deliver_now
+      flash[:ok] = "We just sent you an email at '#{user.email}'.<br/><br/>Click the link in the email, and you'll be in! <br/> Note: check your junk/spam inbox if you don't see a new email right away.".html_safe
     end
     redirect_to login_url(already_joined: true)
   end

--- a/app/controllers/concerns/user_creation.rb
+++ b/app/controllers/concerns/user_creation.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+# Implements a few methods that controllers can use to respond after initializing a new user record.
+module UserCreation
+  protected
+
+  # The user argument should be a User instance that is not persisted yet. The method will save
+  # the user record, send a confirmation email, and generate a response. The user is not saved
+  # when the request or user attributes look like spam.
+  def respond_with_user(user)
+    if user.valid?
+      respond_with_valid_user(user)
+    else
+      render :new
+    end
+  end
+
+  private
+
+  def respond_with_valid_user(user)
+    # When the user agent or remote IP address indicates that this request is spam.
+    if is_a_bot?
+      Rails.logger.info('Based on remote IP or user-agent this looks like a spammer.')
+    # When any of the  user attributes values indicate that this user was created by spammers.
+    elsif user.spam?
+      Rails.logger.info('Based on user attributes this looks like a spammer.')
+    else
+      # Sets the perishable token used for email confirmation and saves the record.
+      user.reset_perishable_token!
+      UserNotification.signup(user).deliver_now
+    end
+    redirect_to login_url(already_joined: true)
+  end
+end

--- a/app/controllers/mass_invites_users_controller.rb
+++ b/app/controllers/mass_invites_users_controller.rb
@@ -5,7 +5,9 @@ class MassInvitesUsersController < ApplicationController
 
   before_action lambda {
     @mass_invite = MassInvite.find_by!(token: params[:mass_invite_token])
-    render :archived if @mass_invite.archived?
+    if @mass_invite.archived?
+      redirect_to '/get_an_account', flash: { notice: "That invite no longer exists!" }
+    end
   }
 
   def new

--- a/app/controllers/mass_invites_users_controller.rb
+++ b/app/controllers/mass_invites_users_controller.rb
@@ -10,6 +10,7 @@ class MassInvitesUsersController < ApplicationController
 
   def new
     @user = User.new
+    @page_title = "You're invited!"
   end
 
   def create

--- a/app/controllers/mass_invites_users_controller.rb
+++ b/app/controllers/mass_invites_users_controller.rb
@@ -13,7 +13,7 @@ class MassInvitesUsersController < ApplicationController
   end
 
   def create
-    @user = User.new(user_params)
+    @user = @mass_invite.users.new(user_params)
     respond_with_user(@user)
   end
 

--- a/app/controllers/mass_invites_users_controller.rb
+++ b/app/controllers/mass_invites_users_controller.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+class MassInvitesUsersController < ApplicationController
+  include UserCreation
+
+  before_action lambda {
+    @mass_invite = MassInvite.find_by!(token: params[:mass_invite_token])
+    render :archived if @mass_invite.archived?
+  }
+
+  def new
+    @user = User.new
+  end
+
+  def create
+    @user = User.new(user_params)
+    respond_with_user(@user)
+  end
+
+  def show
+    redirect_to new_mass_invite_users_url(@mass_invite)
+  end
+
+  private
+
+  def user_params
+    params.require(:user).permit(:email, :login, :password, :password_confirmation)
+  end
+end

--- a/app/helpers/admin_form_builder.rb
+++ b/app/helpers/admin_form_builder.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class AdminFormBuilder < ActionView::Helpers::FormBuilder
+  include ActionView::Helpers::FormTagHelper
+
+  attr_accessor :output_buffer
+
+  def field(attribute, options = {}, &block)
+    content = @template.capture(&block) if block_given?
+    options[:class] = options.key?(:class) ? Array(options[:class]) : []
+    options[:class] << 'field'
+    options[:class] << 'invalid' if @object.errors.include?(attribute)
+    tag.div(**options) do
+      concat(content) if content.present?
+    end
+  end
+
+  def label_with_error(name)
+    if @object.errors.messages[name].present?
+      label(
+        name, [
+          @object.class.human_attribute_name(name),
+          @object.errors.messages[name].to_sentence
+        ].join(' ')
+      )
+    else
+      label(name)
+    end
+  end
+end

--- a/app/models/mass_invite.rb
+++ b/app/models/mass_invite.rb
@@ -19,7 +19,7 @@ class MassInvite < ApplicationRecord
   private
 
   def set_token
-    self.token ||= SecureRandom.alphanumeric(8)
+    self.token ||= SecureRandom.alphanumeric(10)
   end
 end
 

--- a/app/models/mass_invite.rb
+++ b/app/models/mass_invite.rb
@@ -8,6 +8,8 @@ class MassInvite < ApplicationRecord
   has_many :mass_invite_signups
   has_many :users, through: :mass_invite_signups
 
+  scope :active, -> { where(archived: false) }
+
   validates :name, :token, presence: true
 
   def to_param

--- a/app/models/mass_invite.rb
+++ b/app/models/mass_invite.rb
@@ -17,3 +17,20 @@ class MassInvite < ApplicationRecord
     self.token ||= SecureRandom.alphanumeric(16)
   end
 end
+
+# == Schema Information
+#
+# Table name: mass_invites
+#
+#  id          :bigint(8)        not null, primary key
+#  archived    :boolean          default(FALSE), not null
+#  name        :text(65535)      not null
+#  token       :string(255)      not null
+#  users_count :integer          default(0), not null
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
+# Indexes
+#
+#  index_mass_invites_on_token  (token) UNIQUE
+#

--- a/app/models/mass_invite.rb
+++ b/app/models/mass_invite.rb
@@ -9,6 +9,7 @@ class MassInvite < ApplicationRecord
   has_many :users, through: :mass_invite_signups
 
   scope :active, -> { where(archived: false) }
+  scope :archived, -> { where(archived: true) }
 
   validates :name, :token, presence: true
 

--- a/app/models/mass_invite.rb
+++ b/app/models/mass_invite.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class MassInvite < ApplicationRecord
+  scope :recent, -> { order(created_at: :desc, id: :desc) }
+
+  after_initialize :set_token, if: :new_record?
+
+  validates :name, :token, presence: true
+
+  def to_param
+    token
+  end
+
+  private
+
+  def set_token
+    self.token ||= SecureRandom.alphanumeric(16)
+  end
+end

--- a/app/models/mass_invite.rb
+++ b/app/models/mass_invite.rb
@@ -5,6 +5,9 @@ class MassInvite < ApplicationRecord
 
   after_initialize :set_token, if: :new_record?
 
+  has_many :mass_invite_signups
+  has_many :users, through: :mass_invite_signups
+
   validates :name, :token, presence: true
 
   def to_param

--- a/app/models/mass_invite.rb
+++ b/app/models/mass_invite.rb
@@ -19,7 +19,7 @@ class MassInvite < ApplicationRecord
   private
 
   def set_token
-    self.token ||= SecureRandom.alphanumeric(16)
+    self.token ||= SecureRandom.alphanumeric(8)
   end
 end
 

--- a/app/models/mass_invite_signup.rb
+++ b/app/models/mass_invite_signup.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class MassInviteSignup < ApplicationRecord
+  belongs_to :mass_invite, counter_cache: :users_count
+  belongs_to :user
+end

--- a/app/models/mass_invite_signup.rb
+++ b/app/models/mass_invite_signup.rb
@@ -4,3 +4,17 @@ class MassInviteSignup < ApplicationRecord
   belongs_to :mass_invite, counter_cache: :users_count
   belongs_to :user
 end
+
+# == Schema Information
+#
+# Table name: mass_invite_signups
+#
+#  id             :bigint(8)        not null, primary key
+#  mass_invite_id :bigint(8)
+#  user_id        :bigint(8)
+#
+# Indexes
+#
+#  index_mass_invite_signups_on_mass_invite_id  (mass_invite_id)
+#  index_mass_invite_signups_on_user_id         (user_id)
+#

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -145,6 +145,9 @@ class User < ApplicationRecord
     byte_size: { less_than: 20.megabytes }
   }, if: :avatar_image_present?
 
+  has_one :mass_invite_signup
+  has_one :mass_invite, through: :mass_invite_signup
+
   # tokens and activation
   def clear_token!
     update_attribute(:perishable_token, nil)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -158,7 +158,7 @@ class User < ApplicationRecord
   end
 
   def never_activated?
-    last_login_at.nil? && perishable_token.present?
+    last_request_at.nil? && perishable_token.present?
   end
 
   def update_account_request!
@@ -301,6 +301,8 @@ class User < ApplicationRecord
       musicians.with_deleted.where(is_spam: true).order('deleted_at DESC')
     when "not_spam"
       with_deleted.where(is_spam: false).recent
+    when "invited"
+      joins(:mass_invite_signup)
     when String
       with_deleted.where("email like '%#{filter}%' or login like '%#{filter}%' or display_name like '%#{filter}%'").recent
     else

--- a/app/views/account_requests/new.html.erb
+++ b/app/views/account_requests/new.html.erb
@@ -1,30 +1,12 @@
 <div class="page_container get_an_account_container">
-  <div class="blank_slate">
-    <div class="left">
-      <div class="blank_slate_illustration">
-      </div>
-      <div class="contributor_name mobile_only">
-        alec
-      </div>
-      <div class="contributor_title mobile_only">
-        illustrator
-      </div>
-    </div>
-    <div class="blank_slate_text">
+  <%= render layout: 'shared/blank_slate', locals: { name: 'alec', role: 'illustrator' } do %>
       <p>
         “Alonetone is open to everyone making music. However, we are invite-only to keep spammers out.
       </p>
       <p>
         Get on the list below! It might take us a day or two to approve your account, but it’s worth it, promise.”
       </p>
-      <div class="contributor_name">
-        alec
-      </div>
-      <div class="contributor_title">
-        illustrator
-      </div>
-    </div>
-  </div>
+  <% end %>
 
   <div class="box">
     <h2>Get an Account</h2>

--- a/app/views/admin/_navigation.html.erb
+++ b/app/views/admin/_navigation.html.erb
@@ -19,6 +19,9 @@
   </ul>
 
   <%= navigation_item "Mass Invites <span>#{MassInvite.active.count}</span>",  admin_mass_invites_path({ filter_by: 'active' }) %>
+  <ul>
+    <%= navigation_item "Archived <span>#{MassInvite.archived.count}</span>",  admin_mass_invites_path({ filter_by: 'archived' }) %>
+  </ul>
 
   <%= navigation_item "All Tracks <span>#{Asset.with_deleted.count}</span>", admin_assets_path %>
   <ul>
@@ -26,14 +29,13 @@
     <%= navigation_item "Deleted Spam <span>#{Asset.with_deleted.where(is_spam: true).count}</span>", admin_assets_path({filter_by: :is_spam}) %>
     <%= navigation_item "Deleted (Not Spam) <span>#{Asset.only_deleted.where(is_spam: false).count}</span>", admin_assets_path({filter_by: :deleted}) %>
   </ul>
+
   <%= navigation_item 'All Comments',  admin_comments_path %>
   <ul>
     <%= navigation_item 'Spam',  admin_comments_path({filter_by: {is_spam: true}}) %>
     <%= navigation_item 'Not Spam', admin_comments_path({filter_by: {is_spam: false}}) %>
   </ul>
-  <ul>
-    <%= navigation_item "Archived",  admin_mass_invites_path({ filter_by: 'archived' }) %>
-  </ul>
+
   <li><%= link_to "Secretz", "/secretz" %></li>
   <li><%= link_to "Akismet Stats", "https://akismet.com/web/1.0/user-stats.php?blog=alonetone.com&api_key=#{Rails.configuration.alonetone.rakismet_key}"%></li>
   <li><%= link_to "Postmark Stats", "https://account.postmarkapp.com/servers/2804035/streams" %></li>

--- a/app/views/admin/_navigation.html.erb
+++ b/app/views/admin/_navigation.html.erb
@@ -11,11 +11,14 @@
 
   <%= navigation_item "All Users <span>#{User.with_deleted.count}</span>", admin_users_path %>
   <ul>
-    <%= navigation_item "Not Spam <span>#{User.filter_by('not_spam').count}</span>", admin_users_path({filter_by: :not_spam}) %>
-    <%= navigation_item "Only Spam <span>#{User.filter_by('is_spam').count}</span>", admin_users_path({filter_by: :is_spam}) %>
+    <%= navigation_item "Valid <span>#{User.filter_by('not_spam').count}</span>", admin_users_path({filter_by: :not_spam}) %>
+    <%= navigation_item "Spam <span>#{User.filter_by('is_spam').count}</span>", admin_users_path({filter_by: :is_spam}) %>
     <%= navigation_item "Spammed Musicians <span>#{User.filter_by('spam_musicians').count}</span>", admin_users_path({filter_by: :spam_musicians}) %>
     <%= navigation_item "Deleted (Not Spam) <span>#{User.filter_by('deleted').count}</span>", admin_users_path({filter_by: :deleted}) %>
   </ul>
+
+  <%= navigation_item "Mass Invites <span>#{MassInvite.active.count}</span>",  admin_mass_invites_path({ filter_by: 'active' }) %>
+
   <%= navigation_item "All Tracks <span>#{Asset.with_deleted.count}</span>", admin_assets_path %>
   <ul>
     <%= navigation_item "Not Spam <span>#{Asset.count}</span>", admin_assets_path({filter_by: :not_spam}) %>
@@ -27,7 +30,6 @@
     <%= navigation_item 'Spam',  admin_comments_path({filter_by: {is_spam: true}}) %>
     <%= navigation_item 'Not Spam', admin_comments_path({filter_by: {is_spam: false}}) %>
   </ul>
-  <%= navigation_item "Mass Invites",  admin_mass_invites_path({ filter_by: 'active' }) %>
   <ul>
     <%= navigation_item "Archived",  admin_mass_invites_path({ filter_by: 'archived' }) %>
   </ul>

--- a/app/views/admin/_navigation.html.erb
+++ b/app/views/admin/_navigation.html.erb
@@ -12,6 +12,7 @@
   <%= navigation_item "All Users <span>#{User.with_deleted.count}</span>", admin_users_path %>
   <ul>
     <%= navigation_item "Valid <span>#{User.filter_by('not_spam').count}</span>", admin_users_path({filter_by: :not_spam}) %>
+    <%= navigation_item "Mass Invited <span>#{User.filter_by('invited').count}</span>", admin_users_path({filter_by: :invited}) %>
     <%= navigation_item "Spam <span>#{User.filter_by('is_spam').count}</span>", admin_users_path({filter_by: :is_spam}) %>
     <%= navigation_item "Spammed Musicians <span>#{User.filter_by('spam_musicians').count}</span>", admin_users_path({filter_by: :spam_musicians}) %>
     <%= navigation_item "Deleted (Not Spam) <span>#{User.filter_by('deleted').count}</span>", admin_users_path({filter_by: :deleted}) %>

--- a/app/views/admin/_navigation.html.erb
+++ b/app/views/admin/_navigation.html.erb
@@ -27,7 +27,10 @@
     <%= navigation_item 'Spam',  admin_comments_path({filter_by: {is_spam: true}}) %>
     <%= navigation_item 'Not Spam', admin_comments_path({filter_by: {is_spam: false}}) %>
   </ul>
-  <%= navigation_item "Mass Invites",  admin_mass_invites_path %>
+  <%= navigation_item "Mass Invites",  admin_mass_invites_path({ filter_by: 'active' }) %>
+  <ul>
+    <%= navigation_item "Archived",  admin_mass_invites_path({ filter_by: 'archived' }) %>
+  </ul>
   <li><%= link_to "Secretz", "/secretz" %></li>
   <li><%= link_to "Akismet Stats", "https://akismet.com/web/1.0/user-stats.php?blog=alonetone.com&api_key=#{Rails.configuration.alonetone.rakismet_key}"%></li>
   <li><%= link_to "Postmark Stats", "https://account.postmarkapp.com/servers/2804035/streams" %></li>

--- a/app/views/admin/_navigation.html.erb
+++ b/app/views/admin/_navigation.html.erb
@@ -27,6 +27,7 @@
     <%= navigation_item 'Spam',  admin_comments_path({filter_by: {is_spam: true}}) %>
     <%= navigation_item 'Not Spam', admin_comments_path({filter_by: {is_spam: false}}) %>
   </ul>
+  <%= navigation_item "Mass Invites",  admin_mass_invites_path %>
   <li><%= link_to "Secretz", "/secretz" %></li>
   <li><%= link_to "Akismet Stats", "https://akismet.com/web/1.0/user-stats.php?blog=alonetone.com&api_key=#{Rails.configuration.alonetone.rakismet_key}"%></li>
   <li><%= link_to "Postmark Stats", "https://account.postmarkapp.com/servers/2804035/streams" %></li>

--- a/app/views/admin/mass_invites/_form.html.erb
+++ b/app/views/admin/mass_invites/_form.html.erb
@@ -1,0 +1,14 @@
+<%= form_for([:admin, @mass_invite], builder: AdminFormBuilder) do |form| %>
+  <%= form.field :name do %>
+    <%= form.label_with_error :name %>
+    <%= form.text_field :name %>
+  <% end %>
+  <%= form.field :token do %>
+    <%= form.label_with_error :token %>
+    <%= form.text_field :token %>
+  <% end %>
+  <ul class="actions submit">
+    <li><%= form.submit 'Create mass invite' %></li>
+    <li><%= link_to 'Cancel', admin_mass_invites_path %></li>
+  </ul>
+<% end %>

--- a/app/views/admin/mass_invites/_mass_invite.html.erb
+++ b/app/views/admin/mass_invites/_mass_invite.html.erb
@@ -2,7 +2,7 @@
   <td><%= mass_invite.name %></div>
   <td><%= l(mass_invite.created_at, format: :short) %></div>
   <td><%= mass_invite.users_count %></td>
-  <td><%= link_to(new_mass_invite_users_path(mass_invite), new_mass_invite_users_url(mass_invite)) %>
+  <td><%= link_to(mass_invite.token, mass_invite_url(mass_invite)) %>
   <td>
     <% if mass_invite.archived? %>
       <%= button_to('Activate', admin_mass_invite_path(mass_invite, mass_invite: { archived: 0 }), method: :patch) %>

--- a/app/views/admin/mass_invites/_mass_invite.html.erb
+++ b/app/views/admin/mass_invites/_mass_invite.html.erb
@@ -1,0 +1,6 @@
+<tr>
+  <td><%= mass_invite.name %></div>
+  <td><%= l(mass_invite.created_at, format: :long) %></div>
+  <td><%= link_to(new_mass_invite_users_path(mass_invite), new_mass_invite_users_url(mass_invite)) %>
+  <td><%= button_to('Archive', admin_mass_invite_path(mass_invite), method: :delete) %>
+</tr

--- a/app/views/admin/mass_invites/_mass_invite.html.erb
+++ b/app/views/admin/mass_invites/_mass_invite.html.erb
@@ -1,6 +1,7 @@
 <tr>
   <td><%= mass_invite.name %></div>
-  <td><%= l(mass_invite.created_at, format: :long) %></div>
+  <td><%= l(mass_invite.created_at, format: :short) %></div>
+  <td><%= mass_invite.users_count %></td>
   <td><%= link_to(new_mass_invite_users_path(mass_invite), new_mass_invite_users_url(mass_invite)) %>
   <td>
     <% if mass_invite.archived? %>

--- a/app/views/admin/mass_invites/_mass_invite.html.erb
+++ b/app/views/admin/mass_invites/_mass_invite.html.erb
@@ -2,5 +2,11 @@
   <td><%= mass_invite.name %></div>
   <td><%= l(mass_invite.created_at, format: :long) %></div>
   <td><%= link_to(new_mass_invite_users_path(mass_invite), new_mass_invite_users_url(mass_invite)) %>
-  <td><%= button_to('Archive', admin_mass_invite_path(mass_invite), method: :delete) %>
+  <td>
+    <% if mass_invite.archived? %>
+      <%= button_to('Activate', admin_mass_invite_path(mass_invite, mass_invite: { archived: 0 }), method: :patch) %>
+    <% else %>
+      <%= button_to('Archive', admin_mass_invite_path(mass_invite, mass_invite: { archived: 1 }), method: :patch) %>
+    <% end %>
+  </td>
 </tr

--- a/app/views/admin/mass_invites/index.html.erb
+++ b/app/views/admin/mass_invites/index.html.erb
@@ -20,6 +20,7 @@
           <tr>
             <th>Name</th>
             <th>Created</th>
+            <th>Users count</th>
           </tr>
         </thead>
         <tbody>

--- a/app/views/admin/mass_invites/index.html.erb
+++ b/app/views/admin/mass_invites/index.html.erb
@@ -21,6 +21,7 @@
             <th>Name</th>
             <th>Created</th>
             <th>Users count</th>
+            <th>Link to invite url</th>
           </tr>
         </thead>
         <tbody>

--- a/app/views/admin/mass_invites/index.html.erb
+++ b/app/views/admin/mass_invites/index.html.erb
@@ -11,6 +11,10 @@
     </div>
 
     <div class="box">
+      <h2>
+        <%= params[:filter_by] == 'archived' ? 'Archived' : 'Active' %>
+        mass invites
+      </h2>
       <table>
         <thead>
           <tr>

--- a/app/views/admin/mass_invites/index.html.erb
+++ b/app/views/admin/mass_invites/index.html.erb
@@ -1,0 +1,31 @@
+<div id="admin_columns">
+  <div class="admin_column_left box">
+    <h2>Admin</h2>
+    <%= render partial: 'admin/navigation' %>
+  </div>
+  <div class="admin_column_right">
+    <%= button_to 'New mass invite', new_admin_mass_invite_path, method: :get %>
+
+    <div class="mini_paginator top_paginator">
+      <%== pagy_nav @pagy %>
+    </div>
+
+    <div class="box">
+      <table>
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Created</th>
+          </tr>
+        </thead>
+        <tbody>
+          <%= render @mass_invites %>
+        </tbody>
+      </table>
+    </div>
+
+    <div class="mini_paginator bottom_paginator">
+      <%== pagy_nav @pagy %>
+    </div>
+  </div>
+</div>

--- a/app/views/admin/mass_invites/new.html.erb
+++ b/app/views/admin/mass_invites/new.html.erb
@@ -1,0 +1,12 @@
+<div id="admin_columns">
+  <div class="admin_column_left box">
+    <h2>Admin</h2>
+    <%= render partial: 'admin/navigation' %>
+  </div>
+  <div class="admin_column_right">
+    <div class="admin_column_right_inner box">
+      <h2>Create a new mass invite</h2>
+      <%= render 'form' %>
+    </div>
+  </div>
+</div>

--- a/app/views/admin/users/_user.html.erb
+++ b/app/views/admin/users/_user.html.erb
@@ -11,9 +11,14 @@
       <div><%= link_to(user.display_name, admin_possibly_deleted_user_path(user.login)) %></div>
       <div><%= user.email %></div>
       <% unless user.soft_deleted? %>
-      <div><%= user.current_login_ip %>
-        <% if user.current_login_ip.present? && (User.with_same_ip_as(user).count > 0)  %>
-        <%= link_to "Spam All #{User.with_same_ip_as(user).count + 1}", mark_all_users_with_ip_as_spam_admin_user_path(user), method: :put %>
+      <div>
+        <% if user.never_activated? %>
+          [ unactivated ]
+        <% else %>
+          <%= user.current_login_ip %>
+          <% if User.with_same_ip_as(user).count > 0 %>
+            <%= link_to "Spam All #{User.with_same_ip_as(user).count + 1}", mark_all_users_with_ip_as_spam_admin_user_path(user), method: :put %>
+          <% end %>
         <% end %>
        </div>
       <% end %>

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -58,6 +58,17 @@
           </div>
         </div>
       </div>
+
+      <div style="padding-left: 1em">
+        <h3>User's Origin Story</h3>
+        <% if mass_invite = @user.mass_invite %>
+          <p>Created through the mass invite ‘<%= mass_invite.name %>’.
+        <% elsif invited_by = @user.invited_by %>
+          <p>Invited by <%= "#{invited_by.login} (#{invited_by.email})" %>.
+        <% else %>
+          <p>Out of darkness, fretted something in its sleeping</p>
+        <% end %>
+      </div>
     </div>
   </div>
 </div>

--- a/app/views/mass_invites_users/archived.html.erb
+++ b/app/views/mass_invites_users/archived.html.erb
@@ -1,0 +1,6 @@
+<div class="page_container">
+  <div class="box">
+    <h1>Sorry, the invitation was closed!</h1>
+    <p>You can always <%= link_to 'request an account', '/get_an_account'%>.</p>
+  </div>
+</div>

--- a/app/views/mass_invites_users/archived.html.erb
+++ b/app/views/mass_invites_users/archived.html.erb
@@ -1,6 +1,0 @@
-<div class="page_container">
-  <div class="box">
-    <h1>Sorry, the invitation was closed!</h1>
-    <p>You can always <%= link_to 'request an account', '/get_an_account'%>.</p>
-  </div>
-</div>

--- a/app/views/mass_invites_users/new.html.erb
+++ b/app/views/mass_invites_users/new.html.erb
@@ -1,28 +1,17 @@
 <div class="page_container get_an_account_container">
-  <div class="blank_slate">
-    <div class="left">
-      <div class="blank_slate_illustration">
-      </div>
-      <div class="contributor_name mobile_only">
-        alec
-      </div>
-      <div class="contributor_title mobile_only">
-        illustrator
-      </div>
-    </div>
-    <div class="blank_slate_text">
-      <p><%= @mass_invite.name %></p>
-      <div class="contributor_name">
-        alec
-      </div>
-      <div class="contributor_title">
-        illustrator
-      </div>
-    </div>
-  </div>
-  
+  <%= render layout: 'shared/blank_slate', locals: { name: 'jenya', role: 'developer' } do %>
+    <p>
+      “Oh wonderful <%= @mass_invite.name %>,
+    </p>
+    <p>
+      Alonetone is an invite-only place to host your music and you are invited!
+
+      You can share this link with others, but please don't post it publically.”
+    </p>
+  <% end %>
+
   <div class="box">
-    <h2>Create an Account</h2>
+    <h2>Create your alonetone account</h2>
     <%= render partial: 'shared/errors', locals: { errors: @user.errors } %>
 
     <%= form_with(model: @user, url: mass_invite_users_path(@mass_invite), local: true) do |f| %>
@@ -43,8 +32,7 @@
           <%= f.label :password, "Password" %>
           <%= f.password_field :password, autocomplete: "new-password" %>
           <%= inline_form_error(@user.errors[:password]) %>
-        </div>
-        <div>
+
           <%= f.label :password_comfirmation, "Repeat password" %>
           <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
           <%= inline_form_error(@user.errors[:password_confirmation]) %>

--- a/app/views/mass_invites_users/new.html.erb
+++ b/app/views/mass_invites_users/new.html.erb
@@ -1,0 +1,58 @@
+<div class="page_container get_an_account_container">
+  <div class="blank_slate">
+    <div class="left">
+      <div class="blank_slate_illustration">
+      </div>
+      <div class="contributor_name mobile_only">
+        alec
+      </div>
+      <div class="contributor_title mobile_only">
+        illustrator
+      </div>
+    </div>
+    <div class="blank_slate_text">
+      <p><%= @mass_invite.name %></p>
+      <div class="contributor_name">
+        alec
+      </div>
+      <div class="contributor_title">
+        illustrator
+      </div>
+    </div>
+  </div>
+  
+  <div class="box">
+    <h2>Create an Account</h2>
+    <%= render partial: 'shared/errors', locals: { errors: @user.errors } %>
+
+    <%= form_with(model: @user, url: mass_invite_users_path(@mass_invite), local: true) do |f| %>
+      <div class="form_row">
+        <div>
+          <%= f.label :email, "Email" %>
+          <%= f.text_field :email %>
+          <%= inline_form_error(@user.errors[:email]) %>
+        </div>
+        <div class="field_with_hint_before">
+          <%= f.label :login, "Pick a username (no spaces allowed)" %>
+          <span>alonetone.com/</span><%= f.text_field :login %>
+          <%= inline_form_error(@user.errors[:login]) %>
+        </div>
+      </div>
+      <div class="form_row">
+        <div>
+          <%= f.label :password, "Password" %>
+          <%= f.password_field :password, autocomplete: "new-password" %>
+          <%= inline_form_error(@user.errors[:password]) %>
+        </div>
+        <div>
+          <%= f.label :password_comfirmation, "Repeat password" %>
+          <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
+          <%= inline_form_error(@user.errors[:password_confirmation]) %>
+        </div>
+      </div>
+      <div>
+        <%= f.submit "Create Account" %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/mass_invites_users/new.html.erb
+++ b/app/views/mass_invites_users/new.html.erb
@@ -4,9 +4,10 @@
       “Welcome, <%= @mass_invite.name %>!
     </p>
     <p>
-      Alonetone is an invite-only place to host your music — and this is your invite!
-
-      Feel free to share the link with others, but please don't post it publicly.”
+      You've been invited to create an account on alonetone. <%= link_to "Read more about alonetone.", about_path %>
+    </p>
+    <p>
+      Feel free to share this invite link, but please don't post it publicly.”
     </p>
   <% end %>
 

--- a/app/views/mass_invites_users/new.html.erb
+++ b/app/views/mass_invites_users/new.html.erb
@@ -1,12 +1,12 @@
 <div class="page_container get_an_account_container">
   <%= render layout: 'shared/blank_slate', locals: { name: 'jenya', role: 'developer' } do %>
     <p>
-      “Oh wonderful <%= @mass_invite.name %>,
+      “Welcome, <%= @mass_invite.name %>!
     </p>
     <p>
-      Alonetone is an invite-only place to host your music and you are invited!
+      Alonetone is an invite-only place to host your music — and this is your invite!
 
-      You can share this link with others, but please don't post it publically.”
+      Feel free to share the link with others, but please don't post it publicly.”
     </p>
   <% end %>
 

--- a/app/views/mass_invites_users/new.html.erb
+++ b/app/views/mass_invites_users/new.html.erb
@@ -4,7 +4,7 @@
       “Welcome, <%= @mass_invite.name %>!
     </p>
     <p>
-      You've been invited to create an account on alonetone. <%= link_to "Read more about alonetone.", about_path %>
+      You've been invited to create an account on alonetone. <%= link_to "Read more about alonetone", about_path %>.
     </p>
     <p>
       Feel free to share this invite link, but please don't post it publicly.”

--- a/app/views/shared/_blank_slate.html.erb
+++ b/app/views/shared/_blank_slate.html.erb
@@ -1,0 +1,21 @@
+<div class="blank_slate">
+  <div class="left">
+    <div class="blank_slate_illustration <%= name %>">
+    </div>
+    <div class="contributor_name mobile_only">
+      <%= name %>
+    </div>
+    <div class="contributor_title mobile_only">
+      <%= role %>
+    </div>
+  </div>
+  <div class="blank_slate_text">
+    <%= yield %>
+    <div class="contributor_name">
+      <%= name %>
+    </div>
+    <div class="contributor_title">
+      <%= role %>
+    </div>
+  </div>
+</div>

--- a/app/views/user_notification/signup.text.erb
+++ b/app/views/user_notification/signup.text.erb
@@ -1,10 +1,10 @@
 You just created an account at alonetone.com, a damn fine home for musicians.
 
-This is your log in information:
+This is your login:
 
-  Username: <%= @user.login %>
+  <%= @user.login %>
 
-Click this url to activate your account and start uploading:
+Click the url to activate your account and start uploading:
 
   <%= @url %>
 
@@ -12,3 +12,5 @@ For help you can always write us at support@alonetone.com
 
 love,
 Sudara
+
+P.S. You can now support us on Patreon! https://patreon.com/alonetone

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -104,6 +104,8 @@ Alonetone::Application.routes.draw do
   root :to => 'assets#latest'
 
   resources :users
+
+  get '/invite/:mass_invite_token', to: 'mass_invites_users#new', as: 'mass_invite'
   resources :mass_invites, param: :token, only: [] do
     resource :users, only: %i[new create show], controller: :mass_invites_users
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -104,6 +104,9 @@ Alonetone::Application.routes.draw do
   root :to => 'assets#latest'
 
   resources :users
+  resources :mass_invites, param: :token, only: [] do
+    resource :users, only: %i[index new create], controller: :mass_invites_users
+  end
 
   get ':login/history' => 'listens#index', :as => 'listens'
   get ':login/comments' => 'comments#index', :as => 'user_comments'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,7 +36,7 @@ Alonetone::Application.routes.draw do
         put :restore
       end
     end
-    resources :mass_invites
+    resources :mass_invites, param: :token
   end
 
   mount Thredded::Engine => '/forums'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -105,7 +105,7 @@ Alonetone::Application.routes.draw do
 
   resources :users
   resources :mass_invites, param: :token, only: [] do
-    resource :users, only: %i[index new create], controller: :mass_invites_users
+    resource :users, only: %i[new create show], controller: :mass_invites_users
   end
 
   get ':login/history' => 'listens#index', :as => 'listens'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,6 +36,7 @@ Alonetone::Application.routes.draw do
         put :restore
       end
     end
+    resources :mass_invites
   end
 
   mount Thredded::Engine => '/forums'

--- a/db/migrate/20210118191751_create_mass_invites.rb
+++ b/db/migrate/20210118191751_create_mass_invites.rb
@@ -1,0 +1,14 @@
+class CreateMassInvites < ActiveRecord::Migration[6.1]
+  def change
+    create_table :mass_invites do |t|
+      t.text :name, null: false
+      t.string :token, null: false
+      t.boolean :archived, default: false, null: false
+      t.integer :users_count, default: 0, null: false
+
+      t.timestamps
+    end
+
+    add_index :mass_invites, :token, unique: true
+  end
+end

--- a/db/migrate/20210124191355_create_mass_invite_signups.rb
+++ b/db/migrate/20210124191355_create_mass_invite_signups.rb
@@ -1,0 +1,8 @@
+class CreateMassInviteSignups < ActiveRecord::Migration[6.1]
+  def change
+    create_table :mass_invite_signups do |t|
+      t.references :user
+      t.references :mass_invite
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_18_191751) do
+ActiveRecord::Schema.define(version: 2021_01_24_191355) do
 
   create_table "account_requests", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "email"
@@ -187,6 +187,13 @@ ActiveRecord::Schema.define(version: 2021_01_18_191751) do
     t.index ["listener_id"], name: "index_listens_on_listener_id"
     t.index ["track_owner_id", "created_at"], name: "index_listens_on_track_owner_id_and_created_at"
     t.index ["track_owner_id"], name: "index_listens_on_track_owner_id"
+  end
+
+  create_table "mass_invite_signups", charset: "utf8mb4", force: :cascade do |t|
+    t.bigint "user_id"
+    t.bigint "mass_invite_id"
+    t.index ["mass_invite_id"], name: "index_mass_invite_signups_on_mass_invite_id"
+    t.index ["user_id"], name: "index_mass_invite_signups_on_user_id"
   end
 
   create_table "mass_invites", charset: "utf8mb4", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_20_172437) do
+ActiveRecord::Schema.define(version: 2021_01_18_191751) do
 
   create_table "account_requests", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "email"
@@ -187,6 +187,16 @@ ActiveRecord::Schema.define(version: 2020_09_20_172437) do
     t.index ["listener_id"], name: "index_listens_on_listener_id"
     t.index ["track_owner_id", "created_at"], name: "index_listens_on_track_owner_id_and_created_at"
     t.index ["track_owner_id"], name: "index_listens_on_track_owner_id"
+  end
+
+  create_table "mass_invites", charset: "utf8mb4", force: :cascade do |t|
+    t.text "name", null: false
+    t.string "token", null: false
+    t.boolean "archived", default: false, null: false
+    t.integer "users_count", default: 0, null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["token"], name: "index_mass_invites_on_token", unique: true
   end
 
   create_table "memberships", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|

--- a/spec/controllers/concerns/user_creation_spec.rb
+++ b/spec/controllers/concerns/user_creation_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe UserCreation, type: :controller do
+  controller(ActionController::Base) do
+    include PreventAbuse
+    include UserCreation
+
+    def create
+      respond_with_user(
+        User.new(
+          email: 'jeremy@example.com',
+          login: 'Jeremy',
+          password: 'secret123-',
+          password_confirmation: 'secret123-'
+        )
+      )
+    end
+  end
+
+  before do
+    controller.request.env['HTTP_USER_AGENT'] = 'webkit'
+  end
+
+  context 'with user' do
+    before do
+      akismet_stub_response_ham
+      controller.request.remote_addr = '62.251.41.177'
+    end
+
+    it 'saves the record and redirects to the login page' do
+      expect { post :create }.to change(User, :count).by(+1)
+      expect(response).to redirect_to(login_url(already_joined: true))
+    end
+  end
+
+  context 'with user attributes marked as spam' do
+    before do
+      akismet_stub_response_spam
+      controller.request.remote_addr = '62.251.41.177'
+    end
+
+    it 'does not save the record and redirects to the login page' do
+      expect { post :create }.to_not change(User, :count)
+      expect(response).to redirect_to(login_url(already_joined: true))
+    end
+  end
+
+  context 'with user from a request identified as spammer' do
+    before do
+      akismet_stub_response_ham
+      controller.request.remote_addr = '121.14.1.1'
+    end
+
+    it 'does not save the record and redirects to the login page' do
+      expect { post :create }.to_not change(User, :count)
+      expect(response).to redirect_to(login_url(already_joined: true))
+    end
+  end
+end

--- a/spec/fixtures/mass_invites.yml
+++ b/spec/fixtures/mass_invites.yml
@@ -1,0 +1,28 @@
+williams_friends:
+  name: Bill's Friends
+  token: 5xNZ5M292hQSlGaH
+  archived: true
+  users_count: 0
+  created_at: <%= 1.year.ago %>
+  updated_at: <%= 1.year.ago %>
+cheese_eating_challenge:
+  name: Henri's Cheese Eating Challenge
+  token: OK22YhRGVbm6Vk4e
+  archived: false
+  users_count: 0
+  created_at: <%= 2.weeks.ago %>
+  updated_at: <%= 2.weeks.ago %>
+one_song:
+  name: One Song Per Hour Challenge
+  token: YOQPIYvl0aBGnX2g
+  archived: false
+  users_count: 12
+  created_at: <%= 1.week.ago %>
+  updated_at: <%= 1.week.ago %>
+november_invite:
+  name: Alonetone November User Extravaganza
+  token: KNw7OJjaMoVoQ6gp
+  archived: false
+  users_count: 5
+  created_at: <%= 1.minute.ago %>
+  updated_at: <%= 1.minute.ago %>

--- a/spec/helpers/admin_form_builder_spec.rb
+++ b/spec/helpers/admin_form_builder_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe AdminFormBuilder, type: :helper do
+  it 'renders a field div for an attribute without errors' do
+    record = User.new
+    html = form_for(record, builder: AdminFormBuilder) do |form|
+      form.field :login do
+        form.label_with_error :login
+      end
+    end
+    expect(html).to match_css('form > div.field > label[for="user_login"]')
+  end
+
+  it 'renders a field div for an attribute with an error' do
+    record = User.new
+    record.errors.add(:login, :blank)
+    html = form_for(record, builder: AdminFormBuilder) do |form|
+      form.field :login do
+        form.label_with_error :login
+      end
+    end
+    expect(html).to match_css('form > div.field.invalid label[for="user_login"]')
+  end
+end

--- a/spec/models/mass_invite_spec.rb
+++ b/spec/models/mass_invite_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe MassInvite, type: :model do
+  it 'sets a token after initialization' do
+    expect(MassInvite.new.token).to_not be_empty
+  end
+
+  it 'uses its token as the request param' do
+    mass_invite = MassInvite.new
+    expect(mass_invite.to_param).to eq(mass_invite.token)
+  end
+
+  context 'scopes' do
+    it 'orders mass invites by creation order' do
+      last = Time.zone.now
+      MassInvite.recent.each do |mass_invite|
+        expect(mass_invite.created_at).to be < last
+        last = mass_invite.created_at
+      end
+    end
+  end
+
+  context 'validation' do
+    let(:valid_mass_invite) do
+      MassInvite.new(name: 'One Song Per Year Challenge')
+    end
+
+    it 'should be valid with all required attributes' do
+      expect(valid_mass_invite).to be_valid
+    end
+
+    it 'should not allow a blank name' do
+      valid_mass_invite.name = ''
+      expect(valid_mass_invite).not_to be_valid
+      expect(valid_mass_invite.errors[:name]).to_not be_empty
+    end
+
+    it 'should not allow a blank token' do
+      valid_mass_invite.token = ''
+      expect(valid_mass_invite).not_to be_valid
+      expect(valid_mass_invite.errors[:token]).to_not be_empty
+    end
+  end
+end

--- a/spec/models/mass_invite_spec.rb
+++ b/spec/models/mass_invite_spec.rb
@@ -12,6 +12,20 @@ RSpec.describe MassInvite, type: :model do
     expect(mass_invite.to_param).to eq(mass_invite.token)
   end
 
+  context 'user count' do
+    it 'increases when creating a user' do
+      mass_invite = mass_invites(:cheese_eating_challenge)
+      expect do
+        mass_invite.users.create!(
+          login: 'Anisha',
+          email: 'anisha@example.com',
+          password: 'wonttell87$',
+          password_confirmation: 'wonttell87$'
+        )
+      end.to change(mass_invite, :users_count).by(+1)
+    end
+  end
+
   context 'scopes' do
     it 'orders mass invites by creation order' do
       last = Time.zone.now

--- a/spec/request/admin/mass_invites_controller_spec.rb
+++ b/spec/request/admin/mass_invites_controller_spec.rb
@@ -6,11 +6,20 @@ RSpec.describe Admin::MassInvitesController, type: :request do
       create_user_session(users(:sudara))
     end
 
-    it 'sees an overview of all mass invites' do
+    it 'sees an overview of all active mass invites' do
       get '/admin/mass_invites'
       expect(response).to have_http_status(:ok)
       expect(response).to render_template(:index)
       expect(response.body).to match_css('table')
+      expect(response.body).to match_css('tr', count: MassInvite.where(archived: false).count)
+    end
+
+    it 'sees an overview of all archived mass invites' do
+      get '/admin/mass_invites?filter_by=archived'
+      expect(response).to have_http_status(:ok)
+      expect(response).to render_template(:index)
+      expect(response.body).to match_css('table')
+      expect(response.body).to match_css('tr', count: MassInvite.where(archived: true).count)
     end
 
     it 'sees a form to create a new mass invite' do
@@ -36,13 +45,14 @@ RSpec.describe Admin::MassInvitesController, type: :request do
     end
 
     it 'sees validation errors when a mass invite creation fails' do
-        post(
-          '/admin/mass_invites',
-          params: { mass_invite: { name: '', token: '' } }
-        )
-        expect(response).to have_http_status(:ok)
-        expect(response).to render_template(:new)
-        expect(response.body).to match_css('div.field.invalid')
+      post(
+        '/admin/mass_invites',
+        params: { mass_invite: { name: '', token: '' } }
+      )
+      expect(response).to have_http_status(:ok)
+      expect(response).to render_template(:new)
+      expect(response.body).to match_css('div.field.invalid')
+    end
     end
   end
 

--- a/spec/request/admin/mass_invites_controller_spec.rb
+++ b/spec/request/admin/mass_invites_controller_spec.rb
@@ -1,0 +1,55 @@
+require 'rails_helper'
+
+RSpec.describe Admin::MassInvitesController, type: :request do
+  context 'an admin' do
+    before do
+      create_user_session(users(:sudara))
+    end
+
+    it 'sees an overview of all mass invites' do
+      get '/admin/mass_invites'
+      expect(response).to have_http_status(:ok)
+      expect(response).to render_template(:index)
+      expect(response.body).to match_css('table')
+    end
+
+    it 'sees a form to create a new mass invite' do
+      get '/admin/mass_invites/new'
+      expect(response).to have_http_status(:ok)
+      expect(response).to render_template(:new)
+      expect(response.body).to match_css('form')
+    end
+
+    it 'creates a new mass invite' do
+      expect do
+        post(
+          '/admin/mass_invites',
+          params: {
+            mass_invite: {
+              name: 'Christmas Surprise',
+              token: 'NiFhaXEn1NCAxmKC'
+            }
+          }
+        )
+      end.to change(MassInvite, :count).by(+1)
+      expect(response.status).to redirect_to(admin_mass_invites_url)
+    end
+
+    it 'sees validation errors when a mass invite creation fails' do
+        post(
+          '/admin/mass_invites',
+          params: { mass_invite: { name: '', token: '' } }
+        )
+        expect(response).to have_http_status(:ok)
+        expect(response).to render_template(:new)
+        expect(response.body).to match_css('div.field.invalid')
+    end
+  end
+
+  context 'a visitor' do
+    it 'must login before accessing the controller' do
+      get '/admin/mass_invites'
+      expect(response.status).to redirect_to(login_url)
+    end
+  end
+end

--- a/spec/request/admin/mass_invites_controller_spec.rb
+++ b/spec/request/admin/mass_invites_controller_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe Admin::MassInvitesController, type: :request do
           }
         )
       end.to change(MassInvite, :count).by(+1)
-      expect(response.status).to redirect_to(admin_mass_invites_url)
+      expect(response.status).to redirect_to(admin_mass_invites_url(filter_by: 'active'))
     end
 
     it 'sees validation errors when a mass invite creation fails' do
@@ -53,6 +53,25 @@ RSpec.describe Admin::MassInvitesController, type: :request do
       expect(response).to render_template(:new)
       expect(response.body).to match_css('div.field.invalid')
     end
+
+    it 'archives a mass invite' do
+      mass_invite = mass_invites(:cheese_eating_challenge)
+      patch(
+        "/admin/mass_invites/#{mass_invite.token}",
+        params: { mass_invite: { archived: true } }
+      )
+      expect(response.status).to redirect_to(admin_mass_invites_url(filter_by: 'active'))
+      expect(mass_invite.reload).to be_archived
+    end
+
+    it 'activates a mass invite' do
+      mass_invite = mass_invites(:williams_friends)
+      patch(
+        "/admin/mass_invites/#{mass_invite.token}",
+        params: { mass_invite: { archived: false } }
+      )
+      expect(response.status).to redirect_to(admin_mass_invites_url(filter_by: 'active'))
+      expect(mass_invite.reload).to_not be_archived
     end
   end
 

--- a/spec/request/mass_invites_users_controller_spec.rb
+++ b/spec/request/mass_invites_users_controller_spec.rb
@@ -70,9 +70,7 @@ RSpec.describe MassInvitesUsersController, type: :request do
 
     it 'shows a message that the mass invite is closed' do
       get "/mass_invites/#{mass_invite.token}/users/new"
-      expect(response).to have_http_status(:ok)
-      expect(response).to render_template(:archived)
-      expect(response.body).to match_css('h1')
+      expect(response).to redirect_to('/get_an_account')
     end
   end
 end

--- a/spec/request/mass_invites_users_controller_spec.rb
+++ b/spec/request/mass_invites_users_controller_spec.rb
@@ -1,0 +1,76 @@
+require "rails_helper"
+
+RSpec.describe MassInvitesUsersController, type: :request do
+  context 'active mass invite' do
+    let(:mass_invite) { mass_invites(:november_invite) }
+
+    it 'shows a form to create a new user' do
+      get "/mass_invites/#{mass_invite.token}/users/new"
+      expect(response).to have_http_status(:ok)
+      expect(response).to render_template(:new)
+      expect(response.body).to match_css('form')
+    end
+
+    it 'creates a new user' do
+      akismet_stub_response_ham
+      expect do
+        post(
+          "/mass_invites/#{mass_invite.token}/users",
+          params: {
+            user: {
+              email: 'jeremy@example.com',
+              login: 'Jeremy',
+              password: 'secret123-',
+              password_confirmation: 'secret123-'
+            }
+          },
+          headers: {
+            'x-forwarded-for' => '62.251.41.177',
+            'user-agent' => 'webkit'
+          }
+        )
+      end.to change(User, :count).by(+1)
+      expect(response).to redirect_to(login_url(already_joined: true))
+    end
+
+    it 'shows validation errors when creation failed' do
+      akismet_stub_response_ham
+      expect do
+        post(
+          "/mass_invites/#{mass_invite.token}/users",
+          params: {
+            user: {
+              email: '',
+              login: '',
+              password: '',
+              password_confirmation: ''
+            }
+          },
+          headers: {
+            'x-forwarded-for' => '62.251.41.177',
+            'user-agent' => 'webkit'
+          }
+        )
+      end.to_not change(User, :count)
+      expect(response).to have_http_status(:ok)
+      expect(response).to render_template(:new)
+      expect(response.body).to match_css('div.inline_form_error')
+    end
+
+    it 'redirects to the form when someone enters the URL from a failed creation request' do
+      get "/mass_invites/#{mass_invite.token}/users"
+      expect(response).to redirect_to(new_mass_invite_users_url(mass_invite))
+    end
+  end
+
+  context 'archived mass invite' do
+    let(:mass_invite) { mass_invites(:williams_friends) }
+
+    it 'shows a message that the mass invite is closed' do
+      get "/mass_invites/#{mass_invite.token}/users/new"
+      expect(response).to have_http_status(:ok)
+      expect(response).to render_template(:archived)
+      expect(response.body).to match_css('h1')
+    end
+  end
+end

--- a/spec/request/mass_invites_users_controller_spec.rb
+++ b/spec/request/mass_invites_users_controller_spec.rb
@@ -14,22 +14,24 @@ RSpec.describe MassInvitesUsersController, type: :request do
     it 'creates a new user' do
       akismet_stub_response_ham
       expect do
-        post(
-          "/mass_invites/#{mass_invite.token}/users",
-          params: {
-            user: {
-              email: 'jeremy@example.com',
-              login: 'Jeremy',
-              password: 'secret123-',
-              password_confirmation: 'secret123-'
+        expect do
+          post(
+            "/mass_invites/#{mass_invite.token}/users",
+            params: {
+              user: {
+                email: 'jeremy@example.com',
+                login: 'Jeremy',
+                password: 'secret123-',
+                password_confirmation: 'secret123-'
+              }
+            },
+            headers: {
+              'x-forwarded-for' => '62.251.41.177',
+              'user-agent' => 'webkit'
             }
-          },
-          headers: {
-            'x-forwarded-for' => '62.251.41.177',
-            'user-agent' => 'webkit'
-          }
-        )
-      end.to change(User, :count).by(+1)
+          )
+        end.to change(User, :count).by(+1)
+      end.to change { mass_invite.reload.users_count }.by(+1)
       expect(response).to redirect_to(login_url(already_joined: true))
     end
 


### PR DESCRIPTION
* Adds `MassInvite` for mass invites and `MassInviteSignup` to count users signups through the mass invite.
* Adds admin controllers and views to manage mass invites.
* Adds a user's origin so you can see if they were mass invites, invited, or were born from the dark dark void.
* Allow users to create an account through an active mass invite link.
* Move the user creation spam stuff into a concern in case we need it for other controllers that create accounts and maybe refactor the users controller<sup>1</sup>.


Frontend Todos

* [x] Blank slate copy
* [x] Prettier route
* [x] After user creation, make it clear user needs to check email
* [x] Password fields should be on top of each other
* [x] Check out expired invite situation / copy
* [ ] QA whole flow as a n00b guest
* [x] "show" page for the mass invite that lists users? Or subcategory for mass-invited signups under "All Users" in admin
* [x] @ofsound can look at admin form (might be unifying forms across the site)

References #1088

---

* <sup>1</sup> It looks like all the `flash` related code in the users controller doesn't do anything because it's not show on the login page.