### PR TITLE
Use find_by_login_method to configure Authlogic

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -178,8 +178,8 @@ class User < ApplicationRecord
     User.where(current_login_ip: user.current_login_ip).where('id != ?', user.id)
   end
 
-  def self.find_by_login_or_email(login)
-    User.find_by_login(login) || User.find_by_email(login)
+  def self.find_by_login_or_email(login_or_email)
+    User.where(login: login_or_email).or(User.where(email: login_or_email)).first
   end
 
   def listened_to_today_ids

--- a/app/models/user_session.rb
+++ b/app/models/user_session.rb
@@ -1,5 +1,5 @@
 class UserSession < Authlogic::Session::Base
-  find_by_login_method :find_by_login_or_email
+  record_selection_method :find_by_login_or_email
 
   # override authlogic's version of this to take into account @sudo
   def update_info

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -14,6 +14,18 @@ RSpec.describe User, type: :model do
     end
   end
 
+  describe 'record selection method' do
+    it 'finds a user by login' do
+      user = users(:henri_willig)
+      expect(User.find_by_login_or_email(user.login)).to eq(user)
+    end
+
+    it 'finds a user by email' do
+      user = users(:henri_willig)
+      expect(User.find_by_login_or_email(user.email)).to eq(user)
+    end
+  end
+
   describe 'scopes' do
     it 'include profile and avatar image to prevent n+1 queries' do
       expect do


### PR DESCRIPTION
Rails said:

```
DEPRECATION WARNING: find_by_login_method is deprecated in favor of record_selection_method, to avoid confusion with ActiveRecord's "Dynamic Finders". (https://guides.rubyonrails.org/v6.0/active_record_querying.html#dynamic-finders) For example, rubocop-rails is confused by the deprecated method. (https://github.com/rubocop-hq/rubocop-rails/blob/master/lib/rubocop/cop/rails/dynamic_find_by.rb) (called from <class:UserSession> at /Users/manfred/Code/alonetone/app/models/user_session.rb:2)
```

* Replaces with `find_by_login_method ` with `record_selection_method` when configuring the method in `UserSession`.
* Change `User.find_by_login_or_email` to use one query to find the user.
* Add some tests.

I tested this locally by logging in with login and email. I also made sure you can't login with a black username and valid password.