### PR TITLE
Use Ruby on Rails 6.1 way of iterating error messages

### DIFF
--- a/app/controllers/assets_controller.rb
+++ b/app/controllers/assets_controller.rb
@@ -124,7 +124,6 @@ class AssetsController < ApplicationController
         asset.update_attribute(:is_spam, asset.spam?) # makes an api call
         at_least_one_upload = true
       else
-        errors = asset.errors.full_messages.join('.')
         flashes += "'#{CGI.escapeHTML asset.mp3_file_name}' failed to upload. Please double check that it's an Mp3.<br/>"
       end
     end

--- a/app/views/assets/_edit.html.erb
+++ b/app/views/assets/_edit.html.erb
@@ -1,15 +1,6 @@
 <%= form_with(model: asset, url: "/#{@user.login}/tracks/#{asset.id}",
   local: (true unless @assets), data: { action: 'ajax:beforeSend->save#spin ajax:success->save#success ajax:error->save#error ajax:complete->save#complete' }) do |f| %>
-  <% if asset.errors.any? %>
-    <div class="errors">
-      There were some problems...
-      <ul>
-        <% asset.errors.full_messages.each do |message| %>
-          <li><%= message %></li>
-        <% end %>
-      </ul>
-    </div>
-  <% end %>
+  <%= render partial: 'shared/errors', locals: { errors: asset.errors } %>
 
   <div class="track_edit">
     <header>

--- a/app/views/password_resets/edit.html.erb
+++ b/app/views/password_resets/edit.html.erb
@@ -1,20 +1,5 @@
 <div class="box password_reset">
-  <% if @user.errors.any? %>
-    <div id="error_explanation">
-      <h3>
-      <% if @user.errors.size == 1 %>
-        One minor thing looks off:
-      <% else %>
-        Just a couple things to tweak:
-      <% end %>
-      </h3>
-      <ol>
-      <% @user.errors.full_messages.each do |msg| %>
-        <li><%= msg %></li>
-      <% end %>
-      </ol>
-    </div>
-  <% end %>
+  <%= render partial: 'shared/errors', locals: { errors: @user.errors } %>
   <% if @newly_invited_user %>
   <h2>Pick a password and you can start uploading!</h2>
   <% else %>

--- a/app/views/shared/_errors.html.erb
+++ b/app/views/shared/_errors.html.erb
@@ -8,8 +8,8 @@
     <% end %>
     </h3>
     <ol>
-    <% errors.full_messages.each do |msg| %>
-      <li><%= msg %></li>
+    <% errors.each do |error| %>
+      <li><%= error.full_message %></li>
     <% end %>
     </ol>
   </div>


### PR DESCRIPTION
* Use the 6.1 way of iterating error message in the shared error partial.
* Use the shared error partial in views that had their own implementation.
* Remove dead error code form the assets controller.

This leaves one case that is in the Authlogic gem.