### PR TITLE
Make two quick fixes after the GSAP tracks_reveal merge into Master

### DIFF
--- a/app/assets/stylesheets/components/tracks.scss
+++ b/app/assets/stylesheets/components/tracks.scss
@@ -220,11 +220,12 @@
     }
   }
   .tracks_reveal {
+    display: none;
     position: relative;
     margin-top: -361px; // good default, js will tweak
     overflow: auto;
     box-sizing: border-box;
-    display: none;
+    z-index: 0;
     a.add_to_favorites,
     a.favorited {
       position: absolute;

--- a/app/javascript/controllers/normal_playback_controller.js
+++ b/app/javascript/controllers/normal_playback_controller.js
@@ -76,6 +76,7 @@ export default class extends PlaybackController {
         duration: 0.25,
         marginTop: 0,
         ease: 'power4.inOut',
+        display: 'block',
       })
       if (this.alreadyPlayed) {
         this.seekBarContainerTarget.classList.add('show')


### PR DESCRIPTION

Add a z-index to track_reveal so all those contents stay below the asset_top

Add an extra display: block to safe guard against a broken state that could result from a quick open>close>open click on an accordion track

## "Ready For Review" checklist

These checklists are to help ensure the code review basics are covered. Consider removing to reduce noise.

* [ ] PR title accurately summarizes changes
* [ ] New tests were added for isolated methods or new endpoints
* [ ] I opened an issue for any logical followups
* [ ] If this fixes a bug, "Fixes #XXX" is either the very first or very last line of the description.

## Before code review *and after additional commits* during review.

* [ ] Update title and description to account for additional changes
* [ ] All tests green
* [ ] Migrations were tested locally and do the right thing
* [ ] Booted up the branch locally, exercised any new code
* [ ] Percy changes are purposeful or explained
* [ ] Css changes are happy on mobile (via Percy is ok)
