### PR TITLE
Fixes for .flash padding, track description padding, footer collapsing

### DIFF
--- a/app/assets/stylesheets/components/notifications.scss
+++ b/app/assets/stylesheets/components/notifications.scss
@@ -14,7 +14,7 @@
   line-height: 1.2;
   position: relative;
   z-index: 101;
-  padding: 15px 0;
+  padding: 15px 15px;
   text-align: center;
   color: $flash-text;
   background-color: $accent;

--- a/app/assets/stylesheets/components/site_footer.scss
+++ b/app/assets/stylesheets/components/site_footer.scss
@@ -1,4 +1,4 @@
-$footer-collapse: 'only screen and (max-width: 952px)';
+$footer-collapse: 'only screen and (max-width: 975px)';
 
 footer#site_footer {
   font-size: 13px;

--- a/app/assets/stylesheets/components/tracks.scss
+++ b/app/assets/stylesheets/components/tracks.scss
@@ -272,7 +272,6 @@
         .user_description {
           color: $track-description-text;
           margin-right: 26px;
-          min-height:16px;
           word-wrap: break-word;
           -webkit-hyphens: auto;
           -moz-hyphens: auto;

--- a/app/assets/stylesheets/components/tracks.scss
+++ b/app/assets/stylesheets/components/tracks.scss
@@ -307,7 +307,7 @@
         .below_description {
           display: flex;
           justify-content: space-between;
-          height: 24px;
+          height: 28px;
           margin-top: auto;
           a {
             font-size: 12px;

--- a/app/assets/stylesheets/components/tracks.scss
+++ b/app/assets/stylesheets/components/tracks.scss
@@ -237,6 +237,7 @@
     }
     .tracks_reveal_top {
       display: flex;
+      min-height: 67px;
       margin-right: 10px;
       margin-left: 10px;
       margin-bottom: 9px;

--- a/app/assets/stylesheets/components/tracks.scss
+++ b/app/assets/stylesheets/components/tracks.scss
@@ -270,6 +270,8 @@
         line-height: 17px;
         margin-right: 0;
         flex: 1;
+        display: flex;
+        flex-direction: column;
         .user_description {
           color: $track-description-text;
           margin-right: 26px;
@@ -306,6 +308,7 @@
           display: flex;
           justify-content: space-between;
           height: 24px;
+          margin-top: auto;
           a {
             font-size: 12px;
             display: block;


### PR DESCRIPTION
Fixes #1109
Fixes #1104

*Deploying requires a cache clear*

Fixes an issue I've noticed on iPad where a flash message is the exact width of the screen, revealing the lack of padding.

Seems that extra padding ( actually a min-height ) of the user_description was also preserving the bottom alignment of the Track details and Listen and Favorite section within an accordion track.

I could maybe separate that section from the top down lay outing, and have it stuck to the bottom of that container rather than preserving a fixed distance below the date, or it could float a bit higher as it appears in the 2nd screenshot.

<img width="482" alt="Screen Shot 2021-03-02 at 4 54 51 PM" src="https://user-images.githubusercontent.com/407724/109731226-185d6d00-7b78-11eb-98e2-7aceb71e82df.png">

<img width="459" alt="Screen Shot 2021-03-02 at 4 54 45 PM" src="https://user-images.githubusercontent.com/407724/109731233-1a273080-7b78-11eb-8f50-4fe184c13725.png">




## "Ready For Review" checklist

These checklists are to help ensure the code review basics are covered. Consider removing to reduce noise.

* [ ] PR title accurately summarizes changes
* [ ] New tests were added for isolated methods or new endpoints
* [ ] I opened an issue for any logical followups
* [ ] If this fixes a bug, "Fixes #XXX" is either the very first or very last line of the description.

## Before code review *and after additional commits* during review.

* [ ] Update title and description to account for additional changes
* [ ] All tests green
* [ ] Migrations were tested locally and do the right thing
* [ ] Booted up the branch locally, exercised any new code
* [ ] Percy changes are purposeful or explained
* [ ] Css changes are happy on mobile (via Percy is ok)
