### PR TITLE
Pull in latest topics from discourse

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,6 +10,8 @@
   <%= stylesheet_link_tag 'application', disabled: dark_theme? %>
   <%= stylesheet_link_tag 'dark_theme', disabled: light_theme? %>
   <%= javascript_pack_tag "application", 'data-turbolinks-track': 'reload', defer: true  %>
+  <script src="https://forum.alonetone.com/javascripts/embed-topics.js" defer></script>
+
   <%= csrf_meta_tag %>
   <%= render partial: 'shared/javascript_payload' %>
   <%= render partial: 'shared/analytics' %>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -11,13 +11,17 @@
 
 <% if logged_in? %>
 <div class="footer_forum_topics" data-turbolinks="false">
+
   <div class="footer_forum_topics_inner">
-    <a href="/forums" class="forum_view_all">
-        View all... &nbsp;<i class="icon_caret">
+    <a href="https://forum.alonetone.com" class="forum_view_all">
+        View all on the forum &nbsp;<i class="icon_caret">
         <%== render file: svg_path('svg/icon_caret.svg') %>
         </i>
     </a>
     <h3>Latest forum topics</h3>
+      <d-topics-list discourse-url="https://forum.alonetone.com" per-page="4" template="complete">
+    </d-topics-list>
+    <!--
     <ul>
     <% latest_forum_topics.each do |topic|  %>
       <li>
@@ -27,6 +31,7 @@
       </li>
     <% end %>
     </ul>
+    -->
   </div>
 </div>
 <% end %>


### PR DESCRIPTION
[insert @ofsound magic here]

We can pull in the latest topics and style with discourse's embedded css: https://forum.alonetone.com/admin/customize/themes/1/common/embedded_scss/edit

Supporting both themes might be awkward? Not sure it's going to be possible to get that info through the iframe without some js...
