### PR TITLE
Update animation_heart and favorite counts when favoriting

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -84,7 +84,9 @@ class UsersController < ApplicationController
 
     current_user.toggle_favorite(asset)
     respond_to do |format|
-      format.turbo_stream { render turbo_stream: '' }
+      format.turbo_stream do
+        render turbo_stream: turbo_stream.update_all(".faved-#{asset.id}", asset.reload.favorites_count)
+      end
     end
   end
 

--- a/app/javascript/controllers/favorite_controller.js
+++ b/app/javascript/controllers/favorite_controller.js
@@ -5,7 +5,29 @@ export default class extends HeartController {
     id: Number,
   }
 
+  connect() {
+    // access controller from child element
+    this.element[this.identifier] = this
+  }
+
   isFavorited() {
     return window.userFavorites.includes(this.idValue)
+  }
+
+  toggle({broadcast=true}) {
+    super.toggle()
+
+    if (broadcast)
+      this.broadcast()
+  }
+
+  broadcast() {
+    const matches = document.querySelectorAll(`[data-favorite-id-value="${this.idValue}"]`)
+    matches.forEach((element) => {
+      if (element === this.element)
+        return
+
+      element.favorite.toggle({broadcast: false})
+    })
   }
 }

--- a/app/views/assets/_asset.html.erb
+++ b/app/views/assets/_asset.html.erb
@@ -84,10 +84,13 @@
           </i>
           </div>
 
-          <div class="favorites"><%= asset.favorites_count %>
-              <i class="icon_favs">
+          <div class="favorites">
+            <div class="<%= "faved-#{asset.id}"%>">
+              <%= asset.favorites_count %>
+            </div>
+            <i class="icon_favs">
               <%== render file: svg_path('svg/icon_favorite_inverted.svg') %>
-              </i>
+            </i>
           </div>
         </div>
     </div>

--- a/app/views/shared/_asset.html.erb
+++ b/app/views/shared/_asset.html.erb
@@ -50,7 +50,9 @@
         <i class="icon_favs">
           <%== render file: svg_path('svg/icon_favorite_inverted.svg') %>
         </i>
-        <%= @asset.favorites_count %>
+        <div class="<%= "faved-#{@asset.id}"%>">
+          <%= @asset.favorites_count %>
+        </div>
       </div>
       <div class="plays">
         <i class="icon_plays">


### PR DESCRIPTION
When favoriting an asset, the favorite count does not update until you refresh the page.

In addition, if the asset/mp3 is displayed in multiple sections: "latest uploads", "recently favorited", "latest comments", the other instances of that asset do not get updated (heart svg does not update).

For the favorite counts, I added a turbo_stream update action to update count without having to refresh the page.

For the animation_heart state, I updated stimulus controller to broadcast to other instances of the same asset/mp3 to also toggle.
