### PR TITLE
Heart toggles

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -84,7 +84,9 @@ class UsersController < ApplicationController
 
     current_user.toggle_favorite(asset)
     respond_to do |format|
-      format.turbo_stream { render turbo_stream: '' }
+      format.turbo_stream do
+        render turbo_stream: turbo_stream.update_all(".faved-#{asset.id}", asset.reload.favorites_count)
+      end
     end
   end
 

--- a/app/javascript/controllers/favorite_controller.js
+++ b/app/javascript/controllers/favorite_controller.js
@@ -8,4 +8,13 @@ export default class extends HeartController {
   isFavorited() {
     return window.userFavorites.includes(this.idValue)
   }
+
+  broadcast(e) {
+    this.dispatch('broadcasted', { detail: { id: this.idValue }, target: window })
+  }
+
+  toggle(e) {
+    if (this.idValue === e.detail.id)
+      super.toggle()
+  }
 }

--- a/app/javascript/controllers/favorite_controller.js
+++ b/app/javascript/controllers/favorite_controller.js
@@ -5,16 +5,16 @@ export default class extends HeartController {
     id: Number,
   }
 
+  static outlets = [ "favorite" ]
+
   isFavorited() {
     return window.userFavorites.includes(this.idValue)
   }
 
-  broadcast(e) {
-    this.dispatch('broadcasted', { detail: { id: this.idValue }, target: window })
-  }
-
-  toggle(e) {
-    if (this.idValue === e.detail.id)
-      super.toggle()
+  broadcast() {
+    this.favoriteOutlets.forEach((result) => {
+      if (this.idValue == result.idValue)
+        result.toggle()
+    })
   }
 }

--- a/app/views/assets/_asset.html.erb
+++ b/app/views/assets/_asset.html.erb
@@ -56,7 +56,7 @@
     <%= button_to toggle_favorite_path(asset_id: asset.id), class: 'add_to_favorites',
       method: :put, data: {
         controller: 'favorite',
-        action: 'favorite#toggle',
+        action: 'favorite#broadcast favorite:broadcasted@window->favorite#toggle',
         'favorite-id-value': asset.id
       } do %>
       <%== render file: svg_path('svg/animation_heart.svg') %>

--- a/app/views/assets/_asset.html.erb
+++ b/app/views/assets/_asset.html.erb
@@ -84,10 +84,13 @@
           </i>
           </div>
 
-          <div class="favorites"><%= asset.favorites_count %>
-              <i class="icon_favs">
+          <div class="favorites">
+            <div class="<%= "faved-#{asset.id}"%>">
+              <%= asset.favorites_count %>
+            </div>
+            <i class="icon_favs">
               <%== render file: svg_path('svg/icon_favorite_inverted.svg') %>
-              </i>
+            </i>
           </div>
         </div>
     </div>

--- a/app/views/assets/_asset.html.erb
+++ b/app/views/assets/_asset.html.erb
@@ -56,8 +56,9 @@
     <%= button_to toggle_favorite_path(asset_id: asset.id), class: 'add_to_favorites',
       method: :put, data: {
         controller: 'favorite',
-        action: 'favorite#broadcast favorite:broadcasted@window->favorite#toggle',
-        'favorite-id-value': asset.id
+        action: 'favorite#broadcast',
+        'favorite-id-value': asset.id,
+        'favorite-favorite-outlet': ".add_to_favorites"
       } do %>
       <%== render file: svg_path('svg/animation_heart.svg') %>
     <% end %>

--- a/app/views/shared/_asset.html.erb
+++ b/app/views/shared/_asset.html.erb
@@ -50,7 +50,9 @@
         <i class="icon_favs">
           <%== render file: svg_path('svg/icon_favorite_inverted.svg') %>
         </i>
-        <%= @asset.favorites_count %>
+        <div class="<%= "faved-#{@asset.id}"%>">
+          <%= @asset.favorites_count %>
+        </div>
       </div>
       <div class="plays">
         <i class="icon_plays">
@@ -125,3 +127,4 @@
   <% end %>
 </div>
 </turbo-frame>
+


### PR DESCRIPTION
Hello! Sorry, I missed your last message.  Here's a fresh PR to update favorite counts and heart animations.

First commit is to update favorite counts using turbo streams.

Second and third commits are two different ways of updating heart toggle: one by custom events and the other by Stimulus Outlets API.

My understanding is that custom events used to be idiomatic way to handle cross controller communications in Stimulus before they release Outlets API with Stimulus 3.2.
