### PR TITLE
Reserved words

### DIFF
--- a/app/assets/stylesheets/components/admin.scss
+++ b/app/assets/stylesheets/components/admin.scss
@@ -273,7 +273,9 @@
       padding: 0.375em 0.5em;
     }
   }
-  form.new_mass_invite {
-    padding: 0 1em;
+  form {
+    &.new_mass_invite, &.new_reserved_word {
+      padding: 0 1em;
+    }
   }
 }

--- a/app/controllers/admin/reserved_words_controller.rb
+++ b/app/controllers/admin/reserved_words_controller.rb
@@ -1,0 +1,38 @@
+module Admin
+  class ReservedWordsController < Admin::BaseController
+    before_action :find_reserved_word, only: %i[delete]
+
+    def index
+        @pagy, @reserved_words = pagy(ReservedWord.all)
+    end
+
+    def new
+      @reserved_word = ReservedWord.new
+    end
+
+    def create
+      @reserved_word = ReservedWord.new(reserved_word_params)
+      
+      if @reserved_word.save
+        redirect_to admin_reserved_words_url
+      else
+        render :new
+      end
+    end
+
+    def delete
+      @reserved_word.destroy
+      redirect_to admin_reserved_words_url
+    end
+
+    private
+    
+    def find_reserved_word
+      @reserved_word = ReservedWord.find(params[:id])
+    end
+
+    def reserved_word_params
+      params.require(:reserved_word).permit(:name)
+    end
+  end
+end

--- a/app/controllers/admin/reserved_words_controller.rb
+++ b/app/controllers/admin/reserved_words_controller.rb
@@ -1,9 +1,9 @@
 module Admin
   class ReservedWordsController < Admin::BaseController
-    before_action :find_reserved_word, only: %i[delete]
+    before_action :find_reserved_word, only: %i[destroy]
 
     def index
-        @pagy, @reserved_words = pagy(ReservedWord.all)
+      @pagy, @reserved_words = pagy(ReservedWord.all)
     end
 
     def new
@@ -12,7 +12,6 @@ module Admin
 
     def create
       @reserved_word = ReservedWord.new(reserved_word_params)
-      
       if @reserved_word.save
         redirect_to admin_reserved_words_url
       else
@@ -20,19 +19,19 @@ module Admin
       end
     end
 
-    def delete
+    def destroy
       @reserved_word.destroy
       redirect_to admin_reserved_words_url
     end
 
     private
-    
+
     def find_reserved_word
       @reserved_word = ReservedWord.find(params[:id])
     end
 
     def reserved_word_params
-      params.require(:reserved_word).permit(:name)
+      params.require(:reserved_word).permit(:name, :details)
     end
   end
 end

--- a/app/models/account_request.rb
+++ b/app/models/account_request.rb
@@ -33,40 +33,34 @@ class AccountRequest < ApplicationRecord
 
   validates :entity_type, inclusion: {
     in: entity_types,
-    message: "We need to know what sort of thing you want to upload!"
+    message: :unselected_entity_type
   }
 
   validates :email,
     on: :create,
     format: {
       with: URI::MailTo::EMAIL_REGEXP,
-      message: "should look like an email address."
+      message: :invalid_regex
     }
   validate :email_is_unique, on: :create
 
   validates :login,
     on: :create,
+    login_is_allowed: true,
     format: {
       with: /\A\w+\z/,
-      message: "should use only letters and numbers."
+      message: :must_be_alphanumeric
     }
-  validate :login_is_unique, on: :create
 
   validates :details, length: {
     on: :create,
     minimum: 40,
-    too_short: "must be at least 40 characters: Please link to your music/website or add more info!"
+    too_short: :details_too_short
   }
 
   def email_is_unique
     if User.where(email: email).exists?
-      errors.add(:email, "You already have an account on alonetone!")
-    end
-  end
-
-  def login_is_unique
-    if User.where(login: login).exists?
-      errors.add(:login, "Sorry, login is taken. Be creative!")
+      errors.add(:email, :duplicate_account)
     end
   end
 

--- a/app/models/reserved_word.rb
+++ b/app/models/reserved_word.rb
@@ -1,0 +1,22 @@
+class ReservedWord < ApplicationRecord
+  validates :name, presence: true
+
+  def contains(search)
+    Regexp.new(name, Regexp::IGNORECASE).match(search)
+  end
+end
+
+# == Schema Information
+#
+# Table name: reserved_words
+#
+#  id          :bigint(8)         not null, primary key
+#  name        :string(255)       not null
+#  details     :text
+#  created_at  :datetime          not null
+#  updated_at  :datetime          not null
+#
+# Indexes
+#
+#  index_reserved_words_on_name  (name) UNIQUE
+#

--- a/app/models/reserved_word.rb
+++ b/app/models/reserved_word.rb
@@ -1,8 +1,22 @@
 class ReservedWord < ApplicationRecord
+  # Names are admin-entered regexes matched on the signup path, so cap match time against catastrophic backtracking.
+  MATCH_TIMEOUT = 0.5
+
   validates :name, presence: true
+  validate :name_is_a_valid_regexp
 
   def contains(search)
-    Regexp.new(name, Regexp::IGNORECASE).match(search)
+    Regexp.new(name, Regexp::IGNORECASE, timeout: MATCH_TIMEOUT).match?(search)
+  rescue RegexpError
+    false
+  end
+
+  private
+
+  def name_is_a_valid_regexp
+    Regexp.new(name) if name.present?
+  rescue RegexpError
+    errors.add(:name, :invalid_regexp)
   end
 end
 
@@ -10,11 +24,11 @@ end
 #
 # Table name: reserved_words
 #
-#  id          :bigint(8)         not null, primary key
-#  name        :string(255)       not null
-#  details     :text
-#  created_at  :datetime          not null
-#  updated_at  :datetime          not null
+#  id         :bigint(8)        not null, primary key
+#  details    :text(65535)
+#  name       :string(255)      not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
 #
 # Indexes
 #

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -33,11 +33,10 @@ class User < ApplicationRecord
       message: "should use only letters and numbers."
     },
     length: { within: 3..100 },
-    uniqueness: {
-      case_sensitive: false,
+    login_is_allowed: {
       if: :will_save_change_to_login?
     }
-
+  
   validates :password,
     confirmation: { if: :require_password? },
     length: {

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -36,7 +36,7 @@ class User < ApplicationRecord
     login_is_allowed: {
       if: :will_save_change_to_login?
     }
-  
+
   validates :password,
     confirmation: { if: :require_password? },
     length: {

--- a/app/validators/login_is_allowed_validator.rb
+++ b/app/validators/login_is_allowed_validator.rb
@@ -1,0 +1,38 @@
+class LoginIsAllowedValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    if !login_is_unique(value)
+      record.errors.add(attribute, :login_not_unique)
+    end
+
+    if !login_is_allowed(value)
+      record.errors.add(attribute, :login_not_allowed)
+    end
+  end
+  
+  def login_is_allowed(login)
+    return !login_contains_reserved_words(login) && !login_contains_route_part(login)
+  end
+  
+  def login_is_unique(login)
+    if User.where(login: login).exists?
+      return false
+    end
+
+    if AccountRequest.where(login: login).exists?
+      return false
+    end
+
+    true
+  end
+
+  def login_contains_reserved_words(login)
+    ReservedWord.find_each.any? { |rw| rw.contains(login) }
+  end
+
+  def login_contains_route_part(login)
+    Rails.application.routes.routes.any? {|route|
+      route = route.path.spec.to_s
+      route.split(/[^\w]/).reject(&:empty?).any? { |part| login == part }
+    }
+  end
+end

--- a/app/validators/login_is_allowed_validator.rb
+++ b/app/validators/login_is_allowed_validator.rb
@@ -1,38 +1,48 @@
 class LoginIsAllowedValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
-    if !login_is_unique(value)
-      record.errors.add(attribute, :login_not_unique)
-    end
+    return if value.blank?
 
-    if !login_is_allowed(value)
-      record.errors.add(attribute, :login_not_allowed)
-    end
-  end
-  
-  def login_is_allowed(login)
-    return !login_contains_reserved_words(login) && !login_contains_route_part(login)
-  end
-  
-  def login_is_unique(login)
-    if User.where(login: login).exists?
-      return false
-    end
-
-    if AccountRequest.where(login: login).exists?
-      return false
-    end
-
-    true
+    record.errors.add(attribute, :login_not_unique) unless login_is_unique?(record, value)
+    record.errors.add(attribute, :login_not_allowed) unless login_is_allowed?(value)
   end
 
-  def login_contains_reserved_words(login)
-    ReservedWord.find_each.any? { |rw| rw.contains(login) }
+  private
+
+  def login_is_unique?(record, login)
+    !other_user_has_login?(record, login) && !pending_request_reserves_login?(record, login)
   end
 
-  def login_contains_route_part(login)
-    Rails.application.routes.routes.any? {|route|
-      route = route.path.spec.to_s
-      route.split(/[^\w]/).reject(&:empty?).any? { |part| login == part }
-    }
+  def other_user_has_login?(record, login)
+    scope = User.where(login: login)
+    scope = scope.where.not(id: record.id) if record.is_a?(User) && record.persisted?
+    scope.exists?
+  end
+
+  # A user is created from an approved account request that shares its login, so a
+  # request only reserves a login while waiting, and only against other requests.
+  def pending_request_reserves_login?(record, login)
+    return false if record.is_a?(User)
+
+    scope = AccountRequest.waiting.where(login: login)
+    scope = scope.where.not(id: record.id) if record.is_a?(AccountRequest) && record.persisted?
+    scope.exists?
+  end
+
+  def login_is_allowed?(login)
+    !login_contains_reserved_word?(login) && !login_matches_route_segment?(login)
+  end
+
+  def login_contains_reserved_word?(login)
+    ReservedWord.find_each.any? { |reserved_word| reserved_word.contains(login) }
+  end
+
+  def login_matches_route_segment?(login)
+    self.class.route_segments.include?(login)
+  end
+
+  def self.route_segments
+    @route_segments ||= Rails.application.routes.routes.flat_map { |route|
+      route.path.spec.to_s.split(/[^\w]/)
+    }.reject(&:empty?).to_set
   end
 end

--- a/app/views/admin/_navigation.html.erb
+++ b/app/views/admin/_navigation.html.erb
@@ -36,6 +36,7 @@
     <%= navigation_item 'Not Spam', admin_comments_path({filter_by: {is_spam: false}}) %>
   </ul>
 
+  <li><%= navigation_item "Reserved Words <span>#{ReservedWord.count}</span>", admin_reserved_words_path %></li>
   <li><%= link_to "Secretz", "/secretz" %></li>
   <li><%= link_to "Akismet Stats", "https://akismet.com/web/1.0/user-stats.php?blog=alonetone.com&api_key=#{Rails.configuration.alonetone.rakismet_key}"%></li>
   <li><%= link_to "Postmark Stats", "https://account.postmarkapp.com/servers/2804035/streams" %></li>

--- a/app/views/admin/reserved_words/_form.html.erb
+++ b/app/views/admin/reserved_words/_form.html.erb
@@ -1,0 +1,14 @@
+<%= form_for([:admin, @reserved_word], builder: AdminFormBuilder) do |form| %>
+  <%= form.field :name do %>
+    <%= form.label_with_error :name %>
+    <%= form.text_field :name %>
+  <% end %>
+  <%= form.field :details do %>
+    <%= form.label_with_error :details %>
+    <%= form.text_field :details %>
+  <% end %>
+  <ul class="actions submit">
+    <li><%= form.submit 'Create reserved word' %></li>
+    <li><%= link_to 'Cancel', admin_reserved_words_path %></li>
+  </ul>
+<% end %>

--- a/app/views/admin/reserved_words/_reserved_word.html.erb
+++ b/app/views/admin/reserved_words/_reserved_word.html.erb
@@ -1,0 +1,5 @@
+<tr>
+  <td><%= reserved_word.name %></div>
+  <td><%= l(reserved_word.created_at, format: :short) %></td>
+  <td><%= button_to "Delete Reserved Word", delete_admin_reserved_word_path(reserved_word), method: :put %></td>
+  </tr>

--- a/app/views/admin/reserved_words/_reserved_word.html.erb
+++ b/app/views/admin/reserved_words/_reserved_word.html.erb
@@ -1,5 +1,6 @@
 <tr>
-  <td><%= reserved_word.name %></div>
+  <td><%= reserved_word.name %></td>
+  <td><%= reserved_word.details %></td>
   <td><%= l(reserved_word.created_at, format: :short) %></td>
-  <td><%= button_to "Delete Reserved Word", delete_admin_reserved_word_path(reserved_word), method: :put %></td>
-  </tr>
+  <td><%= button_to "Delete Reserved Word", admin_reserved_word_path(reserved_word), method: :delete %></td>
+</tr>

--- a/app/views/admin/reserved_words/index.html.erb
+++ b/app/views/admin/reserved_words/index.html.erb
@@ -1,0 +1,35 @@
+<div id="admin_columns">
+  <div class="admin_column_left box">
+    <h2>Admin</h2>
+    <%= render partial: 'admin/navigation' %>
+  </div>
+  <div class="admin_column_right">
+    <%= button_to 'New reserved word', new_admin_reserved_word_path, method: :get %>
+
+    <div class="mini_paginator top_paginator">
+      <%== pagy_nav @pagy %>
+    </div>
+
+    <div class="box">
+      <h2>
+        Reserved words
+      </h2>
+      <table>
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Created</th>
+            <th>&nbsp;</th>
+          </tr>
+        </thead>
+        <tbody>
+          <%= render @reserved_words %>
+        </tbody>
+      </table>
+    </div>
+
+    <div class="mini_paginator bottom_paginator">
+      <%== pagy_nav @pagy %>
+    </div>
+  </div>
+</div>

--- a/app/views/admin/reserved_words/index.html.erb
+++ b/app/views/admin/reserved_words/index.html.erb
@@ -18,6 +18,7 @@
         <thead>
           <tr>
             <th>Name</th>
+            <th>Details</th>
             <th>Created</th>
             <th>&nbsp;</th>
           </tr>

--- a/app/views/admin/reserved_words/new.html.erb
+++ b/app/views/admin/reserved_words/new.html.erb
@@ -1,0 +1,13 @@
+<div id="admin_columns">
+  <div class="admin_column_left box">
+    <h2>Admin</h2>
+    <%= render partial: 'admin/navigation' %>
+  </div>
+  <div class="admin_column_right">
+    <div class="admin_column_right_inner box">
+      <h2>Create a new reserved word</h2>
+    
+      <%= render 'form' %>
+    </div>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3,6 +3,26 @@ en:
     attributes:
       account_request:
         entity_type: "What you do:"
+    errors:
+      models:
+        account_request:
+          attributes:
+            login:
+              login_not_allowed: Sorry, login is taken. be creative!
+              login_not_unique: Sorry, login is taken. be creative!
+              must_be_alphanumeric: should use only letters and numbers.
+            details:
+              details_too_short: "must be at least 40 characters: Please link to your music/website or add more info!"
+            email:
+              duplicate_account: You already have an account on alonetone!
+              invalid_regex: should look like an email address.
+            entity_type:
+              unselected_entity_type: We need to know what sort of thing you want to upload!
+        user:
+          attributes:
+            login:
+              login_not_allowed: not allowed.
+              login_not_unique: is already taken.
 
   errors:
     messages:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -8,8 +8,8 @@ en:
         account_request:
           attributes:
             login:
-              login_not_allowed: Sorry, login is taken. be creative!
-              login_not_unique: Sorry, login is taken. be creative!
+              login_not_allowed: Sorry, that login isn't allowed. Be creative!
+              login_not_unique: Sorry, login is taken. Be creative!
               must_be_alphanumeric: should use only letters and numbers.
             details:
               details_too_short: "must be at least 40 characters: Please link to your music/website or add more info!"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -23,6 +23,10 @@ en:
             login:
               login_not_allowed: not allowed.
               login_not_unique: is already taken.
+        reserved_word:
+          attributes:
+            name:
+              invalid_regexp: is not a valid regular expression.
 
   errors:
     messages:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,6 +36,11 @@ Rails.application.routes.draw do
         put :restore
       end
     end
+    resources :reserved_words do
+      member do
+        put :delete
+      end
+    end
     resources :mass_invites, param: :token
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,11 +36,7 @@ Rails.application.routes.draw do
         put :restore
       end
     end
-    resources :reserved_words do
-      member do
-        put :delete
-      end
-    end
+    resources :reserved_words, only: %i[index new create destroy]
     resources :mass_invites, param: :token
   end
 

--- a/db/migrate/20240121160656_create_reserved_words.rb
+++ b/db/migrate/20240121160656_create_reserved_words.rb
@@ -1,0 +1,12 @@
+class CreateReservedWords < ActiveRecord::Migration[7.0]
+  def change
+    create_table :reserved_words do |t|
+      t.string :name, null: false
+      t.text :details
+
+      t.timestamps
+    end
+
+    add_index :reserved_words, :name, unique: true
+  end
+end

--- a/db/migrate/20260608000001_create_reserved_words.rb
+++ b/db/migrate/20260608000001_create_reserved_words.rb
@@ -1,4 +1,4 @@
-class CreateReservedWords < ActiveRecord::Migration[7.0]
+class CreateReservedWords < ActiveRecord::Migration[8.1]
   def change
     create_table :reserved_words do |t|
       t.string :name, null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -265,6 +265,14 @@ ActiveRecord::Schema[7.2].define(version: 2026_05_26_191520) do
     t.index ["user_id"], name: "index_profiles_on_user_id"
   end
 
+  create_table "reserved_words", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "name", null: false
+    t.text "details"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["name"], name: "index_reserved_words_on_name", unique: true
+  end
+
   create_table "settings", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "user_id"
     t.boolean "display_listen_count", default: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_05_26_191520) do
+ActiveRecord::Schema[7.2].define(version: 2026_06_08_000001) do
   create_table "account_requests", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "email"
     t.string "login"

--- a/spec/fixtures/reserved_words.yml
+++ b/spec/fixtures/reserved_words.yml
@@ -1,0 +1,9 @@
+petaq:
+  name: petaQ
+  created_at: 2010-04-08 13:00:03
+  updated_at: 2020-04-08 13:00:03
+
+trader:
+  name: "trader$"
+  created_at: 2010-04-08 13:00:03
+  updated_at: 2020-04-08 13:00:03

--- a/spec/models/account_request_spec.rb
+++ b/spec/models/account_request_spec.rb
@@ -37,6 +37,20 @@ RSpec.describe AccountRequest, type: :model do
       expect(account_request).not_to be_valid
       expect(account_request.errors[:login]).to_not be_empty
     end
+
+    it "should not allow a login already reserved by another waiting request" do
+      account_request = valid_account_request
+      account_request.login = account_requests(:waiting).login
+      expect(account_request).not_to be_valid
+      expect(account_request.errors[:login]).to_not be_empty
+    end
+
+    it "should reject a login that collides with an application route" do
+      account_request = valid_account_request
+      account_request.login = "playlists"
+      expect(account_request).not_to be_valid
+      expect(account_request.errors[:login]).to_not be_empty
+    end
   end
 
   context "on approval" do

--- a/spec/models/reserved_word_spec.rb
+++ b/spec/models/reserved_word_spec.rb
@@ -1,0 +1,18 @@
+require "rails_helper"
+
+RSpec.describe ReservedWord, type: :model do
+  describe("#contains") do
+    it "performs exact matches" do
+      expect(reserved_words(:petaq).contains("petaQ")).to be_truthy
+    end
+
+    it "performs case-insensitive matches" do
+      expect(reserved_words(:petaq).contains("petaq")).to be_truthy
+    end
+
+    it "performs regular-expression matches" do
+      expect(reserved_words(:trader).contains("Andorian Trader")).to be_truthy
+      expect(reserved_words(:trader).contains("Andorian Traders")).to be_falsey
+    end
+  end
+end

--- a/spec/models/reserved_word_spec.rb
+++ b/spec/models/reserved_word_spec.rb
@@ -1,7 +1,19 @@
 require "rails_helper"
 
 RSpec.describe ReservedWord, type: :model do
+  describe("validation") do
+    it "rejects a name that is not a valid regular expression" do
+      word = ReservedWord.new(name: "[unclosed")
+      expect(word).not_to be_valid
+      expect(word.errors.details[:name]).to include(error: :invalid_regexp)
+    end
+  end
+
   describe("#contains") do
+    it "returns false for a name that is not a valid regular expression" do
+      expect(ReservedWord.new(name: "[unclosed").contains("anything")).to be(false)
+    end
+
     it "performs exact matches" do
       expect(reserved_words(:petaq).contains("petaQ")).to be_truthy
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -53,6 +53,24 @@ RSpec.describe User, type: :model do
       expect(new_user(login: "aa")).not_to be_valid
     end
 
+    it "rejects a login that collides with an application route" do
+      expect(new_user(login: "playlists")).not_to be_valid
+    end
+
+    it "rejects a login already taken by another user" do
+      expect(new_user(login: users(:jamie_kiesl).login)).not_to be_valid
+    end
+
+    it "allows a login matching a waiting account request (the approval flow creates such users)" do
+      expect(new_user(login: account_requests(:waiting).login)).to be_valid
+    end
+
+    it "does not re-check login uniqueness when the login is unchanged" do
+      user = users(:sudara)
+      user.display_name = "A New Display Name"
+      expect(user).to be_valid
+    end
+
     # https://www.wikiwand.com/en/Email_address#/Examples
     it "should validate email" do
       expect(new_user(email: "userEmail1&@gmail.com")).to be_valid

--- a/spec/request/admin/reserved_words_controller_spec.rb
+++ b/spec/request/admin/reserved_words_controller_spec.rb
@@ -1,0 +1,44 @@
+require 'rails_helper'
+
+RSpec.describe Admin::ReservedWordsController, type: :request do
+  context 'an admin' do
+    before do
+      create_user_session(users(:sudara))
+    end
+
+    it 'sees an overview of all reserved words' do
+      get '/admin/reserved_words'
+      expect(response).to have_http_status(:ok)
+      expect(response).to render_template(:index)
+      expect(response.body).to match_css('table')
+      expect(response.body).to match_css('tr', count: MassInvite.count)
+    end
+
+    it 'sees a form to create a new reserved word' do
+      get '/admin/reserved_words/new'
+      expect(response).to have_http_status(:ok)
+      expect(response).to render_template(:new)
+      expect(response.body).to match_css('form')
+    end
+
+    describe '#delete' do
+      it "should delete a user" do
+        expect {
+          put delete_admin_reserved_word_path(reserved_words(:petaq))
+        }.to change(ReservedWord, :count).by(-1)
+      end
+
+      it "should redirect admin to root_path" do
+        put delete_admin_reserved_word_path(reserved_words(:petaq))
+        expect(response).to redirect_to(admin_reserved_words_path)
+      end
+    end
+  end
+
+  context 'a visitor' do
+    it 'must login before accessing the controller' do
+      get '/admin/reserved_words'
+      expect(response.status).to redirect_to(login_url)
+    end
+  end
+end

--- a/spec/request/admin/reserved_words_controller_spec.rb
+++ b/spec/request/admin/reserved_words_controller_spec.rb
@@ -9,27 +9,28 @@ RSpec.describe Admin::ReservedWordsController, type: :request do
     it 'sees an overview of all reserved words' do
       get '/admin/reserved_words'
       expect(response).to have_http_status(:ok)
-      expect(response).to render_template(:index)
       expect(response.body).to match_css('table')
-      expect(response.body).to match_css('tr', count: MassInvite.count)
+      ReservedWord.find_each do |word|
+        expect(response.body).to include(word.name)
+      end
     end
 
     it 'sees a form to create a new reserved word' do
       get '/admin/reserved_words/new'
       expect(response).to have_http_status(:ok)
-      expect(response).to render_template(:new)
+      expect(response.body).to include('Create a new reserved word')
       expect(response.body).to match_css('form')
     end
 
-    describe '#delete' do
-      it "should delete a user" do
+    describe '#destroy' do
+      it "deletes the reserved word" do
         expect {
-          put delete_admin_reserved_word_path(reserved_words(:petaq))
+          delete admin_reserved_word_path(reserved_words(:petaq))
         }.to change(ReservedWord, :count).by(-1)
       end
 
-      it "should redirect admin to root_path" do
-        put delete_admin_reserved_word_path(reserved_words(:petaq))
+      it "redirects back to the reserved words index" do
+        delete admin_reserved_word_path(reserved_words(:petaq))
         expect(response).to redirect_to(admin_reserved_words_path)
       end
     end

--- a/spec/validators/login_is_allowed_validator_spec.rb
+++ b/spec/validators/login_is_allowed_validator_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe LoginIsAllowedValidator do
+    class LoginIsAllowedValidatorModel
+        include ActiveModel::Validations
+
+        attr_reader :login
+    
+        def initialize(login)
+          @login = login
+        end
+    
+        validates :login, login_is_allowed: true
+    end
+
+    it 'allows nil' do
+      record = LoginIsAllowedValidatorModel.new(nil)
+      expect(record).to be_valid
+    end
+
+    it 'allows empty' do
+      record = LoginIsAllowedValidatorModel.new('')
+      expect(record).to be_valid
+    end
+
+    it 'disallows duplicate user logins' do
+      record = LoginIsAllowedValidatorModel.new('williamshatner')
+      expect(record).to_not be_valid
+      expect(record.errors.details).to eq(
+        login: [
+          {
+            error: :login_not_unique
+          }
+        ]
+    )
+    end
+
+    it 'disallows duplicate account request (waiting) logins' do
+      record = LoginIsAllowedValidatorModel.new('newband')
+      expect(record).to_not be_valid
+      expect(record.errors.details).to eq(
+        login: [
+          {
+            error: :login_not_unique
+          }
+        ]
+    )
+    end
+
+    it 'disallows reserved words' do
+      record = LoginIsAllowedValidatorModel.new('petaQ')
+      expect(record).to_not be_valid
+      expect(record.errors.details).to eq(
+        login: [
+          {
+            error: :login_not_allowed
+          }
+        ]
+    )
+    end
+
+    it 'disallows names used by application routes' do
+      ['admin', 'format', 'user_id', 'rails'].each do |login|
+        record = LoginIsAllowedValidatorModel.new(login)
+        expect(record).to_not be_valid
+        expect(record.errors.details).to eq(
+          login: [
+            {
+              error: :login_not_allowed
+            }
+          ]
+        )
+      end
+    end
+end

--- a/spec/validators/login_is_allowed_validator_spec.rb
+++ b/spec/validators/login_is_allowed_validator_spec.rb
@@ -7,11 +7,11 @@ RSpec.describe LoginIsAllowedValidator do
         include ActiveModel::Validations
 
         attr_reader :login
-    
+
         def initialize(login)
           @login = login
         end
-    
+
         validates :login, login_is_allowed: true
     end
 
@@ -34,7 +34,7 @@ RSpec.describe LoginIsAllowedValidator do
             error: :login_not_unique
           }
         ]
-    )
+      )
     end
 
     it 'disallows duplicate account request (waiting) logins' do
@@ -46,7 +46,7 @@ RSpec.describe LoginIsAllowedValidator do
             error: :login_not_unique
           }
         ]
-    )
+      )
     end
 
     it 'disallows reserved words' do
@@ -58,11 +58,11 @@ RSpec.describe LoginIsAllowedValidator do
             error: :login_not_allowed
           }
         ]
-    )
+      )
     end
 
     it 'disallows names used by application routes' do
-      ['admin', 'format', 'user_id', 'rails'].each do |login|
+      %w[admin format user_id rails].each do |login|
         record = LoginIsAllowedValidatorModel.new(login)
         expect(record).to_not be_valid
         expect(record.errors.details).to eq(


### PR DESCRIPTION
Supersedes #1239 

TODO: 

* make approve! transactional so a collision can never leave a half-approved, user-less row. Failure rolls back and request stays waiting. No corrupt state to hand-fix. 
* Catch the collision in the admin approve action so the moderator sees "Couldn't approve — login 'coolname' is
  now taken" in the row, instead of a 500.
* How the moderator then resolves it — this is where I need your call: